### PR TITLE
Support of "default_server" NGINX config attribute

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -47,11 +47,17 @@ class Homestead
     settings["sites"].each do |site|
       config.vm.provision "shell" do |s|
           if (site.has_key?("hhvm") && site["hhvm"])
-            s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 $2"
+            s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 $2 $3"
             s.args = [site["map"], site["to"]]
+            if (site.has_key?("default"))
+              s.args.push "default_server"
+            end
           else
-            s.inline = "bash /vagrant/scripts/serve.sh $1 $2"
+            s.inline = "bash /vagrant/scripts/serve.sh $1 $2 $3"
             s.args = [site["map"], site["to"]]
+            if (site.has_key?("default"))
+              s.args.push "default_server"
+            end
           end
       end
     end

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -2,7 +2,7 @@
 
 block="server {
     listen 80;
-    server_name $1;
+    server_name $1 $3;
     root "$2";
 
     index index.html index.htm index.php;

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 block="server {
-    listen 80;
-    server_name $1 $3;
+    listen 80 $3;
+    server_name $1;
     root "$2";
 
     index index.html index.htm index.php;


### PR DESCRIPTION
Here I simply give the ability to the Homestead.yaml file to set a default server. I was looking for a solution to use the ``vagrant share`` command. Vagrant share was working fine but as there is one unique domain name for multiple sites on my Vagrant box, NGINX was using the first server coming in the list by alphabetical order. With the ``default_server`` directive in the config file, I'm able to select which server would be used by default when I hit the box.

Here is how I do it from my ``Homestead.yml`` file now:
```yaml
sites:
    - map: myhomestead.app
      to: /home/vagrant/Code/myhomesteadapp/public
      hhvm: true
      default: true
    - map: anotherhomestead.app
      to: /home/vagrant/Code/anotherhomesteadapp/public
      hhvm: true
```