### PR TITLE
Ignore existing MySQL databases instead of re-creating

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
 DB=$1;
-mysql -uhomestead -psecret -e "DROP DATABASE IF EXISTS $DB";
-mysql -uhomestead -psecret -e "CREATE DATABASE $DB";
+mysql -uhomestead -psecret -e "CREATE DATABASE IF NOT EXISTS $DB";


### PR DESCRIPTION
Instead of dropping and recreating MySQL databases, just create ones that don't already exist.

This will make it easier to run `homestead up --provision` on an existing VM to load new sites, without emptying any existing databases.