### PR TITLE
Default Hostname

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -11,7 +11,7 @@ class Homestead
 
     # Configure The Box
     config.vm.box = "laravel/homestead"
-    config.vm.hostname = "homestead"
+    config.vm.hostname = settings["hostname"] ||= "homestead"
 
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"


### PR DESCRIPTION
Allowing hostname to be set within Homestead.yaml file. If no hostname
is set, then hostname is default to homestead.