### PR TITLE
Force Ubuntu 64 Version 

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -13,6 +13,7 @@ class Homestead
       vb.customize ["modifyvm", :id, "--cpus", settings["cpus"] ||= "1"]
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
     end
 
     # Configure Port Forwarding To The Box


### PR DESCRIPTION
If homestead is start on 32 bit host it will loop in an endless "Connection Timout" because vagrant try to start it as an Ubuntu 32 bit. 
