### PR TITLE
add Vagrant CLI name

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -27,6 +27,9 @@ class Homestead
       end
     end
 
+    # Vagrant CLI name (multi-machine)
+    config.vm.define settings["name"] || "homestead-7"
+
     # Configure A Few VirtualBox Settings
     config.vm.provider "virtualbox" do |vb|
       vb.name = settings["name"] ||= "homestead-7"


### PR DESCRIPTION
in terminal - instead of "default", show "name" from the YAML settings