### PR TITLE
Add support for HyperV provider on Windows

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -14,7 +14,7 @@ class Homestead
     config.vm.hostname = settings["hostname"] ||= "homestead"
 
     # Configure A Private Network IP
-    config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
+    config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10" unless settings["provider"] == "hyperv"
 
     # Configure Additional Networks
     if settings.has_key?("networks")

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -51,6 +51,12 @@ class Homestead
       v.cpus = settings["cpus"] ||= 1
     end
 
+    config.vm.provider :hyperv do |hv|
+      hv.vmname = settings["name"] ||= "homestead"
+      hv.memory = settings["memory"] ||= 2048
+      hv.cpus = settings["cpus"] ||= 1
+    end
+
     # Standardize Ports Naming Schema
     if (settings.has_key?("ports"))
       settings["ports"].each do |port|


### PR DESCRIPTION
I wasn't ever planning on suggesting this as an improvement for the reasons @taylorotwell discussed in #247 but then #249 happened.

Now that the `laravel/homestead` box can be overridden in the configuration (in my case, with `johnpbloch/homestead`, which was built and packaged from [my fork of settler](/johnpbloch/settler)), I see no reason not to give a PR a shot.

The change for networking is a result of the unique way [HyperV handles networking](https://docs.vagrantup.com/v2/hyperv/limitations.html). Leaving the private network in there for HyperV doesn't cause any problems, so if you'd rather I get rid of that change, I'd be happy to remove it.

Other than that, the only other addition is a provider-specific block to set up the configured changes to memory, name, and CPU.