### PR TITLE
Allow the homestead yaml file to define extra network adapters

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,6 +16,12 @@ class Homestead
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
 
+    if settings.has_key?("networks")
+      settings["networks"].each do |network|
+        config.vm.network network["type"], ip: network["ip"], bridge: network["bridge"] ||= nil
+      end
+    end
+
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|
       vb.name = settings["name"] ||= "homestead"


### PR DESCRIPTION
This allows the homestead VM to have extra network adapters, like a public one

```
networks:
    - type: public_network
      ip: "10.1.1.250"
      bridge: "en0: Ethernet"
```