### PR TITLE
Remove trailing slashes in nginx vhost

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -13,6 +13,10 @@ block="server {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
 
+    if (!-d \$request_filename) {
+        rewrite ^/(.*)/$ /\$1 permanent;
+    }
+
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }
 

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -13,6 +13,10 @@ block="server {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
 
+    if (!-d \$request_filename) {
+        rewrite ^/(.*)/$ /\$1 permanent;
+    }
+
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }
 


### PR DESCRIPTION
This basically does the same thing as the `RewriteRule ^(.*)/$ /$1 [L,R=301]` rule in a Laravel application's `.htaccess` file.

One thing to note is that this will now be default behavior for all sites in Homestead while not everyone might want this. What I suggest is making this the default so it's the same behavior as Laravel applications but add a config option for each site in which they can enable/disable this behavior. I'm afraid my own server knowledge isn't that good to set this up myself.

Btw @taylorotwell: I guess this also needs to implemented for Forge because we currently don't have the option to disable trailing slashes for Forge websites. Just to give an example: Disqus thinks a url with or without a trailing slash are two different urls and offers different comments for each url. So I'd really like to set this as an option somewhere or expect it to be default behavior to remove the trailing slash.
