### PR TITLE
Add support for custom hostname

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -1,4 +1,5 @@
 ---
+hostname: "homestead"
 ip: "192.168.10.10"
 memory: 2048
 cpus: 1

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -2,7 +2,7 @@ class Homestead
   def Homestead.configure(config, settings)
     # Configure The Box
     config.vm.box = "laravel/homestead"
-    config.vm.hostname = "homestead"
+    config.vm.hostname = settings["hostname"] ||= "homestead"
 
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"


### PR DESCRIPTION
A little bit of flexibility here is welcome. With a goal of using the Homestead box for multiple projects of different technologies/frameworks, allowing the developer to define the name of the VM is way more flexible than updating such technologies/projects codebase.
