### PR TITLE
Config option for custom port settings in config file

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -24,8 +24,10 @@ class Homestead
     config.vm.network "forwarded_port", guest: 5432, host: 54320
 
     # Add custom port options from configuration settings
-    settings["ports"].each do |port|
-      config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"] ||= "tcp"
+    if settings.has_key?("ports")
+      settings["ports"].each do |port|
+        config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"] ||= "tcp"
+      end
     end
 
     # Configure The Public Key For SSH Access

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -23,6 +23,11 @@ class Homestead
     config.vm.network "forwarded_port", guest: 3306, host: 33060
     config.vm.network "forwarded_port", guest: 5432, host: 54320
 
+    # Add custom port options from configuration settings
+    settings["ports"].each do |port|
+      config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"] ||= "tcp"
+    end
+
     # Configure The Public Key For SSH Access
     config.vm.provision "shell" do |s|
       s.inline = "echo $1 | tee -a /home/vagrant/.ssh/authorized_keys"


### PR DESCRIPTION
Add support for custom port settings in the configuration file

```yaml
ports:
    - guest: 80
      host: 8080
    - guest: 1028
      host: 1028
    - guest: 443
      host: 44500
      protocol: udp
```

Additional option to set the protocol to tcp/udp

> Default port configurations still remain but can now be overwritten.