### PR TITLE
Locking nginx site configuration files in Homestead.yaml

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -47,6 +47,7 @@ class Homestead
 
     # Install All The Configured Nginx Sites
     settings["sites"].each do |site|
+      next if site.has_key?("locked") && site["locked"]
       config.vm.provision "shell" do |s|
           if (site.has_key?("hhvm") && site["hhvm"])
             s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 $2"


### PR DESCRIPTION
Allow locking a site in Homestead.yaml so it's existing nginx site configuration file (/etc/nginx/sites-available/example) wont be overwritten on the next vagrant provision. (Useful for non or more custom Laravel projects powered by Homestead)
### Example

``` yaml
# Homestead.yaml

sites:
    - map: example.dev
      to: /home/vagrant/web/example
      locked: true
```
