### PR TITLE
Add config.ssh.forward_agent to enable SSH from The Box

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -9,6 +9,9 @@ class Homestead
     # Prevent TTY Errors
     config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
 
+    # Allow SSH Agent Forward from The Box
+    config.ssh.forward_agent = true
+
     # Configure The Box
     config.vm.box = settings["box"] ||= "laravel/homestead"
     config.vm.hostname = settings["hostname"] ||= "homestead"


### PR DESCRIPTION
When running some cap commands, I kept getting unauthorized access errors. As such, I was having to regenerate a new key pair and adding that key to my server to SSH in, even though my private key was on my VM. This fixes that error.