### PR TITLE
Improves support with Vagrant Manager on multiple project.

### DIFF
--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -1,7 +1,7 @@
 require 'json'
 require 'yaml'
 
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION ||= "2"
 confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname(__FILE__))
 
 homesteadYamlPath = "Homestead.yaml"


### PR DESCRIPTION
When executing `vagrant global-status --prune` with multiple homestead
instances, you receive an error

```
/Users/crynobone/Sites/spark/Vagrantfile:4: warning: already initialized
constant VAGRANTFILE_API_VERSION
/Users/crynobone/Sites/forge/Vagrantfile:4: warning: previous definition
of VAGRANTFILE_API_VERSION was here
```

Signed-off-by: crynobone <crynobone@gmail.com>