### PR TITLE
UTF-8 charset and collation for MySQL

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -2,4 +2,4 @@
 
 DB=$1;
 mysql -uhomestead -psecret -e "DROP DATABASE IF EXISTS $DB";
-mysql -uhomestead -psecret -e "CREATE DATABASE $DB";
+mysql -uhomestead -psecret -e "CREATE DATABASE $DB DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
MySQL's built-in default for new databases is `latin1` / `latin1_swedish_ci`.  Can we make `utf8` / `utf8_unicode_ci` the default for Homestead's MySQL databases?  Specifying it at database creation seems like the simplest solution to me.

We could also/instead modify the Homestead.yaml syntax to specify these.  For example...

```
databases:
    - name: homestead
      charset: utf8
      collation: utf8_unicode_ci
    - name: otherdb
      charset: latin1
      collation: latin1_swedish_ci
```

But I'd still argue that UTF-8 should be the default.