### PR TITLE
Adding File.expand_path() when reading SSH keys so '~/.ssh/key.pub' paths work

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -23,7 +23,7 @@ class Homestead
     # Configure The Public Key For SSH Access
     config.vm.provision "shell" do |s|
       s.inline = "echo $1 | tee -a /home/vagrant/.ssh/authorized_keys"
-      s.args = [File.read(settings["authorize"])]
+    s.args = [File.read(File.expand_path(settings["authorize"]))]
     end
 
     # Copy The SSH Private Keys To The Box
@@ -31,7 +31,7 @@ class Homestead
       config.vm.provision "shell" do |s|
         s.privileged = false
         s.inline = "echo \"$1\" > /home/vagrant/.ssh/$2 && chmod 600 /home/vagrant/.ssh/$2"
-        s.args = [File.read(key), key.split('/').last]
+        s.args = [File.read(File.expand_path(key)), key.split('/').last]
       end
     end
 


### PR DESCRIPTION
Adding File.expand_path() when reading SSH keys so '~/.ssh/key.pub' paths may be used to allow users to easily share homestead boxes among other developers working on the same project without having to edit Homestead.yaml

My use case for this was being able to hand other coworkers this same box and allow them to simply vagrant up instead of having to edit files. 
