### PR TITLE
fixed serve and serve-hhvm command inside vm

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+PORT=$3
+if [ -z "$3" ]; then PORT=$3; else PORT=80; fi
 block="server {
-    listen $3;
+    listen $PORT;
     server_name $1;
     root \"$2\";
 

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+PORT=$3
+if [ -z "$3" ]; then PORT=$3; else PORT=80; fi
 block="server {
-    listen $3;
+    listen $PORT;
     server_name $1;
     root \"$2\";
 


### PR DESCRIPTION
As serve commands now able to use custom port. Default command won't work. I've seen @taylorotwell set default port in homestead.rb. But, no default port were set in serve command in .bash_aliases. As I can't patch .bash_aliases files, I made the default in the scripts.

Currently, if I run serve command, it show:
```
dos2unix: converting file /vagrant/scripts/serve.sh to Unix format ...
 * Restarting nginx nginx                                                [ Fail ]
php5-fpm stop/waiting
php5-fpm start/running, process 3183
```

Because missing port in nginx config. This commit fix that.