### PR TITLE
laravel-create shortcut

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -9,6 +9,10 @@ alias phpspec='vendor/bin/phpspec'
 alias phpunit='vendor/bin/phpunit'
 alias serve=serve-laravel
 
+function laravel-create() { 
+    composer create-project laravel/laravel "$@" --prefer-dist; 
+}
+
 function serve-laravel() {
     if [[ "$1" && "$2" ]]
     then


### PR DESCRIPTION
Added a shortcut to ~/.homestead/aliases for running `composer create-project laravel/laravel --prefer-dist`. Accepts any options accepted by composer create-project including path and version. 
Example use: `laravel-create Blog 5.1`