### PR TITLE
Add homestead install command

### DIFF
--- a/homestead
+++ b/homestead
@@ -39,5 +39,6 @@ $app->add(new Laravel\Homestead\UpdateCommand);
 $app->add(new Laravel\Homestead\SshCommand);
 $app->add(new Laravel\Homestead\StatusCommand);
 $app->add(new Laravel\Homestead\SuspendCommand);
+$app->add(new Laravel\Homestead\InstallCommand);
 
 $app->run();

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -110,16 +110,18 @@ class Homestead
     end
 
     # Configure All Of The Configured Databases
-    settings["databases"].each do |db|
-      config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/create-mysql.sh"
-        s.args = [db]
-      end
+    if settings.has_key?("databases")
+        settings["databases"].each do |db|
+          config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/create-mysql.sh"
+            s.args = [db]
+          end
 
-      config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/create-postgres.sh"
-        s.args = [db]
-      end
+          config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/create-postgres.sh"
+            s.args = [db]
+          end
+        end
     end
 
     # Configure All Of The Server Environment Variables

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -18,7 +18,7 @@ class Homestead
 
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|
-      vb.name = 'homestead'
+      vb.name = settings["name"] ||= "homestead"
       vb.customize ["modifyvm", :id, "--memory", settings["memory"] ||= "2048"]
       vb.customize ["modifyvm", :id, "--cpus", settings["cpus"] ||= "1"]
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
@@ -110,18 +110,16 @@ class Homestead
     end
 
     # Configure All Of The Configured Databases
-    if settings.has_key?("databases")
-        settings["databases"].each do |db|
-          config.vm.provision "shell" do |s|
-            s.path = scriptDir + "/create-mysql.sh"
-            s.args = [db]
-          end
-    
-          config.vm.provision "shell" do |s|
-            s.path = scriptDir + "/create-postgres.sh"
-            s.args = [db]
-          end
-        end
+    settings["databases"].each do |db|
+      config.vm.provision "shell" do |s|
+        s.path = scriptDir + "/create-mysql.sh"
+        s.args = [db]
+      end
+
+      config.vm.provision "shell" do |s|
+        s.path = scriptDir + "/create-postgres.sh"
+        s.args = [db]
+      end
     end
 
     # Configure All Of The Server Environment Variables

--- a/src/InstallCommand.php
+++ b/src/InstallCommand.php
@@ -1,0 +1,108 @@
+<?php namespace Laravel\Homestead;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class InstallCommand extends Command {
+
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('install')
+            ->setDescription('Install Homestead into the current project')
+            ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The name the virtual machine.')
+            ->addOption('hostname', null, InputOption::VALUE_OPTIONAL, 'The hostname the virtual machine.');
+        $this->rootPath = getcwd();
+        $this->sourcePath = homestead_path();
+        $this->projectFolder = basename(getcwd());
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->rootPath.'/Vagrantfile');
+        copy(__DIR__.'/stubs/Homestead.yaml', $this->rootPath.'/Homestead.yaml');
+        copy(__DIR__.'/stubs/after.sh', $this->rootPath.'/after.sh');
+        copy(__DIR__.'/stubs/aliases', $this->rootPath.'/aliases');
+
+        if ($input->getOption('name'))
+        {
+            $this->updateName($input->getOption('name'));
+        }
+
+        if ($input->getOption('hostname'))
+        {
+            $this->updateHostName($input->getOption('hostname'));
+        }
+        $this->updatePaths();
+
+        $output->writeln('Homestead Installed!');
+    }
+
+    /**
+     * Update paths in Homestead.yaml
+     */
+    protected function updatePaths()
+    {
+        $file = file_get_contents($this->rootPath.'/Homestead.yaml');
+
+        // Update folder map path
+        $newFile = str_replace("- map: ~/Code", "- map: ".$this->rootPath, $file);
+
+        // Update folder to path
+        $newFile = str_replace("to: /home/vagrant/Code",
+            "to: /home/vagrant/".$this->projectFolder,
+            $newFile);
+
+        // Fix path to the public folder (sites: to:)
+        $newFile = str_replace($this->projectFolder."/Laravel",
+            $this->projectFolder,
+            $newFile);
+
+        // Save the new file
+        file_put_contents($this->rootPath.'/Homestead.yaml', $newFile);
+    }
+
+    /**
+     * Adds the virtual machine's name setting in the Homstead.yaml
+     * This is needed because Virtualbox requires unique names
+     * @param $vbName
+     */
+    protected function updateName($vbName)
+    {
+        // Update virtualbox name
+        $file = file_get_contents($this->rootPath.'/Homestead.yaml');
+        $newFile = str_replace("cpus: 1", "cpus: 1".PHP_EOL."name: ".$vbName, $file);
+
+        file_put_contents($this->rootPath.'/Homestead.yaml', $newFile);
+    }
+
+    /**
+     * Adds the virtual machine's hostname setting in the Homstead.yaml
+     * @param $hostname
+     */
+    protected function updateHostName($hostname)
+    {
+        // Update virtualbox hostname
+        $file = file_get_contents($this->rootPath.'/Homestead.yaml');
+        $newFile = str_replace("cpus: 1", "cpus: 1".PHP_EOL."hostname: ".$hostname, $file);
+
+        file_put_contents($this->rootPath.'/Homestead.yaml', $newFile);
+    }
+
+}

