### PR TITLE
Update first site map to use homestead.test

### DIFF
--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -14,7 +14,7 @@ folders:
       to: /home/vagrant/Code
 
 sites:
-    - map: homestead.app
+    - map: homestead.test
       to: /home/vagrant/Code/Laravel/public
 
 databases:


### PR DESCRIPTION
.app is a TLD that should not be used for testing.

We should use **Reserved Top Level DNS Names** ([RFC 2606](http://www.ietf.org/rfc/rfc2606.txt)) for testing.

> The fiercely competed new gTLD .app has sold to Google for a record-breaking $25 million.
( http://domainincite.com/18066-google-buys-app-for-over-25-million )

We should use one of the following TLDs for testing:

* .test
* .example
* .invalid
* .localhost

I selected .test, as it seems a little more appropriate.