### PR TITLE
Prevent "failed create symbolic link"

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -37,6 +37,6 @@ block="server {
 "
 
 echo "$block" > "/etc/nginx/sites-available/$1"
-ln -s "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+ln -sf "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
 service php5-fpm restart


### PR DESCRIPTION
Prevent "failed create symbolic link" if you update folder location for existing host.
