### PR TITLE
Allow the VM's private IP to be configurable.

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -1,4 +1,6 @@
 ---
+private_ip: "192.168.33.10"
+
 authorize: /Users/me/.ssh/id_rsa.pub
 
 keys:

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -5,7 +5,7 @@ class Homestead
     config.vm.hostname = "homestead"
 
     # Configure A Private Network IP
-    config.vm.network :private_network, ip: "192.168.33.10"
+    config.vm.network :private_network, ip: settings["private_ip"]
 
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
A lot of people have multiple VMs running on their machine at any given time, or the default IP may be in use on their home network, so Homestead should give them the option to change it.
