### PR TITLE
Add artisan and migrate aliases

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -4,6 +4,9 @@ alias ...="cd ../.."
 alias h='cd ~'
 alias c='clear'
 
+alias art="php artisan"
+alias migrate="php artisan migrate"
+
 function serve() {
 	if [[ "$1" && "$2" ]]
 	then


### PR DESCRIPTION
Added `art` (`php artisan`) and `migrate` (`php artisan migrate`) aliases.

I know lots of laravel guys are using `art` alias (including @JeffreyWay).

Also, `php artisan migrate` is the most frequently used artisan command on Homestead, so why not simplify things.