### PR TITLE
Fix bug on Windows in the edit command

### DIFF
--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -19,6 +19,16 @@ class EditCommand extends Command {
 	}
 
 	/**
+	 * Find the correct executable to run depending of the OS.
+	 *
+	 * @return string
+	 */
+	protected function executableName()
+	{
+		return strpos(strtoupper(PHP_OS), 'WIN') === 0 ? 'start' : 'open';
+	}
+
+	/**
 	 * Execute the command.
 	 *
 	 * @param  \Symfony\Component\Console\Input\InputInterface  $input
@@ -27,7 +37,8 @@ class EditCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('open ~/.homestead/Homestead.yaml', realpath(__DIR__.'/../'), null, null, null);
+		$commandLine = $this->executableName() .' '.homestead_path().'/Homestead.yaml';
+		$process = new Process($commandLine, realpath(__DIR__.'/../'), null, null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{


### PR DESCRIPTION
`open` does not exist on windows.
This commit fixes the bug by selecting `start` or `open` according to the OS.
