### PR TITLE
Fixing perl locale warning

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -95,6 +95,17 @@ class Homestead
       end
     end
 
+    # Setup locale
+    config.vm.provision "shell" do |s|
+      s.inline = 'if ! grep -q "LANGUAGE=" /etc/environment; then echo "LANGUAGE=en_US.UTF-8" >> /etc/environment; fi'
+    end
+    config.vm.provision "shell" do |s|
+      s.inline = 'if ! grep -q "LC_ALL=" /etc/environment; then echo "LC_ALL=en_US.UTF-8" >> /etc/environment; fi'
+    end
+    config.vm.provision "shell" do |s|
+      s.inline = 'if ! grep -q "LANG=" /etc/environment; then echo "LANG=en_US.UTF-8" >> /etc/environment; fi'
+    end
+
     # Update Composer On Every Provision
     config.vm.provision "shell" do |s|
       s.inline = "/usr/local/bin/composer self-update"


### PR DESCRIPTION
This commit fixes the common perl warning for locale in Ubuntu by setting default locale to en_US.UTF-8

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = (unset),
    LC_ALL = (unset),
    LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
```