### PR TITLE
Serve script is failing when using oh my zsh under Homestead env

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -5,7 +5,7 @@ alias h='cd ~'
 alias c='clear'
 
 function serve() {
-	if [[ "$1" && "$2" ]]
+	if [[ $# -eq 2 ]]
 	then
 		sudo dos2unix /vagrant/scripts/serve.sh
 		sudo bash /vagrant/scripts/serve.sh "$1" "$2"


### PR DESCRIPTION
The `serve` command is not found when adding homestead aliases to zsh  `echo "source $HOME/.bash_aliases" >> /home/vagrant/.zshrc`:

```bash
/home/vagrant/.bash_aliases:8: parse error near `&&'
➜  ~  serve
zsh: command not found: serve
```
