### PR TITLE
Fix to show PHP errors

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -28,7 +28,7 @@ block="server {
         fastcgi_pass unix:/var/run/php5-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         fastcgi_intercept_errors on;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;


### PR DESCRIPTION
Changed the nginx template to show PHP errors. Before I was getting a `502 Bad Gateway` and had to look in the log files.
