### PR TITLE
Added force option to nginx site symbolic link

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -37,6 +37,6 @@ block="server {
 "
 
 echo "$block" > "/etc/nginx/sites-available/$1"
-ln -s "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
 service php5-fpm restart


### PR DESCRIPTION
By adding the force option you will not get the following errors when doing `vagrant provision`:

```
==> default: ln: 
==> default: failed to create symbolic link ‘/etc/nginx/sites-enabled/laravel.dev’
==> default: : File exists
```
