### PR TITLE
Give the VM a cleaner name of "homestead" 

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -9,6 +9,7 @@ class Homestead
 
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|
+      vb.name = 'homestead'
       vb.customize ["modifyvm", :id, "--memory", settings["memory"] ||= "2048"]
       vb.customize ["modifyvm", :id, "--cpus", settings["cpus"] ||= "1"]
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]


### PR DESCRIPTION
This is just a little cosmetic change.
If you have a lot of different VMs (with different providers like e.g. puphpet or ansible) you can increase the readability in tools like VagrantBar (https://github.com/BipSync/VagrantBar) when you have a cleaner name of `homestead` instead of the gibberish default naming of `homestead_default_20140828141123` when displayed in the GUIs.