--- a/src/InstallCommand.php
+++ b/src/InstallCommand.php
@@ -21,7 +21,7 @@ class InstallCommand extends Command {
             ->setDescription('Install Homestead into the current project')
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The name the virtual machine.')
             ->addOption('hostname', null, InputOption::VALUE_OPTIONAL, 'The hostname the virtual machine.');
-        $this->rootPath = str_replace('/vendor/bin/', '', getcwd());
+        $this->rootPath = getcwd();
         $this->sourcePath = homestead_path();
         $this->projectFolder = basename(getcwd());
     }

--- a/src/InstallCommand.php
+++ b/src/InstallCommand.php
@@ -21,7 +21,7 @@ class InstallCommand extends Command {
             ->setDescription('Install Homestead into the current project')
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The name the virtual machine.')
             ->addOption('hostname', null, InputOption::VALUE_OPTIONAL, 'The hostname the virtual machine.');
-        $this->rootPath = getcwd();
+        $this->rootPath = str_replace('/vendor/bin/', '', getcwd());
         $this->sourcePath = homestead_path();
         $this->projectFolder = basename(getcwd());
     }

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -2,7 +2,7 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION = "2"
-confDir = $confDir ||= File.expand_path("~/.composer/vendor/laravel/homestead")
+confDir = $confDir ||= File.expand_path("vendor/laravel/homestead")
 
 homesteadYamlPath = "Homestead.yaml"
 afterScriptPath = "after.sh"

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -1,0 +1,23 @@
+require 'json'
+require 'yaml'
+
+VAGRANTFILE_API_VERSION = "2"
+confDir = $confDir ||= File.expand_path("~/.composer/vendor/laravel/homestead")
+
+homesteadYamlPath = "Homestead.yaml"
+afterScriptPath = "after.sh"
+aliasesPath = "aliases"
+
+require File.expand_path(confDir + '/scripts/homestead.rb')
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+	if File.exists? aliasesPath then
+		config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
+	end
+
+	Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
+
+	if File.exists? afterScriptPath then
+		config.vm.provision "shell", path: afterScriptPath
+	end
+end


### PR DESCRIPTION
Add homestead install command to allow users to install homestead into their Laravel project directly.

The use case for this would be to completely isolate the Homestead vagrant environment per project and allow users to ship Homestead environments with their code base making it easier for contributors to get up and running.

### Usage

```
laravel new project
cd project
composer require laravel/homestead
./vendor/bin/homestead install
```

Copies ```Vagrantfile```, ```Homestead.yaml```, ```after.sh```,  and ```aliases``` from the global Homestead folder to the project folder. The other files used by homestead are loaded/used out of the homestead path so they can be easily updated from upstream. These files we copy into the project are the ones I most commonly configure per project.

The command also updates paths in ```Homestead.yaml``` for the project folder.

#### Two options can be used:

Because Virtualbox requires box names to be unique the user can set a unique box name. (this is something we may want to do regardless, possibly use the project folder as the box name by default while allowing this override as well)

```
./vendor/bin/homestead install --name=MyBoxName
```

You can specify a hostname to be used:

```
./vendor/bin/homestead install --hostname=customname
```

#### Vagrant Operations

We have now installed a copy of the Homestead configuration into our project we used native Vagrant command to interact with the box.

```
vagrant up|halt|destroy
```