### PR TITLE
Update aliases

### DIFF
--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -10,7 +10,7 @@ alias phpunit='vendor/bin/phpunit'
 alias serve=serve-laravel
 
 function serve-laravel() {
-    if [[ "$1" && "$2" ]]
+    if [ $# -ge 2 ]
     then
         sudo dos2unix /vagrant/scripts/serve-laravel.sh
         sudo bash /vagrant/scripts/serve-laravel.sh "$1" "$2" 80


### PR DESCRIPTION
I was encountering the following error whenever I updated my ~/.bash_aliases file and ran "source ~/.bash_aliases".

/home/vagrant/.bash_aliases:8: parse error near `&&'

This prevented the serve command from working. Changing how the arguments get checked fixed the problem.