### PR TITLE
Fix whoops 404 catch by nginx 1.6.2

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -19,8 +19,6 @@ block="server {
     access_log off;
     error_log  /var/log/nginx/$1-error.log error;
 
-    error_page 404 /index.php;
-
     sendfile off;
 
     location ~ \.php$ {

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -19,8 +19,6 @@ block="server {
     access_log off;
     error_log  /var/log/nginx/$1-error.log error;
 
-    error_page 404 /index.php;
-
     sendfile off;
 
     location ~ \.php$ {


### PR DESCRIPTION
Since homestead 2.0 the nginx release versión is 1.6.2 for some reason the error_page 404 /index.php is not letting Whoops display. https://laracasts.com/discuss/channels/general-discussion/restore-notfoundhttpexception

Removing the directive makes it work again.

Thanks!