### PR TITLE
Do not overwrite existing files on make

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -62,14 +62,21 @@ class MakeCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output)
     {
         copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
-        copy(__DIR__.'/stubs/Homestead.yaml', $this->basePath.'/Homestead.yaml');
+
+        if (!file_exists($this->basePath.'/Homestead.yaml')) {
+            copy( __DIR__ . '/stubs/Homestead.yaml', $this->basePath . '/Homestead.yaml' );
+        }
 
         if ($input->getOption('after')) {
-            copy(__DIR__.'/stubs/after.sh', $this->basePath.'/after.sh');
+            if (!file_exists($this->basePath.'/after.sh')) {
+                copy( __DIR__ . '/stubs/after.sh', $this->basePath . '/after.sh' );
+            }
         }
 
         if ($input->getOption('aliases')) {
-            copy(__DIR__.'/stubs/aliases', $this->basePath.'/aliases');
+            if (!file_exists($this->basePath.'/aliases')) {
+                copy( __DIR__ . '/stubs/aliases', $this->basePath . '/aliases' );
+            }
         }
 
         if ($input->getOption('name')) {


### PR DESCRIPTION
When running the make command: If Homestead.yaml, aliases, or after.sh files exist, do not overwrite, assume they came with the application.

