### PR TITLE
Windows machines homstead_path()

### DIFF
--- a/homestead
+++ b/homestead
@@ -12,7 +12,7 @@ else
 
 function homestead_path()
 {
-	return $_SERVER['HOME'].'/.homestead';
+	return ( isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'] ) . DIRECTORY_SEPARATOR . '.homestead';
 }
 
 $app = new Symfony\Component\Console\Application('Laravel Homestead', '2.0.0');


### PR DESCRIPTION
$_SERVER['HOME'] is not defined in windows hosts
Instead we have to use $_SERVER['HOMEPATH'] and $_SERVER['HOMEDRIVE']
Another way is to manually add system environment variable 'HOME' but i think this should be mentioned in the docs
