### PR TITLE
Support parallels as a provider v2

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -36,6 +36,14 @@ class Homestead
       end
     end
 
+    # Configure A Few Parallels Settings
+    config.vm.provider "parallels" do |v|
+      v.update_guest_tools = true
+      v.optimize_power_consumption = false
+      v.memory = settings["memory"] ||= 2048
+      v.cpus = settings["cpus"] ||= 1
+    end
+
     # Standardize Ports Naming Schema
     if (settings.has_key?("ports"))
       settings["ports"].each do |port|

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -10,7 +10,7 @@ class Homestead
     config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
     # Configure The Box
-    config.vm.box = "laravel/homestead"
+    config.vm.box = settings["box"] ||= "laravel/homestead"
     config.vm.hostname = settings["hostname"] ||= "homestead"
 
     # Configure A Private Network IP


### PR DESCRIPTION
Thought about what you said and you're completely right, @taylorotwell. This pull request allows for a box customization so people can define a box in their `Homestead.yaml`. This way people can use whatever providers they like.

I packaged a parallels box built with https://github.com/laravel/settler. To use that box, place this setting in the `Homestead.yaml`

```yaml
# Homestead.yaml
box: adej/parallels-homestead
```