### PR TITLE
use parallels port instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel/homestead",
+    "name": "ivonunes/homestead",
     "description": "A virtual machine for web artisans.",
     "require": {
         "php": ">=5.4",
@@ -21,5 +21,5 @@
     "bin": [
         "homestead"
     ],
-    "minimum-stability": "stable"
+    "minimum-stability": "dev"
 }

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -1,7 +1,7 @@
 class Homestead
   def Homestead.configure(config, settings)
     # Configure The Box
-    config.vm.box = "laravel/homestead"
+    config.vm.box = "ivonunes/homestead"
     config.vm.hostname = "homestead"
 
     # Configure A Private Network IP


### PR DESCRIPTION
this allows the documentation method of "checkout from git and run without php CL tool" to work for parallels as well (just use other branch).

this should be in a branch like: parallels. if you make one i will re-PR to it.

this seems to be the best/easiest place for this. we can keep remerging master into it on updates and more likely to have contributions