### PR TITLE
Add port forwarding configuration to Homestead.yaml

### DIFF
--- a/Homestead.yaml
+++ b/Homestead.yaml
@@ -8,6 +8,11 @@ authorize: ~/.ssh/id_rsa.pub
 keys:
     - ~/.ssh/id_rsa
 
+ports:
+    - {host: 8000, guest: 80}
+    - {host: 33060, guest: 3306}
+    - {host: 54320, guest: 5432}
+    
 folders:
     - map: ~/Code
       to: /home/vagrant/Code

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -15,10 +15,10 @@ class Homestead
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     end
 
-    # Configure Port Forwarding To The Box
-    config.vm.network "forwarded_port", guest: 80, host: 8000
-    config.vm.network "forwarded_port", guest: 3306, host: 33060
-    config.vm.network "forwarded_port", guest: 5432, host: 54320
+    # Configure Port Forwarding To The Box    
+    settings["ports"].each do |port|
+      config.vm.network "forwarded_port", guest: port["guest"], host: port["host"] ||= nil
+    end
 
     # Configure The Public Key For SSH Access
     config.vm.provision "shell" do |s|


### PR DESCRIPTION
Removing the hardcoded port forwarding from **homestead.rb** and make it configurable from **Homestead.yaml**

It is fairly common to change or add new port forwarding so having them in the configuration file is more clean
