### PR TITLE
Adding Multi-Connections Bridge Adapters

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,6 +16,13 @@ class Homestead
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
 
+    # Configure A Public Network with Bridge Connection
+    if settings.include? 'public_network'
+      settings["public_network"].each do |bridge|
+        config.vm.network :public_network, ip: bridge["ip"] , bridge: bridge["origin"]
+      end
+    end
+
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|
       vb.name = settings["name"] ||= "homestead"

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -1,5 +1,8 @@
 ---
 ip: "192.168.10.10"
+public_network:
+    - ip: "10.10.0.201"
+      origin: "wlan0"
 memory: 2048
 cpus: 1
 provider: virtualbox


### PR DESCRIPTION
With *public_network* on **Homestead.yaml**, Homestead creates a new *bridge* type adapter to share the Vagrant machine with a local network. 
This change was tested on Linux and OS X.