### PR TITLE
Removed deprecated parallels optimize_power_consumption option

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -50,7 +50,6 @@ class Homestead
     # Configure A Few Parallels Settings
     config.vm.provider "parallels" do |v|
       v.update_guest_tools = true
-      v.optimize_power_consumption = false
       v.memory = settings["memory"] ||= 2048
       v.cpus = settings["cpus"] ||= 1
     end


### PR DESCRIPTION
This change fixes following Parallels Desktop warning:
```
Bringing machine 'default' up with 'parallels' provider...
Setting "optimize_power_consumption" has been deprecated in the Parallels
provider and will be removed in the future releases. Power consumption
is enabled by default. If you want to keep it enabled, then just remove
this setting from your Vagrantfile. Otherwise, please replace it with
this block in order to disable the power consumption:

  config.vm.provider "parallels" do |prl|
    prl.customize ["set", :id, "--longer-battery-life", "off"]
  end
```