### PR TITLE
Escape database name in MySQL script

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 DB=$1;
-mysql -uhomestead -psecret -e "DROP DATABASE IF EXISTS $DB";
-mysql -uhomestead -psecret -e "CREATE DATABASE $DB";
+mysql -uhomestead -psecret -e "DROP DATABASE IF EXISTS \`$DB\`";
+mysql -uhomestead -psecret -e "CREATE DATABASE \`$DB\`";


### PR DESCRIPTION
Otherwise it will break, if the database name contains a period.

Breaking `Homestead.yaml`:

```yaml
databases:
    - homestead
    - example.com
```