### PR TITLE
Add 'boot_timeout' option

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -15,6 +15,11 @@ class Homestead
 
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
+    
+    # Configure A Specific Boot Timeout
+    if settings.has_key?("boot_timeout")
+      config.vm.boot_timeout = settings["boot_timeout"]
+    end
 
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -3,6 +3,7 @@ ip: "192.168.10.10"
 memory: 2048
 cpus: 1
 provider: virtualbox
+# boot_timeout: 300
 
 authorize: ~/.ssh/id_rsa.pub
 


### PR DESCRIPTION
Sometimes the programmer's `after.sh` extra provisioning file may contain heavy/long-lasting commands that could make the extra-provisioning process stop.

The PR adds the optional `config.vm.boot_timeout` Vagrant setting, so it is available for the programmer if needed.

More info here: http://docs.vagrantup.com/v2/vagrantfile/machine_settings.html