### PR TITLE
using symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "php": ">=5.4",
         "symfony/console": "~2.0",
-        "symfony/process": "~2.0"
+        "symfony/process": "~2.0",
+        "symfony/yaml": "~2.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,32 +1,32 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e860295f4a8adca4374eedbb18cfba04",
+    "hash": "8ba1b38d2f06823b0fdb41ff142cdfc1",
     "packages": [
         {
             "name": "symfony/console",
-            "version": "v2.6.4",
-            "target-dir": "Symfony/Component/Console",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "e44154bfe3e41e8267d7a3794cd9da9a51cfac34"
+                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/e44154bfe3e41e8267d7a3794cd9da9a51cfac34",
-                "reference": "e44154bfe3e41e8267d7a3794cd9da9a51cfac34",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/564398bc1f33faf92fc2ec86859983d30eb81806",
+                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.1",
+                "symfony/phpunit-bridge": "~2.7",
                 "symfony/process": "~2.1"
             },
             "suggest": {
@@ -37,11 +37,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Console\\": ""
                 }
             },
@@ -51,44 +51,46 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Console Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-25 04:39:26"
+            "homepage": "https://symfony.com",
+            "time": "2015-06-10 15:30:22"
         },
         {
             "name": "symfony/process",
-            "version": "v2.6.4",
-            "target-dir": "Symfony/Component/Process",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "ecfc23e89d9967999fa5f60a1e9af7384396e9ae"
+                "reference": "552d8efdc80980cbcca50b28d626ac8e36e3cdd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/ecfc23e89d9967999fa5f60a1e9af7384396e9ae",
-                "reference": "ecfc23e89d9967999fa5f60a1e9af7384396e9ae",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/552d8efdc80980cbcca50b28d626ac8e36e3cdd1",
+                "reference": "552d8efdc80980cbcca50b28d626ac8e36e3cdd1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Process\\": ""
                 }
             },
@@ -98,17 +100,66 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Process Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-25 04:39:26"
+            "homepage": "https://symfony.com",
+            "time": "2015-06-08 09:37:21"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/9808e75c609a14f6db02f70fccf4ca4aab53c160",
+                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-06-10 15:30:22"
         }
     ],
     "packages-dev": [],

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -2,10 +2,8 @@
 
 namespace Laravel\Homestead;
 
-use Symfony\Component\Process\Process;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -35,8 +33,6 @@ class MakeCommand extends Command
 
     /**
      * Configure the command options.
-     *
-     * @return void
      */
     protected function configure()
     {
@@ -56,27 +52,26 @@ class MakeCommand extends Command
     /**
      * Execute the command.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
-     * @return void
+     * @param \Symfony\Component\Console\Input\InputInterface   $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
         copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
 
         if (!file_exists($this->basePath.'/Homestead.yaml')) {
-            copy( __DIR__ . '/stubs/Homestead.yaml', $this->basePath . '/Homestead.yaml' );
+            copy(__DIR__.'/stubs/Homestead.yaml', $this->basePath.'/Homestead.yaml');
         }
 
         if ($input->getOption('after')) {
             if (!file_exists($this->basePath.'/after.sh')) {
-                copy( __DIR__ . '/stubs/after.sh', $this->basePath . '/after.sh' );
+                copy(__DIR__.'/stubs/after.sh', $this->basePath.'/after.sh');
             }
         }
 
         if ($input->getOption('aliases')) {
             if (!file_exists($this->basePath.'/aliases')) {
-                copy( __DIR__ . '/stubs/aliases', $this->basePath . '/aliases' );
+                copy(__DIR__.'/stubs/aliases', $this->basePath.'/aliases');
             }
         }
 
@@ -94,7 +89,7 @@ class MakeCommand extends Command
     }
 
     /**
-     * Update paths in Homestead.yaml
+     * Update paths in Homestead.yaml.
      */
     protected function configurePaths()
     {
@@ -103,9 +98,9 @@ class MakeCommand extends Command
         // Update host folder path
         $homesteadFile['folders'][0]['map'] = $this->basePath;
         // Update guest folder path
-        $homesteadFile['folders'][0]['to'] = "/home/vagrant/".$this->defaultName;
+        $homesteadFile['folders'][0]['to'] = '/home/vagrant/'.$this->defaultName;
         // Update public folder path
-        $homesteadFile['sites'][0]['to'] = $homesteadFile['folders'][0]['to'] . "/public";
+        $homesteadFile['sites'][0]['to'] = $homesteadFile['folders'][0]['to'].'/public';
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);
     }
