### PR TITLE
Nginx remove trailing slash

### DIFF
--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -27,6 +27,10 @@ block="server {
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
+    
+    if (!-d $request_filename) {
+        rewrite ^/(.*)/$ /$1 permanent;
+    }
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -27,6 +27,10 @@ block="server {
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
     }
+    
+    if (!-d $request_filename) {
+        rewrite ^/(.*)/$ /$1 permanent;
+    }
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -18,6 +18,10 @@ block="server {
     location / {
         try_files \$uri \$uri/ /app_dev.php?\$query_string;
     }
+    
+    if (!-d $request_filename) {
+        rewrite ^/(.*)/$ /$1 permanent;
+    }
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }


### PR DESCRIPTION
homestead is using nginx as webserver. so the .htaccess in the public folder has no impact.

i added 
```
if (!-d $request_filename) {
rewrite ^/(.*)/$ /$1 permanent;
}
```
to all the bash script files. hopefully the right one