### PR TITLE
add init/edit command option to support different environment configure file

### DIFF
--- a/src/EditCommand.php
+++ b/src/EditCommand.php
@@ -15,7 +15,8 @@ class EditCommand extends Command {
 	protected function configure()
 	{
 		$this->setName('edit')
-                  ->setDescription('Edit the Homestead.yaml file');
+			->setDescription('Edit the Homestead.yaml file')
+			->addArgument('name');
 	}
 
 	/**
@@ -27,7 +28,14 @@ class EditCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		$command = $this->executable().' '.homestead_path().'/Homestead.yaml';
+		$envName = $input->getArgument('name');
+		if (is_null($envName))
+		{
+			$envName = 'Homestead';
+		}
+		$configureFilePath = homestead_path()."/{$envName}.yaml";
+
+		$command = $this->executable().' '.$configureFilePath;
 
 		$process = new Process($command, realpath(__DIR__.'/../'), array_merge($_SERVER, $_ENV), null, null);
 

--- a/src/InitCommand.php
+++ b/src/InitCommand.php
@@ -15,7 +15,8 @@ class InitCommand extends Command {
 	protected function configure()
 	{
 		$this->setName('init')
-                  ->setDescription('Create a stub Homestead.yaml file');
+			->setDescription('Create a stub Homestead.yaml file')
+			->addArgument('name');
 	}
 
 	/**
@@ -27,19 +28,29 @@ class InitCommand extends Command {
 	 */
 	public function execute(InputInterface $input, OutputInterface $output)
 	{
-		if (is_dir(homestead_path()))
+		$envName = $input->getArgument('name');
+		if (is_null($envName))
+		{
+			$envName = 'Homestead';
+		}
+		$configureFilePath = homestead_path()."/{$envName}.yaml";
+
+		if (file_exists($configureFilePath))
 		{
 			throw new \InvalidArgumentException("Homestead has already been initialized.");
 		}
 
-		mkdir(homestead_path());
+		if (!is_dir(homestead_path()))
+		{
+			mkdir(homestead_path());
+		}
 
-		copy(__DIR__.'/stubs/Homestead.yaml', homestead_path().'/Homestead.yaml');
+		copy(__DIR__.'/stubs/Homestead.yaml', $configureFilePath);
 		copy(__DIR__.'/stubs/after.sh', homestead_path().'/after.sh');
 		copy(__DIR__.'/stubs/aliases', homestead_path().'/aliases');
 
-		$output->writeln('<comment>Creating Homestead.yaml file...</comment> <info>✔</info>');
-		$output->writeln('<comment>Homestead.yaml file created at:</comment> '.homestead_path().'/Homestead.yaml');
+		$output->writeln('<comment>Creating '.$envName.'.yaml file...</comment> <info>✔</info>');
+		$output->writeln('<comment>Homestead.yaml file created at:</comment> '.homestead_path().'/'.$envName.'.yaml');
 	}
 
 }


### PR DESCRIPTION
I suggest that support differnt environment configuration file.
For example, to test behaviors by middleware like php version between 5.4 and 5.6 and so on.

I added name argument to init and edit command.
[Usage]
homestead init Foo # -> create ~/.homestead/Foo.yaml
homestead edit Foo # -> edit  ~/.homestead/Foo.yaml
(default is "Homestead")

To apply it, configure "homesteadYamlPath" of Vagrantfile by your own editor.