### PR TITLE
Fix couldn't find HOME environment var error

### DIFF
--- a/homestead
+++ b/homestead
@@ -2,6 +2,7 @@
 <?php
 
 $_ENV['VAGRANT_DOTFILE_PATH'] = '~/.homestead/.vagrant';
+$_ENV['HOME'] = getenv('HOME');
 
 if (file_exists(__DIR__.'/vendor/autoload.php'))
 {


### PR DESCRIPTION
Homestead 2.0.8 started throwing 
```
/Applications/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/shared_helpers.rb:89:in `expand_path': couldn't find HOME environment -- expanding `~' (ArgumentError)
	from /Applications/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/shared_helpers.rb:89:in `expand_path'
	from /Applications/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/shared_helpers.rb:89:in `user_data_path'
	from /Applications/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/plugin/manager.rb:16:in `user_plugins_file'
	from /Applications/Vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/plugin/manager.rb:27:in `instance'
	from /Applications/Vagrant/bin/../embedded/gems/gems/vagrant-1.6.5/lib/vagrant/pre-rubygems.rb:22:in `<main>'
```

This is a fix for that. We'll need to bump the version and tag it so OSX users can go back to using version ~2.0 instead of locking to 2.0.7. Let me know and I can bump the version number. 