### PR TITLE
Don't overwrite Vagrantfile

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -59,7 +59,9 @@ class MakeCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
+        if (! file_exists($this->basePath.'/Vagrantfile')) {
+            copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
+        }
 
         if (! file_exists($this->basePath.'/Homestead.yaml')) {
             copy(__DIR__.'/stubs/Homestead.yaml', $this->basePath.'/Homestead.yaml');


### PR DESCRIPTION
Currently, the homestead make command overwrites existing Vagrantfiles, so it makes per project machines unusable.