### PR TITLE
Add default_site setting

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -117,15 +117,17 @@ class Homestead
 
     settings["sites"].each do |site|
       config.vm.provision "shell" do |s|
+          default_site = settings.has_key?("default_site") && settings["default_site"] == site["map"] ? " default" : ""
+
           if (site.has_key?("hhvm") && site["hhvm"])
             s.path = scriptDir + "/serve-hhvm.sh"
-            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", default_site]
           elsif (site.has_key?("type") && (site["type"] == "symfony" || site["type"] == "symfony2"))
             s.path = scriptDir + "/serve-symfony2.sh"
-            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", default_site]
           else
             s.path = scriptDir + "/serve.sh"
-            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", default_site]
           end
       end
     end

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -6,7 +6,7 @@ openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/C
 openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
 
 block="server {
-    listen ${3:-80};
+    listen ${3:-80}$5;
     listen ${4:-443} ssl;
     server_name $1;
     root \"$2\";

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -6,7 +6,7 @@ openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/C
 openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
 
 block="server {
-    listen ${3:-80};
+    listen ${3:-80}$5;
     listen ${4:-443} ssl;
     server_name $1;
     root \"$2\";

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -6,7 +6,7 @@ openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/C
 openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
 
 block="server {
-    listen ${3:-80};
+    listen ${3:-80}$5;
     listen ${4:-443} ssl;
     server_name $1;
     root \"$2\";

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -17,6 +17,8 @@ sites:
     - map: homestead.app
       to: /home/vagrant/Code/Laravel/public
 
+# default_site: homestead.app
+
 databases:
     - homestead
 


### PR DESCRIPTION
This is an optional setting that will set nginx default site. It will be useful if you wanna use external dynamic dns forwarding to homestead.