### PR TITLE
Added homestead reload command

### DIFF
--- a/homestead
+++ b/homestead
@@ -37,5 +37,6 @@ $app->add(new Laravel\Homestead\UpdateCommand);
 $app->add(new Laravel\Homestead\SshCommand);
 $app->add(new Laravel\Homestead\StatusCommand);
 $app->add(new Laravel\Homestead\SuspendCommand);
+$app->add(new Laravel\Homestead\ReloadCommand);
 
 $app->run();

--- a/src/ReloadCommand.php
+++ b/src/ReloadCommand.php
@@ -1,0 +1,38 @@
+<?php namespace Laravel\Homestead;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SshCommand extends Command {
+
+	/**
+	 * Configure the command options.
+	 *
+	 * @return void
+	 */
+	protected function configure()
+	{
+		$this->setName('reload')
+                  ->setDescription('Reload the Homestead machine');
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @param  \Symfony\Component\Console\Input\InputInterface  $input
+	 * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+	 * @return void
+	 */
+	public function execute(InputInterface $input, OutputInterface $output)
+	{
+		$process = new Process('vagrant reload', realpath(__DIR__.'/../'), $_ENV, null, null);
+
+		$process->run(function($type, $line) use ($output)
+		{
+			$output->write($line);
+		});
+	}
+
+}


### PR DESCRIPTION
Will enable vagrant reload to be accessed by homestead reload. This will
ensure Homestead branding is present through out the use of Homestead.
