### PR TITLE
Only create the database if it doesn't already exist

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -2,5 +2,4 @@
 
 DB=$1;
 
-mysql -uhomestead -psecret -e "DROP DATABASE IF EXISTS \`$DB\`";
-mysql -uhomestead -psecret -e "CREATE DATABASE \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";
+mysql -uhomestead -psecret -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
This prevents trashing existing databases when running homestead --provision