### PR TITLE
Add "homestead share" command

### DIFF
--- a/homestead
+++ b/homestead
@@ -34,6 +34,7 @@ $app->add(new Laravel\Homestead\ResumeCommand);
 $app->add(new Laravel\Homestead\RunCommand);
 $app->add(new Laravel\Homestead\UpCommand);
 $app->add(new Laravel\Homestead\UpdateCommand);
+$app->add(new Laravel\Homestead\ShareCommand);
 $app->add(new Laravel\Homestead\SshCommand);
 $app->add(new Laravel\Homestead\StatusCommand);
 $app->add(new Laravel\Homestead\SuspendCommand);

--- a/src/ShareCommand.php
+++ b/src/ShareCommand.php
@@ -1,0 +1,70 @@
+<?php namespace Laravel\Homestead;
+
+use Symfony\Component\Process\ProcessBuilder;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ShareCommand extends Command {
+
+	/**
+	 * Configure the command options.
+	 *
+	 * @return void
+	 */
+	protected function configure()
+	{
+		$this->setName('share')
+			->setDescription('Share the Homestead machine using "vagrant share"')
+			->addOption('name', null, InputOption::VALUE_REQUIRED, 'Change the default name ("share") for the share')
+			->addOption('domain', null, InputOption::VALUE_REQUIRED, 'Set a custom domain name for the share');
+	}
+
+	/**
+	 * Execute the command.
+	 *
+	 * @param  \Symfony\Component\Console\Input\InputInterface  $input
+	 * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+	 * @return void
+	 */
+	public function execute(InputInterface $input, OutputInterface $output)
+	{
+		$arguments = array('share');
+	
+		// Set share name
+		$name = $input->getOption('name');
+		if ($name)
+		{
+			$arguments[] = '--name';
+			$arguments[] = $name;
+		}
+		else
+		{
+			$arguments[] = '--name';
+			$arguments[] = 'share';
+		}
+		
+		// Pass optional custom domain
+		$domain = $input->getOption('domain');
+		if ($domain)
+		{
+			$arguments[] = '--domain';
+			$arguments[] = $domain;
+		}
+		
+		// Build process and execute
+		$builder = new ProcessBuilder($arguments);
+		$builder->setPrefix('vagrant');
+		$builder->setTimeout(null);
+		
+		$builder->addEnvironmentVariables($_ENV);
+		$builder->setWorkingDirectory(realpath(__DIR__.'/../'));
+
+		$builder->getProcess()->run(function($type, $line) use ($output)
+		{
+			$output->write($line);
+		});
+	}
+
+}


### PR DESCRIPTION
This PR adds a `homestead share` command that can be used to share the box using `vagrant share`. Since the name of the share defaults to "share" it is advisable to register a [custom domain] (https://atlas.hashicorp.com/help/vagrant/shares/custom) with Atlas for privacy reasons.

The reason it defaults to "share" is to make it easier to add additional mappings for external access to sites, which would otherwise be pretty much impossible with Atlas' random hostnames. Hostnames are wildcard DNS records, so use `foo.share.custom-domain.tld`, `bar.share.custom-domain.tld` etc. as the hostnames in Homestead.yaml. You basically share your entire Homestead box, not just one specific site. Per-site access is done by using site-specific mappings using these subdomains.