### PR TITLE
Improve file watching for NFS shared folders.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -64,7 +64,8 @@ class Homestead
 
     # Register All Of The Configured Shared Folders
     settings["folders"].each do |folder|
-      config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil
+      mount_opts = folder["type"] == "nfs" ? ['actimeo=1'] : []
+      config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, mount_options: mount_opts
     end
 
     # Install All The Configured Nginx Sites


### PR DESCRIPTION
This should improve watching for file changes inside the VM (e.g. with Grunt etc.).

For reference: http://stackoverflow.com/questions/27035702/grunt-watch-detects-file-changes-only-after-5-seconds-with-vagrant-and-nfs