### PR TITLE
Fix support for `vagrant global-status --prune`

### DIFF
--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -2,7 +2,7 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION = "2"
-confDir = $confDir ||= File.expand_path("vendor/laravel/homestead")
+confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname(__FILE__))
 
 homesteadYamlPath = "Homestead.yaml"
 homesteadJsonPath = "Homestead.json"


### PR DESCRIPTION
When running the command `vagrant global-status --prune` (used by Vagrant Manager) you receive an error that `homestead.rb` can not be loaded. This appears to be because the file path is relative to where you run the vagrant command. In order to fix this issue we can pass the containing directory of the vagrant file to the `expand_path()` method when we make the default `confDir`.