### PR TITLE
Adding the option of setting mount_opts on Homestead.yaml

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -91,7 +91,10 @@ class Homestead
     # Register All Of The Configured Shared Folders
     if settings.include? 'folders'
       settings["folders"].each do |folder|
-        mount_opts = folder["type"] == "nfs" ? ['actimeo=1'] : []
+        mount_opts = []
+        if (folder["type"] == "nfs")
+            mount_opts = folder["mount_opts"] ? folder["mount_opts"] : ['actimeo=1']
+        end
         config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, mount_options: mount_opts
       end
     end


### PR DESCRIPTION
Im really sorry for the stubbornness but i want to keep using Homestead and dont have the need to hack it everytime. 

My last PR was a raw solution. This way we can set mount_opts on Homestead.yaml.