### PR TITLE
Prompt user if the files are being overwritten on Windows

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -4,9 +4,9 @@ set homesteadRoot=%HOMEDRIVE%%HOMEPATH%\.homestead
 
 mkdir "%homesteadRoot%"
 
-copy src\stubs\Homestead.yaml "%homesteadRoot%\Homestead.yaml"
-copy src\stubs\after.sh "%homesteadRoot%\after.sh"
-copy src\stubs\aliases "%homesteadRoot%\aliases"
+copy /-y src\stubs\Homestead.yaml "%homesteadRoot%\Homestead.yaml"
+copy /-y src\stubs\after.sh "%homesteadRoot%\after.sh"
+copy /-y src\stubs\aliases "%homesteadRoot%\aliases"
 
 set homesteadRoot=
-echo "Homestead initialized!"
+echo Homestead initialized!


### PR DESCRIPTION
`init.sh` uses `cp -i` to prompt the user to overwrite the file in case the file already exists. This change does the same for `init.bat`, using `copy /-y`

Also remove quotes from `Homestead initialized!` message, because they were also displayed on output.