### PR TITLE
Add support for Vagrant shared folder options.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -112,7 +112,13 @@ class Homestead
             mount_opts = folder["mount_opts"] ? folder["mount_opts"] : ['actimeo=1']
         end
 
-        config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, mount_options: mount_opts
+        # For b/w compatibility keep separate 'mount_opts', but merge with options
+        options = (folder["options"] || {}).merge({ mount_opts: mount_opts })
+
+        # Double-splat (**) operator only works with symbol keys, so convert
+        options.keys.each{|k| options[k.to_sym] = options.delete(k) }
+
+        config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, **options
       end
     end
 


### PR DESCRIPTION
Add support for generic Vagrant `shared folder` options. For backwards compatibility the `mount_opts` special case is preserved and merged with any other option. If `mount_opts` is given both in `options` and as separate configuration option, the latter takes precedence.

Useful for example disabling NFS export file handling when `/etc/exports` already has this covered.

Example:

    folders:
    - map: ~/progs
      to: /home/vagrant/progs
      type: nfs
      options:
        nfs_export: false

This results in:

    config.vm.synced_folder "~/progs", "/home/vagrant/progs", type: "nfs", nfs_export: false