### PR TITLE
Add artisan as an alias

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -3,6 +3,7 @@ alias ...="cd ../.."
 
 alias h='cd ~'
 alias c='clear'
+alias artisan='php artisan'
 
 function serve() {
 	if [[ "$1" && "$2" ]]


### PR DESCRIPTION
Add artisan as an alias to allow users to use 'arstian' without having to 'php artisan' at the command line" 

New alias allows for: 
```
$ artisan
```

Old method works the same:
```
$ php artisan
``` 

