### PR TITLE
Provision command not setting env.

### DIFF
--- a/src/ProvisionCommand.php
+++ b/src/ProvisionCommand.php
@@ -27,7 +27,7 @@ class ProvisionCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$process = new Process('vagrant provision', realpath(__DIR__.'/../'), null, null, null);
+		$process = new Process('vagrant provision', realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 
 		$process->run(function($type, $line) use ($output)
 		{


### PR DESCRIPTION
This prevents the command from running.
Vagrant cant find the machine
==> default: VM is not currently running. Please, first bring it up with `vagrant up` then run this command.