### PR TITLE
Don't make databases a required setting

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -110,16 +110,18 @@ class Homestead
     end
 
     # Configure All Of The Configured Databases
-    settings["databases"].each do |db|
-      config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/create-mysql.sh"
-        s.args = [db]
-      end
-
-      config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/create-postgres.sh"
-        s.args = [db]
-      end
+    if settings.has_key?("databases")
+        settings["databases"].each do |db|
+          config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/create-mysql.sh"
+            s.args = [db]
+          end
+    
+          config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/create-postgres.sh"
+            s.args = [db]
+          end
+        end
     end
 
     # Configure All Of The Server Environment Variables


### PR DESCRIPTION
I didn't need any databases on my homestead machine, so I commented the complete `databases` block. This resulted in a Ruby error among the lines of `undefined method each of Nil`.

This PR makes the `databases` setting optional, another solution is to have a better error when it isn't available.