### PR TITLE
Allow overriding default Homestead ports

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -37,10 +37,29 @@ class Homestead
     end
 
     # Configure Port Forwarding To The Box
-    config.vm.network "forwarded_port", guest: 80, host: 8000
-    config.vm.network "forwarded_port", guest: 443, host: 44300
-    config.vm.network "forwarded_port", guest: 3306, host: 33060
-    config.vm.network "forwarded_port", guest: 5432, host: 54320
+    # Is HTTP Default Port Overridden?
+    unless settings["ports"].any? { |mapping| mapping["guest"] == 80 }
+      # Set Default HTTP Port Forwarding
+      config.vm.network "forwarded_port", guest: 80, host: 8000
+    end
+
+    # Is HTTPS Port Overridden?
+    unless settings["ports"].any? { |mapping| mapping["guest"] == 443 }
+      # Set Default HTTPS Port Forwarding
+      config.vm.network "forwarded_port", guest: 443, host: 44300
+    end
+
+    # Is MySQL Port Overridden?
+    unless settings["ports"].any? { |mapping| mapping["guest"] == 3306 }
+      # Set Default MySQL Port Forwarding
+      config.vm.network "forwarded_port", guest: 3306, host: 33060
+    end
+
+    # Is PostgreSQL Port Overridden?
+    unless settings["ports"].any? { |mapping| mapping["guest"] == 5432 }
+      # Set Default PostgreSQL Port Forwarding
+      config.vm.network "forwarded_port", guest: 5432, host: 54320
+    end
 
     # Add Custom Ports From Configuration
     if settings.has_key?("ports")

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -37,6 +37,13 @@ class Homestead
     end
 
     # Configure Port Forwarding To The Box
+    # Standardize Ports Naming Schema
+    settings["ports"].each do |port|
+      port["guest"] ||= port["to"]
+      port["host"] ||= port["send"]
+      port["protocol"] ||= "tcp"
+    end
+
     # Is HTTP Default Port Overridden?
     unless settings["ports"].any? { |mapping| mapping["guest"] == 80 }
       # Set Default HTTP Port Forwarding
@@ -64,7 +71,7 @@ class Homestead
     # Add Custom Ports From Configuration
     if settings.has_key?("ports")
       settings["ports"].each do |port|
-        config.vm.network "forwarded_port", guest: port["guest"] || port["to"], host: port["host"] || port["send"], protocol: port["protocol"] ||= "tcp"
+        config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"]
       end
     end
 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -36,7 +36,6 @@ class Homestead
       end
     end
 
-    # Configure Port Forwarding To The Box
     # Standardize Ports Naming Schema
     settings["ports"].each do |port|
       port["guest"] ||= port["to"]
@@ -44,28 +43,19 @@ class Homestead
       port["protocol"] ||= "tcp"
     end
 
-    # Is HTTP Default Port Overridden?
-    unless settings["ports"].any? { |mapping| mapping["guest"] == 80 }
-      # Set Default HTTP Port Forwarding
-      config.vm.network "forwarded_port", guest: 80, host: 8000
-    end
+    # Default Port Forwarding
+    default_ports = {
+      80   => 8000,
+      443  => 44300,
+      3306 => 33060,
+      5432 => 54320
+    }
 
-    # Is HTTPS Port Overridden?
-    unless settings["ports"].any? { |mapping| mapping["guest"] == 443 }
-      # Set Default HTTPS Port Forwarding
-      config.vm.network "forwarded_port", guest: 443, host: 44300
-    end
-
-    # Is MySQL Port Overridden?
-    unless settings["ports"].any? { |mapping| mapping["guest"] == 3306 }
-      # Set Default MySQL Port Forwarding
-      config.vm.network "forwarded_port", guest: 3306, host: 33060
-    end
-
-    # Is PostgreSQL Port Overridden?
-    unless settings["ports"].any? { |mapping| mapping["guest"] == 5432 }
-      # Set Default PostgreSQL Port Forwarding
-      config.vm.network "forwarded_port", guest: 5432, host: 54320
+    # Use Default Port Forwarding Unless Overridden
+    default_ports.each do |guest, host|
+      unless settings["ports"].any? { |mapping| mapping["guest"] == guest }
+        config.vm.network "forwarded_port", guest: guest, host: host
+      end
     end
 
     # Add Custom Ports From Configuration

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -31,5 +31,8 @@ variables:
 #       client-token: bar
 
 # ports:
-#   - guest: 80
-#     host: 8000
+#     - send: 93000
+#       to: 9300
+#     - send: 7777
+#       to: 777
+#       protocol: udp

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -29,3 +29,7 @@ variables:
 #       token: bar
 #       client-id: foo
 #       client-token: bar
+
+# ports:
+#   - guest: 80
+#     host: 8000


### PR DESCRIPTION
PR #188 discussed having a syntax like this available in `Homestead.yaml` to override the default ports. 
```YAML
ports:
  - map: 80
    to: 8000
``` 

Homestead already has support for the following structure: 
```YAML
ports:
  - guest: 80
    host: 8000
``` 

This PR allows the default ports to be overridden. If they are not overridden then the default port forwarding takes place preserving backwards compatibility.