### PR TITLE
add before.sh to clear out environment variables and sites

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,12 +7,17 @@ confDir = $confDir ||= File.expand_path("~/.homestead")
 homesteadYamlPath = confDir + "/Homestead.yaml"
 afterScriptPath = confDir + "/after.sh"
 aliasesPath = confDir + "/aliases"
+beforeScriptPath = confDir + "/before.sh"
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	if File.exists? aliasesPath then
 		config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
+	end
+
+	if File.exists? beforeScriptPath then
+		config.vm.provision "shell", path: beforeScriptPath
 	end
 
 	Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))

--- a/init.sh
+++ b/init.sh
@@ -7,5 +7,6 @@ mkdir -p "$homesteadRoot"
 cp -i src/stubs/Homestead.yaml "$homesteadRoot/Homestead.yaml"
 cp -i src/stubs/after.sh "$homesteadRoot/after.sh"
 cp -i src/stubs/aliases "$homesteadRoot/aliases"
+cp -i src/stubs/before.sh "$homesteadRoot/before.sh"
 
 echo "Homestead initialized!"

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -7,12 +7,17 @@ confDir = $confDir ||= File.expand_path("vendor/laravel/homestead")
 homesteadYamlPath = "Homestead.yaml"
 afterScriptPath = "after.sh"
 aliasesPath = "aliases"
+beforeScriptPath = "before.sh"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 	if File.exists? aliasesPath then
 		config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
+	end
+
+	if File.exists? beforeScriptPath then
+		config.vm.provision "shell", path: beforeScriptPath
 	end
 
 	Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))

--- a/src/stubs/before.sh
+++ b/src/stubs/before.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Clear out old environment variables
+printf "Clear environment variables...\n"
+sed '/#Set Homestead environment variable/,+2 d' /home/vagrant/.profile > tmpfile ; mv tmpfile /home/vagrant/.profile
+sed '/env\[/,+1 d' /etc/php5/fpm/php-fpm.conf > tmpfile ; mv tmpfile /etc/php5/fpm/php-fpm.conf
+
+printf "Clear old nginx sites...\n"
+rm /etc/nginx/sites-enabled/*
+rm /etc/nginx/sites-available/*


### PR DESCRIPTION
Currently when a user re-provisions the VM Homestead will overwrite sites if present, and just append environment variables. The problem is when the user removes a site or environment variable from the yaml file Homestead doesn't remove these from the VM.

This script will look at `/home/vagrant/.profile` and `/etc/php5/fpm/php-fpm.conf` and remove past environment files, as well as remove all sites from `/etc/nginx/sites-enabled` and `/etc/nginx/sites-available/`. Once the `homestead.rb` script runs it will continue to provision the sites and add the environment variables listed in the yaml file as intended. This script will bypass the need to `vagrant destroy` the box.

Please let me know if you have any comments/questions/concerns, or would like me to make any changes.