### PR TITLE
Remove all previously set server environment variables

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -124,6 +124,26 @@ class Homestead
         end
     end
 
+    # Clean Up All The Previously Set Server Environment Variables And Remove Trailing Newlines
+    files_to_clear = {
+      :fpm_conf => "/etc/php5/fpm/php-fpm.conf",
+      :profile  => "/home/vagrant/.profile"
+    }
+
+    config.vm.provision "shell" do |s|
+      s.inline = "sed -i '/env\[[A-Za-z_]*\]/d' " + files_to_clear[:fpm_conf]
+    end
+
+    config.vm.provision "shell" do |s|
+      s.inline = "sed -i '/^#Set Homestead environment variable/,+1d' " + files_to_clear[:profile]
+    end
+
+    files_to_clear.each do |index, file|
+      config.vm.provision "shell" do |s|
+        s.inline = "sed -e :a -e '/^\\n*$/{$d;N;ba' -e '}' -i " + file
+      end
+    end
+
     # Configure All Of The Server Environment Variables
     if settings.has_key?("variables")
       settings["variables"].each do |var|


### PR DESCRIPTION
When I change some env variable specified in `~/.homestead/Homestead.yaml` and then provision the VM, the change isn't reflected on the Homestead instance because the provision script (`scripts/homestead.rb`) just appends the wanted env variable(s) to existing files (`/etc/php5/fpm/php-fpm.conf` and `/home/vagrant/.profile`).

Therefore we need to clean these files from previously set env variables prior to setting the new/current ones.