### PR TITLE
Add PHPUnit and PHPSpec aliases

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -5,6 +5,9 @@ alias h='cd ~'
 alias c='clear'
 alias artisan='php artisan'
 
+alias phpspec='vendor/bin/phpspec'
+alias phpunit='vendor/bin/phpunit'
+
 function serve() {
     if [[ "$1" && "$2" ]]
     then


### PR DESCRIPTION
Alias the call to phpunit and phpspec in the vendor folder so users don't have to type the full path all the time (or add their own alias).

This current aliases do have the weakness of requiring being run at the project root, instead of anywhere in the project tree. Not sure how far down the "flexibility" rabbit hole we'd want to go with this, though.