### PR TITLE
fixed serve script file name.

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -7,12 +7,13 @@ alias artisan='php artisan'
 
 alias phpspec='vendor/bin/phpspec'
 alias phpunit='vendor/bin/phpunit'
+alias serve=serve-laravel
 
-function serve() {
+function serve-laravel() {
     if [[ "$1" && "$2" ]]
     then
-        sudo dos2unix /vagrant/scripts/serve.sh
-        sudo bash /vagrant/scripts/serve.sh "$1" "$2" 80
+        sudo dos2unix /vagrant/scripts/serve-laravel.sh
+        sudo bash /vagrant/scripts/serve-laravel.sh "$1" "$2" 80
     else
         echo "Error: missing required parameters."
         echo "Usage: "


### PR DESCRIPTION
After running the  serve command on homestead machine I get this error:

```
$ serve my.app /home/vagrant/Code/my.app/public/

dos2unix: /vagrant/scripts/serve.sh: No such file or directory
dos2unix: Skipping /vagrant/scripts/serve.sh, not a regular file.
bash: /vagrant/scripts/serve.sh: No such file or directory
```

This is because the PR #263 is renaming serve.sh to serve-laravel.sh: