### PR TITLE
Feature after.rb

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ confDir = $confDir ||= File.expand_path("~/.homestead")
 
 homesteadYamlPath = confDir + "/Homestead.yaml"
 afterScriptPath = confDir + "/after.sh"
+afterRubyPath = "after.rb"
 aliasesPath = confDir + "/aliases"
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
@@ -20,4 +21,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	if File.exists? afterScriptPath then
 		config.vm.provision "shell", path: afterScriptPath
 	end
+
+    if File.exists? afterRubyPath then
+        require File.expand_path(afterRubyPath)
+        HomesteadAfter.processing(config, YAML::load(File.read(homesteadYamlPath)))
+    end
 end

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -71,6 +71,9 @@ class MakeCommand extends Command
             if (!file_exists($this->basePath.'/after.sh')) {
                 copy( __DIR__ . '/stubs/after.sh', $this->basePath . '/after.sh' );
             }
+            if (!file_exists($this->basePath.'/after.rb')) {
+                copy( __DIR__ . '/stubs/after.rb', $this->basePath . '/after.rb' );
+            }
         }
 
         if ($input->getOption('aliases')) {

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -6,6 +6,7 @@ confDir = $confDir ||= File.expand_path("vendor/laravel/homestead")
 
 homesteadYamlPath = "Homestead.yaml"
 afterScriptPath = "after.sh"
+afterRubyPath = "after.rb"
 aliasesPath = "aliases"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
@@ -20,4 +21,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	if File.exists? afterScriptPath then
 		config.vm.provision "shell", path: afterScriptPath
 	end
+
+    if File.exists? afterRubyPath then
+        require File.expand_path(afterRubyPath)
+        HomesteadAfter.processing(config, YAML::load(File.read(homesteadYamlPath)))
+    end
 end

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -18,9 +18,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 	Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
 
-	if File.exists? afterScriptPath then
-		config.vm.provision "shell", path: afterScriptPath
-	end
+    if File.exists? afterScriptPath then
+        config.vm.provision "shell", path: afterScriptPath
+    end
 
     if File.exists? afterRubyPath then
         require File.expand_path(afterRubyPath)

--- a/src/stubs/after.rb
+++ b/src/stubs/after.rb
@@ -1,0 +1,11 @@
+##
+# If you would like to do some extra processing you may
+# add any commands you wish to this file and they will
+# be run at the end of the provisioning.
+# e.g. If you want to enable vagrant plug handling
+# you can add that here
+class HomesteadAfter
+  def HomesteadAfter.processing(config, settings)
+
+  end
+end


### PR DESCRIPTION
As briefly mentioned in #216 this adds an after.rb stub to work in a similar way that we can use after.sh to add extra shell script functionality, after.rb easily allows users to add extra vagrant plugin functionality while still easily remaining up to date with upstream Homestead changes.

I tested this with the plugin mentioned in #216 in an existing and fresh Laravel project and it works as expected. Feedback welcome if there is a better way to handle this. Also my indents may be a bit odd, Phpstorm is confused on files without extensions.