### PR TITLE
adds a wildcard subdomain by default to the nginx configuration

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -7,7 +7,7 @@ openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1
 
 block="server {
     listen ${3:-80};
-    server_name $1;
+    server_name $1 *.$1;
     root \"$2\";
 
     index index.html index.htm index.php;


### PR DESCRIPTION
When building a SaaS app I constantly have to `ssh` into the homestead server and add this wildcard subdomain to the `sites_available` nginx configuration file.