### PR TITLE
Provide the ability to disable port forwarding for default ports.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -47,6 +47,10 @@ class Homestead
       settings["ports"] = []
     end
 
+    if (!settings.has_key?("disabled_default_ports"))
+      settings["disabled_default_ports"] = []
+    end
+
     # Default Port Forwarding
     default_ports = {
       80   => 8000,
@@ -57,9 +61,9 @@ class Homestead
 
     # Use Default Port Forwarding Unless Overridden
     default_ports.each do |guest, host|
-      unless settings["ports"].any? { |mapping| mapping["guest"] == guest }
-        config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
-      end
+      next if settings["ports"].any? { |mapping| mapping["guest"] == guest }
+      next if settings["disabled_default_ports"].include?(guest)
+      config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
     end
 
     # Add Custom Ports From Configuration

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -36,3 +36,7 @@ variables:
 #     - send: 7777
 #       to: 777
 #       protocol: udp
+
+# disabled_default_ports:
+#     - 80
+#     - 443


### PR DESCRIPTION
If the default Homestead port forwarding options conflict with someone else, the only option is to set another port mapping for that port. Which is fine if you are leveraging the port forwarding options to work with homestead. In my case I am not, so it is far more preferable to simply disable the default port forwarding options instead of having me select another port to forward from.

This patch allows you to disable the default port forwarding options on a guest-port-by-guest-port basis. Want to disable the HTTP forwarding? Disable the 80 default port forwarding. Updated the stub to make it easier to remove the 8000 & 44300 port forwarding options.