### PR TITLE
Use BASH builtin tools for parameter substitution

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-PORT=$3
-if [ -z "$3" ]; then PORT=$3; else PORT=80; fi
 block="server {
-    listen $PORT;
+    listen ${3:-80};
     server_name $1;
     root \"$2\";
 

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-PORT=$3
-if [ -z "$3" ]; then PORT=$3; else PORT=80; fi
 block="server {
-    listen $PORT;
+    listen ${3:-80};
     server_name $1;
     root \"$2\";
 


### PR DESCRIPTION
This is to clean up PR #184 
 
Simplify the parameter substitution using BASH's builtin tools.
http://tldp.org/LDP/abs/html/parameter-substitution.html