### PR TITLE
Fix issue with spaces in folder names.

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -3,7 +3,7 @@
 block="server {
     listen 80;
     server_name $1;
-    root $2;
+    root "$2";
 
     index index.html index.htm index.php;
 


### PR DESCRIPTION
If you have a folder name with a space in it, such as say "/home/vagrant/Folder Folder/code" it would show "/home/vagrant/Folder".
