### PR TITLE
automatically add all sites to hosts

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,6 +16,7 @@ class Homestead
     config.vm.box = settings["box"] ||= "laravel/homestead"
     config.vm.box_version = settings["version"] ||= ">= 0"
     config.vm.hostname = settings["hostname"] ||= "homestead"
+    config.hostsupdater.aliases = []
 
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
@@ -133,6 +134,8 @@ class Homestead
 
 
     settings["sites"].each do |site|
+      config.hostsupdater.aliases.push(site["map"])
+      
       type = site["type"] ||= "laravel"
 
       if (site.has_key?("hhvm") && site["hhvm"])


### PR DESCRIPTION
This change auto adds all of the urls under `sites` in the `Homestead.yaml` file to your hosts file, not just the hostname of the vagrant machine.

Here's my `Homestead.yaml` that I used as a test:
```yaml
---
ip: "192.168.10.10"
memory: 2048
cpus: 1
hostname: homestead-fork
name: homestead-fork
provider: virtualbox

authorize: ~/.ssh/id_rsa.pub

keys:
    - ~/.ssh/id_rsa

folders:
    - map: "/Users/aaemnnosttv/forks/homestead-project"
      to: "/home/vagrant/homestead"

sites:
    - map: homestead-1.app
      to: "/home/vagrant/homestead-1/public"
    - map: homestead-2.app
      to: "/home/vagrant/homestead-2/public"
    - map: homestead-3.app
      to: "/home/vagrant/homestead-3/public"

databases:
    - homestead

variables:
    - key: APP_ENV
      value: local
```

`vagrant up`

**BEFORE**
```
==> default: Checking for host entries
==> default: adding to (/etc/hosts) : 192.168.10.10  homestead-fork  # VAGRANT: 23230ee8cb9f4b5c60274130ea323b53 (default) / 61bd0247-9b8c-47d3-a93a-0a14c76f9402
```

**AFTER**
```
==> default: Checking for host entries
==> default: adding to (/etc/hosts) : 192.168.10.10  homestead-fork  # VAGRANT: 23230ee8cb9f4b5c60274130ea323b53 (default) / 61bd0247-9b8c-47d3-a93a-0a14c76f9402
==> default: adding to (/etc/hosts) : 192.168.10.10  homestead-1.app  # VAGRANT: 23230ee8cb9f4b5c60274130ea323b53 (default) / 61bd0247-9b8c-47d3-a93a-0a14c76f9402
==> default: adding to (/etc/hosts) : 192.168.10.10  homestead-2.app  # VAGRANT: 23230ee8cb9f4b5c60274130ea323b53 (default) / 61bd0247-9b8c-47d3-a93a-0a14c76f9402
==> default: adding to (/etc/hosts) : 192.168.10.10  homestead-3.app  # VAGRANT: 23230ee8cb9f4b5c60274130ea323b53 (default) / 61bd0247-9b8c-47d3-a93a-0a14c76f9402
```