### PR TITLE
Added option to set the hostname

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -2,7 +2,7 @@ class Homestead
   def Homestead.configure(config, settings)
     # Configure The Box
     config.vm.box = "laravel/homestead"
-    config.vm.hostname = "homestead"
+    config.vm.hostname = settings["hostname"] ||= "homestead"
 
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"


### PR DESCRIPTION
Working with my team, we each were using laravel/homestead and couldn't set our environment properly sue to the hostname being the same in all of our homestead machines. With this you can define your hostname in your Homestead.yaml file so that we could each have a different hostname allowing for us to set our laravel environment properly.
