### PR TITLE
Change forwarded 80 port to 8080 to fix NodeJS

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,7 +16,7 @@ class Homestead
     end
 
     # Configure Port Forwarding To The Box
-    config.vm.network "forwarded_port", guest: 80, host: 8000
+    config.vm.network "forwarded_port", guest: 80, host: 8080
     config.vm.network "forwarded_port", guest: 3306, host: 33060
     config.vm.network "forwarded_port", guest: 5432, host: 54320
 


### PR DESCRIPTION
By default, nodeJS runs on port 8000. While that occupied by and listening on port 80 services like GulpJS do not function. 

If Homestead is to include NodeJS apps, they should work out of the box. With 8000 in use, they will not.
