### PR TITLE
Check PHP file exists before passing it to PHP

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -27,6 +27,9 @@ block="server {
     sendfile off;
 
     location ~ \.php$ {
+        # don't pass file to PHP unless it exists
+        try_files $uri =404;
+
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_index index.php;

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -29,6 +29,9 @@ block="server {
     client_max_body_size 100m;
 
     location ~ \.php$ {
+        # don't pass file to PHP unless it exists
+        try_files $uri =404;
+
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php5-fpm.sock;
         fastcgi_index index.php;


### PR DESCRIPTION
Returns 404 (which is true for this error), if it doesn't exist.

This fixes the issue of the "No input file selected" response.