### PR TITLE
Fixed errors caused by copying files on Windows based operating systems (and others?)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -4,8 +4,8 @@ mkdir -p ~/.homestead
 
 homesteadRoot=~/.homestead
 
-cp -i src/stubs/Homestead.yaml $homesteadRoot/Homestead.yaml
-cp -i src/stubs/after.sh $homesteadRoot/after.sh
-cp -i src/stubs/aliases $homesteadRoot/aliases
+cp -i src/stubs/Homestead.yaml "$homesteadRoot/Homestead.yaml"
+cp -i src/stubs/after.sh "$homesteadRoot/after.sh"
+cp -i src/stubs/aliases "$homesteadRoot/aliases"
 
 echo "Homestead initialized!"


### PR DESCRIPTION
An issue is caused where the user (i.e. Liam Symonds) has a space in their home folder (i.e.
C:\Users\Liam Symonds). I imagine this would also be prevalent on other
operating systems if the user had a space in their home directory name.

The copy command would think the part after the space (in my case Symonds)
was a new directory and would attempt to copy the first two parts
(homestead files and Liam) to it. This would then fail.