### PR TITLE
Really fix issues with spaces in folder names

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -47,10 +47,10 @@ class Homestead
     settings["sites"].each do |site|
       config.vm.provision "shell" do |s|
           if (site.has_key?("hhvm") && site["hhvm"])
-            s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 $2"
+            s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 \"$2\""
             s.args = [site["map"], site["to"]]
           else
-            s.inline = "bash /vagrant/scripts/serve.sh $1 $2"
+            s.inline = "bash /vagrant/scripts/serve.sh $1 \"$2\""
             s.args = [site["map"], site["to"]]
           end
       end

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -3,7 +3,7 @@
 block="server {
     listen 80;
     server_name $1;
-    root $2;
+    root \"$2\";
 
     index index.html index.htm index.php;
 

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -3,7 +3,7 @@
 block="server {
     listen 80;
     server_name $1;
-    root "$2";
+    root \"$2\";
 
     index index.html index.htm index.php;
 


### PR DESCRIPTION
This PR revisits #118 which didn't actually fix the original problem because it used unescaped double quotes within a double-quoted string. This also makes sure the string doesn't get interpreted as multiple arguments.

I'm not really sure what the proper etiquette/best practice is for something like this (with regard to fixing a closed PR) so I apologize if this would have been better suited as a comment on the original PR.