### PR TITLE
Database upgrades

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
 DB=$1;
+USER=$2;
+PASS=$3;
 
 mysql -uhomestead -psecret -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";
+mysql -uhomestead -psecret -e "GRANT ALL PRIVILEGES ON \`$DB\`.* TO '\`$USER\`'@'localhost' IDENTIFIED BY '\`$PASS\`'; FLUSH PRIVILEGES;";

--- a/scripts/create-postgres.sh
+++ b/scripts/create-postgres.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
 DB=$1;
+USER=$2;
+PASS=$3;
+
 # su postgres -c "dropdb $DB --if-exists"
 su postgres -c "createdb -O homestead '$DB' || true"
+su postgres -c "create user \"$USER\" with password '$PASS';"
+su postgres -c "grant all on schema '$DB' to '$USER';"

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -142,12 +142,12 @@ class Homestead
         settings["databases"].each do |db|
           config.vm.provision "shell" do |s|
             s.path = scriptDir + "/create-mysql.sh"
-            s.args = [db]
+            s.args = [db['name'], db['user'], db['pass']]
           end
 
           config.vm.provision "shell" do |s|
             s.path = scriptDir + "/create-postgres.sh"
-            s.args = [db]
+            s.args = [db['name'], db['user'], db['pass']]
           end
         end
     end

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -18,7 +18,9 @@ sites:
       to: /home/vagrant/Code/Laravel/public
 
 databases:
-    - homestead
+    - name: homestead
+      user: homestead
+      pass: secret
 
 variables:
     - key: APP_ENV


### PR DESCRIPTION
Allow developer to specify not only the database’s name, but a username and password to use as that database’s owner/default login.