### PR TITLE
Enable ssh-config command

### DIFF
--- a/homestead
+++ b/homestead
@@ -32,6 +32,7 @@ $app->add(new Laravel\Homestead\RunCommand);
 $app->add(new Laravel\Homestead\UpCommand);
 $app->add(new Laravel\Homestead\UpdateCommand);
 $app->add(new Laravel\Homestead\SshCommand);
+$app->add(new Laravel\Homestead\SshConfigCommand);
 $app->add(new Laravel\Homestead\StatusCommand);
 $app->add(new Laravel\Homestead\SuspendCommand);
 

--- a/src/SshConfigCommand.php
+++ b/src/SshConfigCommand.php
@@ -1,0 +1,48 @@
+<?php namespace Laravel\Homestead;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SshConfigCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName('ssh-config')
+                  ->setDescription('Outputs OpenSSH valid configuration to connect to Homestead');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return void
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        chdir(__DIR__.'/../');
+
+        passthru($this->setEnvironmentCommand() . ' vagrant ssh-config');
+    }
+
+    protected function setEnvironmentCommand()
+    {
+        if ($this->isWindows()) {
+            return 'SET VAGRANT_DOTFILE_PATH='.$_ENV['VAGRANT_DOTFILE_PATH'].' &&';
+        }
+
+        return 'VAGRANT_DOTFILE_PATH="'.$_ENV['VAGRANT_DOTFILE_PATH'].'"';
+    }
+
+    protected function isWindows()
+    {
+        return strpos(strtoupper(PHP_OS), 'WIN') === 0;
+    }
+}


### PR DESCRIPTION
I'd like to be able to get access to the SSH configuration information for the Homestead vagrant install so that I can setup direct SSH connections from my ssh client(s). This command gets the information that vagrant would normally supply about a vagrant box for SSH clients.