### PR TITLE
Add support for linked clone on VirtualBox

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -35,6 +35,15 @@ class Homestead
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
       vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
+
+      # Use linked clone if possible
+      if (settings.has_key?("linked_clone") && settings["linked_clone"])
+        require 'vagrant/version'
+        # The feature only available on Vagrant 1.8 and later
+        if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+          vb.linked_clone = true
+        end
+      end
     end
 
     # Configure A Few VMware Settings

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -3,6 +3,7 @@ ip: "192.168.10.10"
 memory: 2048
 cpus: 1
 provider: virtualbox
+linked_clone: false
 
 authorize: ~/.ssh/id_rsa.pub
 


### PR DESCRIPTION
Requires Vagrant 1.8 and later. Do have check to see if user has Vagrant 1.8 to include the config, so it won't break people's boxes.