### PR TITLE
Create nginx virtual host if not exists

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -35,8 +35,12 @@ block="server {
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+if [ ! -f "/etc/nginx/sites-available/$1" ];
+    echo "$block" > "/etc/nginx/sites-available/$1"
+fi
+if [ ! -f "/etc/nginx/sites-enabled/$1" ];
+    ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+fi
 service nginx restart
 service php5-fpm restart
 service hhvm restart

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -35,10 +35,10 @@ block="server {
 }
 "
 
-if [ ! -f "/etc/nginx/sites-available/$1" ];
+if [ ! -f "/etc/nginx/sites-available/$1" ]; then
     echo "$block" > "/etc/nginx/sites-available/$1"
 fi
-if [ ! -f "/etc/nginx/sites-enabled/$1" ];
+if [ ! -f "/etc/nginx/sites-enabled/$1" ]; then
     ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 fi
 service nginx restart

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -40,7 +40,11 @@ block="server {
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+if [ ! -f "/etc/nginx/sites-available/$1" ];
+    echo "$block" > "/etc/nginx/sites-available/$1"
+fi
+if [ ! -f "/etc/nginx/sites-enabled/$1" ];
+    ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+fi
 service nginx restart
 service php5-fpm restart

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -40,10 +40,10 @@ block="server {
 }
 "
 
-if [ ! -f "/etc/nginx/sites-available/$1" ];
+if [ ! -f "/etc/nginx/sites-available/$1" ]; then
     echo "$block" > "/etc/nginx/sites-available/$1"
 fi
-if [ ! -f "/etc/nginx/sites-enabled/$1" ];
+if [ ! -f "/etc/nginx/sites-enabled/$1" ]; then
     ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 fi
 service nginx restart


### PR DESCRIPTION
Instead of recreate nginx virtual host on each vagrant start, ignore hosts that already created. I think it is very useful if need to edit nginx virtual host config.