### PR TITLE
Avoid re-appending hostname when Homestead.yaml already exist.

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -63,6 +63,14 @@ class MakeCommand extends Command
 
         if (! file_exists($this->basePath.'/Homestead.yaml')) {
             copy(__DIR__.'/stubs/Homestead.yaml', $this->basePath.'/Homestead.yaml');
+
+            if ($input->getOption('name')) {
+                $this->updateName($input->getOption('name'));
+            }
+
+            if ($input->getOption('hostname')) {
+                $this->updateHostName($input->getOption('hostname'));
+            }
         }
 
         if ($input->getOption('after')) {
@@ -75,14 +83,6 @@ class MakeCommand extends Command
             if (! file_exists($this->basePath.'/aliases')) {
                 copy(__DIR__.'/stubs/aliases', $this->basePath.'/aliases');
             }
-        }
-
-        if ($input->getOption('name')) {
-            $this->updateName($input->getOption('name'));
-        }
-
-        if ($input->getOption('hostname')) {
-            $this->updateHostName($input->getOption('hostname'));
         }
 
         $this->configurePaths();


### PR DESCRIPTION
This would allow user to run `vendor/bin/homestead make` (to update `Vagrantfile` skeleton) and keep the yaml file undisturbed. As of now, we would get a duplicated hostname value when running `homestead make` more than once.

Signed-off-by: crynobone <crynobone@gmail.com>