### PR TITLE
Listen for EDITOR environment variable if one is set

### DIFF
--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -44,6 +44,10 @@ class EditCommand extends Command {
 	 */
 	protected function executable()
 	{
+		if (getenv('EDITOR') !== false)
+		{
+			return getenv('EDITOR');
+		}
 		return strpos(strtoupper(PHP_OS), 'WIN') === 0 ? 'start' : 'open';
 	}
 


### PR DESCRIPTION
In the Arch Linux community at least, there's the usage of an EDITOR environment variable. It's preferable in my mind to have that be the first option to be listened to since that's pretty much always going to be the preferred editor.

If EDITOR is not set then it defaults back to start/open.