### PR TITLE
create-postgres.sh to use configuration database name to drop database

### DIFF
--- a/scripts/create-postgres.sh
+++ b/scripts/create-postgres.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 DB=$1;
-su postgres -c "dropdb homestead --if-exists"
+su postgres -c "dropdb $DB --if-exists"
 su postgres -c "createdb -O homestead '$DB'"


### PR DESCRIPTION
The Postgresql script doesn't use the configuration database name to drop database, resulting in error while re-provisioning VM if the default database name is changed in Homestead.yaml.
