### PR TITLE
Overwrite if server block exists

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -36,7 +36,7 @@ block="server {
 }
 "
 
-echo "$block" >> "/etc/nginx/sites-available/$1"
+echo "$block" > "/etc/nginx/sites-available/$1"
 ln -s "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
 service php5-fpm restart


### PR DESCRIPTION
This is to prevent duplicate server blocks in a single file which gives errors when trying to restart nginx.

I was getting these errors because my server block files contained duplicate server blocks (with the oldest one on top).

``` bash
vagrant@homestead:~$ nginx -s reload
nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (13: Permission denied)
2014/05/22 12:00:02 [warn] 3172#0: the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "dries.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "dries.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "dries.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "dries.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "dries.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "dries.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "lw.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "lw.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "lw.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [warn] 3172#0: conflicting server name "lw.loc" on 0.0.0.0:80, ignored
2014/05/22 12:00:02 [notice] 3172#0: signal process started
2014/05/22 12:00:02 [alert] 3172#0: kill(3079, 1) failed (1: Operation not permitted)    
```
