### PR TITLE
Fix for critical error during provisioning that resulted in VM not being created/provisioned

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -59,10 +59,10 @@ class Homestead
       config.vm.provision "shell" do |s|
           if (site.has_key?("hhvm") && site["hhvm"])
             s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 \"$2\" $3"
-            s.args = [site["map"], site["to"], site["port"].to_s ||= "80"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80"]
           else
             s.inline = "bash /vagrant/scripts/serve.sh $1 \"$2\" $3"
-            s.args = [site["map"], site["to"], site["port"].to_s ||= "80"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80"]
           end
       end
     end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -59,10 +59,10 @@ class Homestead
       config.vm.provision "shell" do |s|
           if (site.has_key?("hhvm") && site["hhvm"])
             s.inline = "bash /vagrant/scripts/serve-hhvm.sh $1 \"$2\" $3"
-            s.args = [site["map"], site["to"], site["port"] ||= 80]
+            s.args = [site["map"], site["to"], site["port"].to_s ||= "80"]
           else
             s.inline = "bash /vagrant/scripts/serve.sh $1 \"$2\" $3"
-            s.args = [site["map"], site["to"], site["port"] ||= 80]
+            s.args = [site["map"], site["to"], site["port"].to_s ||= "80"]
           end
       end
     end


### PR DESCRIPTION
Creating or re-provisioning resulted in the following error: 
"/Applications/Vagrant/embedded/gems/gems/vagrant-1.6.3/plugins/provisioners/shell/provisioner.rb:122:in `quote_and_escape': undefined method `gsub' for 80:Fixnum (NoMethodError)"

The error got introduced in #160 