### PR TITLE
explicitly set nfs version on synced folders

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -91,7 +91,7 @@ class Homestead
     # Register All Of The Configured Shared Folders
     if settings.include? 'folders'
       settings["folders"].each do |folder|
-        mount_opts = folder["type"] == "nfs" ? ['actimeo=1'] : []
+        mount_opts = folder["type"] == "nfs" ? ['actimeo=1,vers=3'] : []
         config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, mount_options: mount_opts
       end
     end


### PR DESCRIPTION
I had the error "mount.nfs: access denied by server while mounting" when mounting whitout this.