### PR TITLE
Remove default environment variables so they don't override `.env` files

### DIFF
--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -21,10 +21,11 @@ databases:
     - homestead
 
 variables:
-    - key: 'APP_ENV'
-      value: 'local'
-    - key: 'APP_DEBUG'
-      value: 'true'
+# Add any environment variables here.
+#    - key: 'APP_ENV'
+#      value: 'local'
+#    - key: 'APP_DEBUG'
+#      value: 'true'
 
 # blackfire:
 #     - id: foo


### PR DESCRIPTION
For example `APP_DEBUG` and `APP_ENV`.

These are defined before environment variables defined in `.env` of a Laravel installation. Therefore `dotenv` won't override these environment variables.

This resulted in half an hour of frustration as I quadruple-checked my `.env` file:

    APP_DEBUG=true

But I in my PHP script I kept getting `false`

    dd($_ENV['APP_DEBUG'], env('APP_DEBUG'), getenv('APP_DEBUG'));

This is one way of fixing the above problem, however I acknowledge that it might be too destructive.

Alternatively better documentation would help.