### PR TITLE
Added example for boolean environment variables

### DIFF
--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -21,8 +21,10 @@ databases:
     - homestead
 
 variables:
-    - key: APP_ENV
-      value: local
+    - key: 'APP_ENV'
+      value: 'local'
+    - key: 'APP_DEBUG'
+      value: 'true'
 
 # blackfire:
 #     - id: foo


### PR DESCRIPTION
I was running into the exception `* Shell provisioner ``args`` must be a string or array.` and found that all values in the variables array MUST be strings. Because in yaml `value: true` would result in a boolean value this is invalid. I propose that we add this example *and* explicitly quote the APP_ENV values for clarity.