@@ -115,8 +110,7 @@ class MakeCommand extends Command
      *
      * VirtualBox requires a unique name for each virtual machine.
      *
-     * @param  string  $name
-     * @return void
+     * @param string $name
      */
     protected function updateName($name)
     {
@@ -125,7 +119,7 @@ class MakeCommand extends Command
         // Add name to the 4th position in the array
         $homesteadFile = array_slice($homesteadFile, 0, 3, true) +
             ['name' => $name] +
-            array_slice($homesteadFile, 3, NULL, true);
+            array_slice($homesteadFile, 3, null, true);
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);
     }
@@ -133,8 +127,7 @@ class MakeCommand extends Command
     /**
      * Set the virtual machine's hostname setting in the Homestead.yaml file.
      *
-     * @param  string  $hostname
-     * @return void
+     * @param string $hostname
      */
     protected function updateHostName($hostname)
     {
@@ -143,7 +136,7 @@ class MakeCommand extends Command
         // Add name to the 4th position in the array
         $homesteadFile = array_slice($homesteadFile, 0, 3, true) +
             ['hostname' => $hostname] +
-            array_slice($homesteadFile, 3, NULL, true);
+            array_slice($homesteadFile, 3, null, true);
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);
     }
@@ -161,9 +154,8 @@ class MakeCommand extends Command
     /**
      * Get the contents of the Homestead.yaml file.
      *
-     * @param  array  $array
-     * @return void
-     */    
+     * @param array $array
+     */
     protected function saveHomesteadFile($array)
     {
         $yaml = Yaml::dump($array, 3);

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -124,12 +124,12 @@ class MakeCommand extends Command
         $homesteadFile = $this->getHomesteadFile();
         // Add name to the 4th position in the array
         $homesteadFile = array_slice($homesteadFile, 0, 3, true) +
-                    array('name' => $name) +
+                    ['name' => $name] +
                     array_slice($homesteadFile, 3, NULL, true);
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);
     }
-    
+
     /**
      * Set the virtual machine's hostname setting in the Homestead.yaml file.
      *
@@ -142,7 +142,7 @@ class MakeCommand extends Command
         $homesteadFile = $this->getHomesteadFile();
         // Add name to the 4th position in the array
         $homesteadFile = array_slice($homesteadFile, 0, 3, true) +
-                    array('hostname' => $hostname) +
+                    ['hostname' => $hostname] +
                     array_slice($homesteadFile, 3, NULL, true);
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -124,8 +124,8 @@ class MakeCommand extends Command
         $homesteadFile = $this->getHomesteadFile();
         // Add name to the 4th position in the array
         $homesteadFile = array_slice($homesteadFile, 0, 3, true) +
-                    ['name' => $name] +
-                    array_slice($homesteadFile, 3, NULL, true);
+            ['name' => $name] +
+            array_slice($homesteadFile, 3, NULL, true);
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);
     }
@@ -142,8 +142,8 @@ class MakeCommand extends Command
         $homesteadFile = $this->getHomesteadFile();
         // Add name to the 4th position in the array
         $homesteadFile = array_slice($homesteadFile, 0, 3, true) +
-                    ['hostname' => $hostname] +
-                    array_slice($homesteadFile, 3, NULL, true);
+            ['hostname' => $hostname] +
+            array_slice($homesteadFile, 3, NULL, true);
         // Save array back to Homestead.yaml as yaml
         $this->saveHomesteadFile($homesteadFile);
     }

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -10,18 +10,21 @@ keys:
     - ~/.ssh/id_rsa
 
 folders:
-    - map: ~/Code
+    -
+      map: ~/Code
       to: /home/vagrant/Code
 
 sites:
-    - map: homestead.app
+    -
+      map: homestead.app
       to: /home/vagrant/Code/Laravel/public
 
 databases:
     - homestead
 
 variables:
-    - key: APP_ENV
+    -
+      key: APP_ENV
       value: local
 
 # blackfire:


### PR DESCRIPTION
Rather than doing a string replace on Homestead.yaml this patch opts for the more elegant use of symfony/yaml. It parses the Homestead.yaml file into an array and then saves this back to the file after modification.