### PR TITLE
Added port forwarding for Redis and Memcached.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,4 +7,8 @@ require path + '/scripts/homestead.rb'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   Homestead.configure(config, YAML::load(File.read(path + '/Homestead.yaml')))
+  
+  config.vm.network "forwarded_port", guest: 6379, host: 63790 # Redis forwarded from default port 6379 to port 63790.
+  config.vm.network "forwarded_port", guest: 11211, host: 11212 # Memcached forwarded from default port 11211 to port 11212.
+  
 end


### PR DESCRIPTION
Forwarded default Redis port 6379 to port 63790 and forwarded default Memcached port 11211 to 11212. This allows both Redis and Memcached instances on the Vagrant machine to be accessible from the host machine without port interference regardless of whether Redis or Memcached instances are running on the host machine.
