### PR TITLE
Change upload max size in PHP

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -43,4 +43,7 @@ block="server {
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 service nginx restart
+
+sudo sed -i "s/upload_max_filesize = .*/upload_max_filesize = 100M/" /etc/php5/fpm/php.ini
+
 service php5-fpm restart


### PR DESCRIPTION
The nginx configuration is now set to maximum upload 100 mb files, but PHP config is still on 2 mb. So the php.ini needs to be configurated too. With one single sed command this is possible.