### PR TITLE
Add support to replace php.ini settings.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -57,6 +57,20 @@ class Homestead
           end
       end
     end
+    
+    # Override PHP.INI settings
+    if settings.has_key?("php_ini_overrides")
+      filename = '/etc/php5/fpm/php.ini'
+
+      settings["php_ini_overrides"].each do |var|
+        key = var.map{ |key, value| key }[0]
+        value = var.map{ |key, value| value }[0]
+        
+        config.vm.provision "shell" do |s|
+            s.inline = "sed -i 's/^\\(#{key}\\).*/\\1 \= #{value}/' #{filename}"
+        end
+      end
+    end
 
     # Configure All Of The Server Environment Variables
     if settings.has_key?("variables")


### PR DESCRIPTION
Making it possible to replace **php.ini** settings through **Homestead.yml** like this:

```
php_ini_overrides:
    - max_execution_time: "300"
    - memory_limit: 2048M
    - post_max_size: 100M
    - upload_max_filesize: 100M   
```
