### PR TITLE
Windows fix for php server var: home

### DIFF
--- a/homestead
+++ b/homestead
@@ -12,6 +12,8 @@ else
 
 function homestead_path()
 {
+	$homePath = (isset($_SERVER['HOMEPATH'])) ? $_SERVER['HOMEPATH'] : $_SERVER['HOME'];
+	return $homePath.'/.homestead';
 	return $_SERVER['HOME'].'/.homestead';
 }
 


### PR DESCRIPTION
In my windows got $_SERVER['HOMEPATH'] instead of $_SERVER['HOMEPATH']

Running Windows 7 Ultimate
