### PR TITLE
Speed up sync the shared folders using NFS

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -42,7 +42,7 @@ class Homestead
 
     # Register All Of The Configured Shared Folders
     settings["folders"].each do |folder|
-      config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil
+      config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, :nfs => true
     end
 
     # Install All The Configured Nginx Sites


### PR DESCRIPTION
My app was slow on Homestead and i dug up and found NFS can speed up the sync of the shared folders.

https://coderwall.com/p/uaohzg

Works great!.
