### PR TITLE
Added site schedule key to setup artisan:schedule cron

### DIFF
--- a/scripts/cron-schedule.sh
+++ b/scripts/cron-schedule.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir /etc/cron.d 2>/dev/null
+
+cron="* * * * * vagrant /usr/bin/php $2/../artisan schedule:run >> /dev/null 2>&1"
+
+echo "$cron" > "/etc/cron.d/$1"
+service cron restart

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -137,6 +137,14 @@ class Homestead
         s.path = scriptDir + "/serve-#{type}.sh"
         s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
       end
+
+      if ( site.has_key?("schedule") && site["schedule"] )
+        config.vm.provision "shell" do |s|
+          s.path = scriptDir + "/cron-schedule.sh"
+          s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
+        end
+      end
+
     end
 
     # Configure All Of The Configured Databases


### PR DESCRIPTION
The new `php artisan schedule:run` command in Laravel is awesome, but it's a little bit of a pain to set up each site with a cron job manually in Homestead.

This PR adds a new key to the sites config and a script which creates a cronjob every minute for the schedule artisan command in the `/etc/cron.d` directory (using the site name minus special chars for the filename).

```
sites:
    - map: homestead.app
      to: /home/vagrant/Code/Laravel/public
      schedule: true
```

Tested on an existing Homestead VM with L5 projects and everything seems to work okay :)