### PR TITLE
Allow synced folders to pass more options than type

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -42,7 +42,15 @@ class Homestead
 
     # Register All Of The Configured Shared Folders
     settings["folders"].each do |folder|
-      config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil
+      if folder.key?("options")
+        # Options hash takes precedence
+        options = folder["options"]
+      else
+        # Check for type key for backwards compatibility
+        options = Hash.new
+        options[:type] = folder.key?("type") ? folder["type"] : nil
+      end
+      config.vm.synced_folder folder["map"], folder["to"], options
     end
 
     # Install All The Configured Nginx Sites


### PR DESCRIPTION
This change allows more flexibility in specifying options for synced folders. For example, passing rsync specific options like in this gist:

https://gist.github.com/samchaffee/0b4d14dde984e68ee30e

The change keeps backwards compatibility with using the "type" folder option as well.
