### PR TITLE
ignore error when database exists

### DIFF
--- a/scripts/create-postgres.sh
+++ b/scripts/create-postgres.sh
@@ -2,4 +2,4 @@
 
 DB=$1;
 su postgres -c "dropdb $DB --if-exists"
-su postgres -c "createdb -O homestead '$DB'"
+su postgres -c "createdb -O homestead '$DB' || true"


### PR DESCRIPTION
Let say you want to add a site+database to an existing homestead vm.

If you re-provision homestead, the create-postgres.sh script fails because existing databases, well, already exist. One solution would be to always drop databases and re-creating them. But I think thats a bit over the top because that would mess with other apps on your homestead vm, while all you wanted to do was add a site.

This small patch just ignores any postgres errors on createdb.  