### PR TITLE
Add support for adding cron jobs through Homestead.yml.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -46,7 +46,7 @@ class Homestead
     end
 
     # install crontabs
-    Homestead.install_cron_tabs(config, setings)
+    Homestead.install_cron_tabs(config, settings)
 
     # Install All The Configured Nginx Sites
     settings["sites"].each do |site|
@@ -72,7 +72,7 @@ class Homestead
     end
   end
 
-  def Homestead.install_cron_tabs(config, setings)
+  def Homestead.install_cron_tabs(config, settings)
     # empty /home/vagrant/.crontabs file
     config.vm.provision "shell" do |s|
       s.inline = "cat /dev/null > /home/vagrant/.crontabs"


### PR DESCRIPTION
Make it possible to **define crontabs** and getting them **installed for 'root' on VM**: _(minute/hour/monthday/week/weekday defaults to '*' if left out)_

```
crontabs:
    - command: /home/vagrant/Code/jobs/addresses-import-job.sh
      minute: '*/15'
      hour: '*'
      monthday: '*'
      week: '*'
      weekday: '*'
```
