### PR TITLE
adds configuration option to import sql dump file when creating databases

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -3,3 +3,7 @@
 DB=$1;
 mysql -uhomestead -psecret -e "DROP DATABASE IF EXISTS $DB";
 mysql -uhomestead -psecret -e "CREATE DATABASE $DB";
+
+if [[ $2 ]]; then
+    mysql -uhomestead -psecret $1 < $2;
+fi

--- a/scripts/create-postgres.sh
+++ b/scripts/create-postgres.sh
@@ -3,3 +3,7 @@
 DB=$1;
 su postgres -c "dropdb $DB --if-exists"
 su postgres -c "createdb -O homestead '$DB' || true"
+
+if [[ $2 ]]; then
+    su postgres -c "psql $1 < $2"
+fi

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -64,15 +64,23 @@ class Homestead
     end
 
     # Configure All Of The Configured Databases
-    settings["databases"].each do |db|
+    settings["databases"].each do |database|
         config.vm.provision "shell" do |s|
             s.path = "./scripts/create-mysql.sh"
-            s.args = [db]
+            if (database.has_key?("sql") && database["sql"])
+              s.args = [database["db"], database["sql"]]
+            else
+              s.args = database["db"]
+            end
         end
 
         config.vm.provision "shell" do |s|
             s.path = "./scripts/create-postgres.sh"
-            s.args = [db]
+            if (database.has_key?("psql") && database["psql"])
+              s.args = [database["db"], database["psql"]]
+            else
+              s.args = database["db"]
+            end
         end
     end
 

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -17,7 +17,7 @@ sites:
       to: /home/vagrant/Code/Laravel/public
 
 databases:
-    - homestead
+    - db: homestead
 
 variables:
     - key: APP_ENV


### PR DESCRIPTION
This adds a configuration options to automatically import a sql dump file when creating the databases.

Example Homestead.yam config:
databases:
    - db: homestead
      sql: /home/vagrant/Code/Laravel/homestead.sql