### PR TITLE
GitHub OAuth-token integration

### DIFF
--- a/scripts/github.sh
+++ b/scripts/github.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+TOKEN=$1;
+
+composer config --global github-oauth.github.com "$TOKEN"

--- a/scripts/github.sh
+++ b/scripts/github.sh
@@ -2,4 +2,4 @@
 
 TOKEN=$1;
 
-composer config --global github-oauth.github.com "$TOKEN"
+su vagrant -c "composer config --global github-oauth.github.com \"$TOKEN\""

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -164,7 +164,7 @@ class Homestead
       config.vm.provision "shell" do |s|
         s.path = scriptDir + "/github.sh"
         s.args = [
-          settings["github"][0]["oauth-token"]
+          settings["github"]["oauth-token"]
         ]
       end
     end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -158,5 +158,15 @@ class Homestead
         ]
       end
     end
+
+    # Configure GitHub
+    if settings.has_key?("github")
+      config.vm.provision "shell" do |s|
+        s.path = scriptDir + "/github.sh"
+        s.args = [
+          settings["github"][0]["oauth-token"]
+        ]
+      end
+    end
   end
 end

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -36,3 +36,6 @@ variables:
 #     - send: 7777
 #       to: 777
 #       protocol: udp
+
+# github:
+#     - oauth-token: value


### PR DESCRIPTION
As GitHub is a core component required for a successful installation of laravel on homestead, it would be nice to have a default setting to specify the GitHub OAuth-token for the default vagrant user. It's quite easy to hit the 60 API call rate limit nowadays.
