### PR TITLE
Add support for symfony ~3.0 on Homestead 2.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "A virtual machine for web artisans.",
     "require": {
         "php": ">=5.5",
-        "symfony/console": "~2.0",
-        "symfony/process": "~2.0"
+        "symfony/console": "~2.0|~3.0",
+        "symfony/process": "~2.0|~3.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Branch `php-7` does support it at the moment and hoping that the current stable release can support it as well.