### PR TITLE
Adding Homestead Environment Variables to the vagrant .profile for CLI usage

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -76,6 +76,11 @@ class Homestead
             s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php5/fpm/php-fpm.conf"
             s.args = [var["key"], var["value"]]
         end
+        
+        config.vm.provision "shell" do |s|
+            s.inline = "echo \"\n#Set Homestead environment variable\nexport $1=$2\" >> /home/vagrant/.profile"
+            s.args = [var["key"], var["value"]]
+        end
       end
 
       config.vm.provision "shell" do |s|


### PR DESCRIPTION
In `homestead.yaml`, you can set a list of environment variables : 
```yaml
variables:
    - key: LARAVEL_ENV
      value: local
```


but they can't be use in the command-line or or in `artisan` command. For exemple, if you use it for detecting environment : 

```php
$env = $app->detectEnvironment(function(){
 
	return getenv('LARAVEL_ENV') ?: 'production';
	
});
```

then, it will also works when you run
```bash
vagrant@homestead:~/website$ php artisan env
Current application environment: local
```

With this, you don't have to specify the environment for each time you run  `php artisan migrate` or `php artisan db:seed`