### PR TITLE
Added "down" alias for "halt" command

### DIFF
--- a/src/HaltCommand.php
+++ b/src/HaltCommand.php
@@ -16,7 +16,7 @@ class HaltCommand extends Command
      */
     protected function configure()
     {
-        $this->setName('halt')->setDescription('Halt the Homestead machine');
+        $this->setName('halt')->setAliases(['down'])->setDescription('Halt the Homestead machine');
     }
 
     /**


### PR DESCRIPTION
I often forget the `halt` command and TBH find it strange that it's not `down` by default. In any case I think this won't harm.