### PR TITLE
Allow custom commands during provisioning

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -19,3 +19,6 @@ sites:
 variables:
     - key: APP_ENV
       value: local
+
+commands:
+    - composer self-update

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -62,5 +62,14 @@ class Homestead
         end
       end
     end
+
+    # Run Any Optional Commands
+    if settings.has_key?("commands")
+      settings["commands"].each do |command|
+        config.vm.provision "shell" do |s|
+            s.inline = command
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows a developer to customize the provisioning process with anything they'd like.

See #68 where I suggest this as the alternative to that PR.

Some examples of what it could be used to run:

```
composer self-update
apt-get update && apt-get upgrade
php /path/to/artisan migrate
php /path/to/artisan db:seed
```
