### PR TITLE
Pass environment variables to 'provision' process

### DIFF
--- a/src/ProvisionCommand.php
+++ b/src/ProvisionCommand.php
@@ -27,7 +27,7 @@ class ProvisionCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant provision', realpath(__DIR__.'/../'), null, null, null);
+		$process = new Process('vagrant provision', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{


### PR DESCRIPTION
Previously, calling 'homestead provision' will not provision the homestead VM because vagrant does not know where to locate the VM.

This commit simply passes those environment variables to `vagrant
provision` so that vagrant will know how to provision the homestead VM.