### PR TITLE
Set the laravel/homestead box as default.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,4 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exists? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath
     end
+    
+    config.vm.box = "laravel/homestead"
+    
 end


### PR DESCRIPTION
In some terminals, the default box is not recognised. Setting the default box to "laravel/homestead" fixes this issue. 

I noticed this when using http://babun.github.io/ on windows.