### PR TITLE
[Symfony] Use the dev front controller

### DIFF
--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -11,12 +11,12 @@ block="server {
     server_name $1;
     root \"$2\";
 
-    index index.html index.htm index.php app.php;
+    index index.html index.htm index.php app_dev.php;
 
     charset utf-8;
 
     location / {
-        try_files \$uri \$uri/ /app.php?\$query_string;
+        try_files \$uri \$uri/ /app_dev.php?\$query_string;
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }


### PR DESCRIPTION
As Homestead is a local development box, I think it should use the dev front controller (`app_dev.php`) instead of the one meant for production (`app.php`).