### PR TITLE
Update serve.sh

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -29,6 +29,7 @@ block="server {
     client_max_body_size 100m;
 
     location ~ \.php$ {
+        try_files \$uri /index.php =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php5-fpm.sock;
         fastcgi_index index.php;


### PR DESCRIPTION
I don't know if there is a more elegant solution, but this worked for me.

Basically I had to port a old app to Laravel and I needed to keep the old uris, and some of them ended with .php. With default homestead serve.sh the server just returned an `No input file specified` error.

So I Updated serve.sh to redirect properly to the application's index.php main script even for uri that ends with .php