### PR TITLE
Fixed yaml parsing error due to backslash on Windows

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -98,7 +98,7 @@ class MakeCommand extends Command
     protected function configurePaths()
     {
         $yaml = str_replace(
-            "- map: ~/Code", "- map: \"".$this->basePath."\"", $this->getHomesteadFile()
+            "- map: ~/Code", "- map: \"".str_replace('\\', '/', $this->basePath)."\"", $this->getHomesteadFile()
         );
 
         $yaml = str_replace(


### PR DESCRIPTION
After running the ```MakeCommand``` on Windows I get this error when doing ```vagrant up```:
```
C:/HashiCorp/Vagrant/embedded/lib/ruby/2.0.0/psych.rb:205:in `parse': (<unknown>): found unknown escape character while parsing a quoted scalar at line 15 column 12 (Psych::SyntaxError)
        from C:/HashiCorp/Vagrant/embedded/lib/ruby/2.0.0/psych.rb:205:in `parse_stream'
        from C:/HashiCorp/Vagrant/embedded/lib/ruby/2.0.0/psych.rb:153:in `parse'
        from C:/HashiCorp/Vagrant/embedded/lib/ruby/2.0.0/psych.rb:129:in `load'
        from E:/Data-Arjan-development/homestead/Vagrantfile:18:in `block in <top (required)>'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/v2/loader.rb:37:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/v2/loader.rb:37:in `load'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/loader.rb:103:in `block (2 levels) in load'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/loader.rb:97:in `each'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/loader.rb:97:in `block in load'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/loader.rb:94:in `each'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/config/loader.rb:94:in `load'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/vagrantfile.rb:28:in `initialize'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:691:in `new'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:691:in `vagrantfile'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:441:in `host'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:207:in `block in action_runner'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:33:in `call'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/action/runner.rb:33:in `run'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:428:in `hook'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/lib/vagrant/environment.rb:673:in `unload'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/bin/vagrant:177:in `ensure in <main>'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/bin/vagrant:177:in `<main>'
```

This is because the ```MakeCommand``` is creating this:
```
folders:
    - map: "C:\data\project"
      to: "/home/vagrant/homestead"
```

Ruby is trying to escape something. But vagrant can actually handle forwarded slashes on Windows. 