### PR TITLE
HHVM missing on homestead 0.2.7

### DIFF
--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -16,6 +16,7 @@ folders:
 sites:
     - map: homestead.app
       to: /home/vagrant/Code/Laravel/public
+      hhvm: true
 
 databases:
     - homestead


### PR DESCRIPTION
This configuration (turning on hhvm as described on http://laravel.com/docs/5.1/homestead) will fail when provisioning with a '==> default: hhvm: unrecognized service' error. According to ```vagrant@homestead:~$ dpkg -l |grep -i hhvm```, hhvm isn't even installed, even though it should be according to the documentation and laravel/settler. 
This has already been reported by many people on laracasts, laravel.io and similar forums: 
https://laracasts.com/discuss/channels/laravel/homestead-hhvm-unrecognized-service
http://laravel.io/forum/03-07-2015-hhvm-unrecognized-service-homestead
https://laracasts.com/discuss/channels/servers/homestead-can-not-work-with-hhvm