### PR TITLE
Avoid ICANN Name Collision

### DIFF
--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -14,7 +14,7 @@ folders:
       to: /home/vagrant/Code
 
 sites:
-    - map: homestead.app
+    - map: homestead.local
       to: /home/vagrant/Code/Laravel/public
 
 databases:


### PR DESCRIPTION
It’s trivial, but with **.app** domain being the new gTLD, I think it’s
best practice to change sample site in yaml file to something like
**.local**.