### PR TITLE
add option to enable ssh agent forwarding

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -37,6 +37,9 @@ class Homestead
         s.args = [File.read(File.expand_path(key)), key.split('/').last]
       end
     end
+    
+    # Configure agent forwarding
+    config.ssh.forward_agent = settings["ssh_agent_forwarding"] ||= false
 
     # Register All Of The Configured Shared Folders
     settings["folders"].each do |folder|


### PR DESCRIPTION
Adds an option to enable ssh agent forwarding. If it is not specified in homestead.yaml set it to disabled.