### PR TITLE
Increase timeout values

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -38,6 +38,9 @@ block="server {
         fastcgi_intercept_errors off;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
Providing slightly increased timeout values lead to fewer amount of 502/503 errors.
Another option would be to make this somehow configureable in ``Homestead.yaml``.