### PR TITLE
fix vagrant file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
 	end
 
-	Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
+	Homestead.configure(config, YAML::load_file(homesteadYamlPath))
 
 	if File.exists? afterScriptPath then
 		config.vm.provision "shell", path: afterScriptPath


### PR DESCRIPTION
Due to error: /Applications/Vagrant/embedded/lib/ruby/2.0.0/psych.rb:205:in `parse': (<unknown>): did not find expected '-' indicator while parsing a block collection at line 13 column 5 (Psych::SyntaxError)