### PR TITLE
Fix issues with $_ENV on Windows

### DIFF
--- a/homestead
+++ b/homestead
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-$_ENV['VAGRANT_DOTFILE_PATH'] = '~/.homestead/.vagrant';
+$_ENV['VAGRANT_DOTFILE_PATH'] = homestead_path().DIRECTORY_SEPARATOR.'.vagrant';
 
 if (file_exists(__DIR__.'/vendor/autoload.php'))
 {

--- a/src/DestroyCommand.php
+++ b/src/DestroyCommand.php
@@ -27,7 +27,7 @@ class DestroyCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant destroy --force', realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process('vagrant destroy --force', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -29,7 +29,7 @@ class EditCommand extends Command {
 	{
 		$command = $this->executable().' '.homestead_path().'/Homestead.yaml';
 
-		$process = new Process($command, realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process($command, realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/HaltCommand.php
+++ b/src/HaltCommand.php
@@ -27,7 +27,7 @@ class HaltCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant halt', realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process('vagrant halt', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/ResumeCommand.php
+++ b/src/ResumeCommand.php
@@ -27,7 +27,7 @@ class ResumeCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant resume', realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process('vagrant resume', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/RunCommand.php
+++ b/src/RunCommand.php
@@ -34,7 +34,21 @@ class RunCommand extends Command {
 
 		$command = $input->getArgument('ssh-command');
 
-		passthru('VAGRANT_DOTFILE_PATH="~/.homestead/.vagrant" vagrant ssh -c "'.$command.'"');
+		passthru($this->setEnvironmentCommand() . ' vagrant ssh -c "'.$command.'"');
 	}
 
+	protected function setEnvironmentCommand()
+	{
+		if ($this->isWindows()) {
+			return 'SET VAGRANT_DOTFILE_PATH='.$_ENV['VAGRANT_DOTFILE_PATH'].' &&';
+		}
+
+		return 'VAGRANT_DOTFILE_PATH="'.$_ENV['VAGRANT_DOTFILE_PATH'].'"';
+	}
+
+	protected function isWindows()
+	{
+		return strpos(strtoupper(PHP_OS), 'WIN') === 0;
+	}
+	
 }

--- a/src/SshCommand.php
+++ b/src/SshCommand.php
@@ -29,7 +29,21 @@ class SshCommand extends Command {
 	{
 		chdir(__DIR__.'/../');
 
-		passthru('VAGRANT_DOTFILE_PATH="~/.homestead/.vagrant" vagrant ssh');
+		passthru($this->setEnvironmentCommand() . ' vagrant ssh');
+	}
+
+	protected function setEnvironmentCommand()
+	{
+		if ($this->isWindows()) {
+			return 'SET VAGRANT_DOTFILE_PATH='.$_ENV['VAGRANT_DOTFILE_PATH'].' &&';
+		}
+
+		return 'VAGRANT_DOTFILE_PATH="'.$_ENV['VAGRANT_DOTFILE_PATH'].'"';
+	}
+
+	protected function isWindows()
+	{
+		return strpos(strtoupper(PHP_OS), 'WIN') === 0;
 	}
 
 }

--- a/src/StatusCommand.php
+++ b/src/StatusCommand.php
@@ -27,7 +27,7 @@ class StatusCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant status', realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process('vagrant status', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/SuspendCommand.php
+++ b/src/SuspendCommand.php
@@ -27,7 +27,7 @@ class SuspendCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant suspend', realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process('vagrant suspend', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/UpCommand.php
+++ b/src/UpCommand.php
@@ -34,7 +34,7 @@ class UpCommand extends Command {
 		if ($input->getOption('provision'))
 			$command .= ' --provision';
 
-		$process = new Process($command, realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process($command, realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{

--- a/src/UpdateCommand.php
+++ b/src/UpdateCommand.php
@@ -27,7 +27,7 @@ class UpdateCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant box update', realpath(__DIR__.'/../'), $_ENV, null, null);
+		$process = new Process('vagrant box update', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{


### PR DESCRIPTION
This fixes issues with 2.0.8 on Windows (being discussed on 167135b).

I've tested this on Windows 8.1 (6.3.9600) and the Windows 10 technical preview (6.4.9879). I don't have any older versions of Windows handy, but it should work on those as well.