### PR TITLE
Configuration directory can be optionally set

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,12 +2,13 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION = "2"
+confDir = $confDir ||= File.expand_path("~/.homestead")
 
-homesteadYamlPath = File.expand_path("~/.homestead/Homestead.yaml")
-afterScriptPath = File.expand_path("~/.homestead/after.sh")
-aliasesPath = File.expand_path("~/.homestead/aliases")
+homesteadYamlPath = confDir + "/Homestead.yaml"
+afterScriptPath = confDir + "/after.sh"
+aliasesPath = confDir + "/aliases"
 
-require_relative 'scripts/homestead.rb'
+require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	if File.exists? aliasesPath then


### PR DESCRIPTION
Rather than defaulting to ~/.homestead, the configuration directory can be optionally set.

This set-up allows for Homestead to be included within a Laravel workspace as a dependency, with per-project specific config. Also, some IDE's (e.g. Netbeans) can also boot the VM based on the project currently being worked on.

The reason the 'folders' setting is wrapped in an if statement now is because, when configured to run from the laravel root, /vagrant already maps to the laravel root folder, so it's unnecessary to force another definition.