### PR TITLE
Added option to configure others databases in PostgreSQL and/or MySQL

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -15,3 +15,9 @@ folders:
 sites:
     - map: homestead.app
       to: /home/vagrant/Code/Laravel/public
+
+databases:
+    postgresql:
+        -
+    mysql:
+        - 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -52,5 +52,27 @@ class Homestead
           s.args = [site["map"], site["to"]]
       end
     end
+
+    # Create PostgreSQL Databases
+    settings["databases"]["postgresql"].each do |postgresql|
+      if !(postgresql.nil?)
+        config.vm.provision "shell" do |s|
+          s.privileged = false
+          s.inline = "export PGPASSWORD=secret;createdb -U homestead -h localhost \"$1\";"
+          s.args = postgresql
+        end
+      end
+    end
+
+    # Create MySQL Databases
+    settings["databases"]["mysql"].each do |mysql|
+      if !(mysql.nil?)
+        config.vm.provision "shell" do |s|
+          s.privileged = false
+          s.inline = "export MYSQL_PWD=secret;mysql -u homestead -h localhost -e \"create database $1\";"
+          s.args = mysql
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Added option to create multiple database in PostgreSQL and/or in MySQL.

Case you have multiple sites, you can configure the Homestead.yaml to automatically create multiple database when you (re)create a virtal server.
