### PR TITLE
Add alias option for sites

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -111,10 +111,10 @@ class Homestead
       config.vm.provision "shell" do |s|
           if (site.has_key?("hhvm") && site["hhvm"])
             s.path = scriptDir + "/serve-hhvm.sh"
-            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", site["alias"] ||= ""]
           else
             s.path = scriptDir + "/serve.sh"
-            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", site["alias"] ||= ""]
           end
       end
     end

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -7,7 +7,7 @@ openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1
 
 block="server {
     listen ${3:-80};
-    server_name $1;
+    server_name $1${5:+ $5};
     root \"$2\";
 
     index index.html index.htm index.php;
@@ -40,7 +40,7 @@ block="server {
 }
 server {
     listen ${4:-443};
-    server_name $1;
+    server_name $1${5:+ $5};
     root \"$2\";
 
     index index.html index.htm index.php;

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -7,7 +7,7 @@ openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1
 
 block="server {
     listen ${3:-80};
-    server_name $1;
+    server_name $1${5:+ $5};
     root \"$2\";
 
     index index.html index.htm index.php;
@@ -45,7 +45,7 @@ block="server {
 }
 server {
     listen ${4:-443};
-    server_name $1;
+    server_name $1${5:+ $5};
     root \"$2\";
 
     index index.html index.htm index.php;


### PR DESCRIPTION
Adds the possibility to declare `alias` to the `sites` block, to make sites respond on different domains.

[This StackOverflow question] (http://stackoverflow.com/questions/31630145/homestead-how-would-i-map-multiple-domains-to-the-same-path) asks for a way to do this, and I thought it would come in handy.