### PR TITLE
Added a check if public key was already in authorized_keys

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -22,7 +22,7 @@ class Homestead
 
     # Configure The Public Key For SSH Access
     config.vm.provision "shell" do |s|
-      s.inline = "echo $1 | tee -a /home/vagrant/.ssh/authorized_keys"
+      s.inline = "echo $1 | grep -xq \"$1\" /home/vagrant/.ssh/authorized_keys || echo $1 | tee -a /home/vagrant/.ssh/authorized_keys"
       s.args = [File.read(File.expand_path(settings["authorize"]))]
     end
 


### PR DESCRIPTION
I was doing few times vagrant provision and noticed that my public key was added each time to /home/vagrant/.ssh/authorized_keys . Made a small modification to the script disabling this behavior and ensuring that vagrant provision only adds the key once if it's not already there.