### PR TITLE
Adapted scripts serve-laravel.sh and serve-hhvm.sh

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 
 mkdir /etc/nginx/ssl 2>/dev/null
-openssl genrsa -out "/etc/nginx/ssl/$1.key" 1024 2>/dev/null
-openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
+
+PATH_SSL="/etc/nginx/ssl"
+PATH_KEY="${PATH_SSL}/${1}.key"
+PATH_CSR="${PATH_SSL}/${1}.csr"
+PATH_CRT="${PATH_SSL}/${1}.crt"
+
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+then
+  openssl genrsa -out "$PATH_KEY" 1024 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+fi
 
 block="server {
     listen ${3:-80};

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
 
 mkdir /etc/nginx/ssl 2>/dev/null
-openssl genrsa -out "/etc/nginx/ssl/$1.key" 1024 2>/dev/null
-openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
+
+PATH_SSL="/etc/nginx/ssl"
+PATH_KEY="${PATH_SSL}/${1}.key"
+PATH_CSR="${PATH_SSL}/${1}.csr"
+PATH_CRT="${PATH_SSL}/${1}.crt"
+
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+then
+  openssl genrsa -out "$PATH_KEY" 1024 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+fi
 
 block="server {
     listen ${3:-80};


### PR DESCRIPTION
Everytime you run the vagrant provision command, new certificates for the domains are created.
So, I just adapted the two files which are responsible for provisioning the domains: serve-laravel.sh and serve-hhvm.sh.

The new code is only providing variables for the paths of .key, .csr and .crt files and checks whether they already exist or not. If yes, they won't be created anymore.