### PR TITLE
Add support for various linux flavors

### DIFF
--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -44,7 +44,13 @@ class EditCommand extends Command {
 	 */
 	protected function executable()
 	{
-		return strpos(strtoupper(PHP_OS), 'WIN') === 0 ? 'start' : 'open';
+		if (strpos(strtoupper(PHP_OS), 'WIN') === 0) {
+			return 'start';
+		}
+		if (strpos(strtoupper(PHP_OS), 'DARWIN') === 0) {
+			return 'open';
+		}
+		return 'xdg-open';
 	}
 
 }

--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -44,13 +44,15 @@ class EditCommand extends Command {
 	 */
 	protected function executable()
 	{
-		if (strpos(strtoupper(PHP_OS), 'WIN') === 0) {
+		if (strpos(strtoupper(PHP_OS), 'WIN') === 0)
+		{
 			return 'start';
 		}
-		if (strpos(strtoupper(PHP_OS), 'DARWIN') === 0) {
+		elseif (strpos(strtoupper(PHP_OS), 'DARWIN') === 0)
+		{
 			return 'open';
 		}
 		return 'xdg-open';
 	}
-
+	
 }


### PR DESCRIPTION
On many linux distros, 'open' is an alias to 'openvt' so `homestead edit` does not work. On Linux, you should use xdg-open to open the file in the user's preferred text editor.