### PR TITLE
Apache support for Homestead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,10 @@ Official documentation [is located here](http://laravel.com/docs/homestead).
 
 ### 2016-01-13 -- added Apache support via Homestead configuration
 
-Enable Apache2 by setting `use_apache:1` in `~/.homestead/Homestead.yaml`  
+Enable Apache2 by setting `use_apache:1` in `~/.homestead/Homestead.yaml`.  
+Set `use_apache` to any other value (`0`, `N/A`, `Hell no`) or don't set it at all if you want the default Homestead.
 
-This will stop NginX, install Apache and configure the virtualhosts  
-You just have to configure your local `/etc/hosts` file as you would for NginX
+This will stop NginX, install Apache and configure the virtualhosts.  
+You just have to configure your local `/etc/hosts` file as you would for NginX.
+
+**When `use_apache:1` is set, it is no longer possible to choose Nginx or HHVM for any site.**

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,11 @@
 The official Laravel local development environment.
 
 Official documentation [is located here](http://laravel.com/docs/homestead).
+
+## ChangeLog
+
+### 2016-01-13 -- added Apache support via Homestead configuration
+
+Enable Apache2 by setting `src:Apache2` in `~/.homestead/Homestead.yaml`  
+This will stop NginX, install Apache and configure the virtualhosts  
+Just have to configure your local `/etc/hosts` file 

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Official documentation [is located here](http://laravel.com/docs/homestead).
 
 ### 2016-01-13 -- added Apache support via Homestead configuration
 
-Enable Apache2 by setting `src:Apache2` in `~/.homestead/Homestead.yaml`  
+Enable Apache2 by setting `use_apache:1` in `~/.homestead/Homestead.yaml`  
+
 This will stop NginX, install Apache and configure the virtualhosts  
-Just have to configure your local `/etc/hosts` file 
+You just have to configure your local `/etc/hosts` file as you would for NginX

--- a/readme.md
+++ b/readme.md
@@ -3,15 +3,3 @@
 The official Laravel local development environment.
 
 Official documentation [is located here](http://laravel.com/docs/homestead).
-
-## ChangeLog
-
-### 2016-01-13 -- added Apache support via Homestead configuration
-
-Enable Apache2 by setting `use_apache:1` in `~/.homestead/Homestead.yaml`.  
-Set `use_apache` to any other value (`0`, `N/A`, `Hell no`) or don't set it at all if you want the default Homestead.
-
-This will stop NginX, install Apache and configure the virtualhosts.  
-You just have to configure your local `/etc/hosts` file as you would for NginX.
-
-**When `use_apache:1` is set, it is no longer possible to choose Nginx or HHVM for any site.**

--- a/scripts/apache_clear.sh
+++ b/scripts/apache_clear.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# only run if apache2 is present
+if [ -f /etc/apache2/apache2.conf ]
+then
+	# remove fqdn
+	a2disconf fqdn
+	rm /etc/apache2/conf-available/fqdn.conf
+
+	# restore charset
+	rm /etc/apache2/conf-available/charset.conf
+	mv /etc/apache2/conf-available/charset.conf.orig /etc/apache2/conf-available/charset.conf
+
+	# disable mod_rewrite
+	a2dismod rewrite
+
+	# disable ssl
+	a2dismod ssl
+
+	# restore /etc/hosts
+	rm /etc/hosts
+	mv /etc/hosts.orig /etc/hosts
+
+	# clear all sites (except for defaults)
+	cd /etc/apache2/sites-available/
+
+	for f in *.conf
+	do
+		if ! [ $(echo $f | grep default) ];
+		then
+			a2dissite $f
+			rm $f
+		fi
+	done
+
+	# remove ssl 
+	rm -R /etc/apache2/ssl
+
+	# not removing apache, just stopping it
+	service apache2 stop
+
+fi
+
+# start NginX
+service nginx restart

--- a/scripts/apache_hosts.sh
+++ b/scripts/apache_hosts.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+echo "127.0.0.1		$1		$1.localhost" >> /etc/hosts
+
+if 
+block="<VirtualHost *:$3>
+		ServerAdmin vagrant@localhost
+
+		ServerName $1
+		DocumentRoot $2
+
+		<Directory $2>
+			AllowOverride All
+			Order allow,deny
+			allow from all
+			Require all granted
+		</Directory>
+
+		ErrorLog \${APACHE_LOG_DIR}/error_$1.log
+		CustomLog \${APACHE_LOG_DIR}/access_$1.log combined
+
+	</VirtualHost>
+
+	<VirtualHost *:$4>
+		ServerAdmin vagrant@localhost
+
+		ServerName $1:$4
+		DocumentRoot $2
+
+		<Directory $2>
+			AllowOverride All
+			Order allow,deny
+			allow from all
+			Require all granted
+		</Directory>
+
+		ErrorLog \${APACHE_LOG_DIR}/error_$1.log
+		CustomLog \${APACHE_LOG_DIR}/access_$1.log combined
+
+		SSLEngine on
+		SSLCertificateFile /etc/apache2/ssl/apache.crt
+		SSLCertificateKeyFile /etc/apache2/ssl/apache.key
+
+	</VirtualHost>
+"
+
+echo "$block" > "/etc/apache2/sites-available/$1.conf"
+a2ensite $1.conf
+service apache2 reload

--- a/scripts/apache_hosts.sh
+++ b/scripts/apache_hosts.sh
@@ -2,7 +2,7 @@
 
 echo "127.0.0.1		$1		$1.localhost" >> /etc/hosts
 
-PATH_SSL="/etc/nginx/ssl"
+PATH_SSL="/etc/apache2/ssl"
 PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"

--- a/scripts/apache_hosts.sh
+++ b/scripts/apache_hosts.sh
@@ -2,7 +2,18 @@
 
 echo "127.0.0.1		$1		$1.localhost" >> /etc/hosts
 
-if 
+PATH_SSL="/etc/nginx/ssl"
+PATH_KEY="${PATH_SSL}/${1}.key"
+PATH_CSR="${PATH_SSL}/${1}.csr"
+PATH_CRT="${PATH_SSL}/${1}.crt"
+
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+then
+  openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+fi
+
 block="<VirtualHost *:$3>
 		ServerAdmin vagrant@localhost
 
@@ -38,8 +49,8 @@ block="<VirtualHost *:$3>
 		CustomLog \${APACHE_LOG_DIR}/access_$1.log combined
 
 		SSLEngine on
-		SSLCertificateFile /etc/apache2/ssl/apache.crt
-		SSLCertificateKeyFile /etc/apache2/ssl/apache.key
+		SSLCertificateFile $PATH_CRT
+		SSLCertificateKeyFile $PATH_KEY
 
 	</VirtualHost>
 "

--- a/scripts/apache_hosts.sh
+++ b/scripts/apache_hosts.sh
@@ -7,7 +7,7 @@ PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"
 
-if [ ! -f $PATH_SSL ]
+if [ ! -d $PATH_SSL ]
 then
 	mkdir $PATH_SSL
 fi

--- a/scripts/apache_hosts.sh
+++ b/scripts/apache_hosts.sh
@@ -7,6 +7,11 @@ PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"
 
+if [ ! -f $PATH_SSL ]
+then
+	mkdir $PATH_SSL
+fi
+
 if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
 then
   openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null

--- a/scripts/apache_install.sh
+++ b/scripts/apache_install.sh
@@ -3,22 +3,36 @@
 # stop nginx
 service nginx stop
 
-# update
-apt-get update
+# only install apache2 if not present yet
+if ! [ -f /etc/apache2/apache2.conf ]
+then
+	# update
+	apt-get update
 
-# install apache
-apt-get install -y apache2 libapache2-mod-php7.0 libapache2-mod-auth-mysql
+	# install apache
+	apt-get install -y apache2 libapache2-mod-php7.0 libapache2-mod-auth-mysql
+
+else
+	service apache2 start
+
+fi
 
 # set ServerName and enable conf
 echo "ServerName localhost" > /etc/apache2/conf-available/fqdn.conf
 a2enconf fqdn
 
 # set default charset to UTF-8
+cp /etc/apache2/conf-available/charset.conf /etc/apache2/conf-available/charset.conf.orig
 echo AddDefaultCharset UTF-8 >> /etc/apache2/conf-available/charset.conf
 
 # enable mod_rewrite
 a2enmod rewrite
+
+# enable ssl
 a2enmod ssl
 
 # restart apache
 service apache2 restart
+
+# make back-up copy of /etc/hosts
+cp /etc/hosts /etc/hosts.orig

--- a/scripts/apache_install.sh
+++ b/scripts/apache_install.sh
@@ -20,9 +20,5 @@ echo AddDefaultCharset UTF-8 >> /etc/apache2/conf-available/charset.conf
 a2enmod rewrite
 a2enmod ssl
 
-# prepare dir for SSL certs
-mkdir /etc/apache2/ssl
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/apache2/ssl/apache.key -out /etc/apache2/ssl/apache.crt
-
 # restart apache
 service apache2 restart

--- a/scripts/apache_install.sh
+++ b/scripts/apache_install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# stop nginx
+service nginx stop
+
+# update
+apt-get update
+
+# install apache
+apt-get install -y apache2 libapache2-mod-php7.0 libapache2-mod-auth-mysql
+
+# set ServerName and enable conf
+echo "ServerName localhost" > /etc/apache2/conf-available/fqdn.conf
+a2enconf fqdn
+
+# set default charset to UTF-8
+echo AddDefaultCharset UTF-8 >> /etc/apache2/conf-available/charset.conf
+
+# enable mod_rewrite
+a2enmod rewrite
+a2enmod ssl
+
+# prepare dir for SSL certs
+mkdir /etc/apache2/ssl
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/apache2/ssl/apache.key -out /etc/apache2/ssl/apache.crt
+
+# restart apache
+service apache2 restart

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -132,6 +132,12 @@ class Homestead
         s.path = scriptDir + "/clear-nginx.sh"
     end
 
+    if (settings["srv"] == "apache2")
+        config.vm.provision "shell" do |s|
+          s.path = scriptDir + "/apache_install.sh"
+        end
+    end
+
 
     settings["sites"].each do |site|
       type = site["type"] ||= "laravel"
@@ -144,9 +150,18 @@ class Homestead
         type = "symfony2"
       end
 
-      config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/serve-#{type}.sh"
-        s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+      if (settings["srv"] == "apache2")
+        # configure the apache2 hosts
+        config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/apache_hosts.sh"
+            s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+        end
+
+      else
+        config.vm.provision "shell" do |s|
+          s.path = scriptDir + "/serve-#{type}.sh"
+          s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+        end
       end
 
       # Configure The Cron Schedule

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -132,7 +132,12 @@ class Homestead
         s.path = scriptDir + "/clear-nginx.sh"
     end
 
-    if (settings["srv"] == "apache2")
+    use_apache = settings["use_apache"] ||= 0
+    if (use_apache != 1)
+      use_apache = 0
+    end
+
+    if (use_apache == 1)
         config.vm.provision "shell" do |s|
           s.path = scriptDir + "/apache_install.sh"
         end
@@ -150,7 +155,7 @@ class Homestead
         type = "symfony2"
       end
 
-      if (settings["srv"] == "apache2")
+      if (use_apache == 1)
         # configure the apache2 hosts
         config.vm.provision "shell" do |s|
             s.path = scriptDir + "/apache_hosts.sh"

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -139,6 +139,10 @@ class Homestead
 
     if (use_apache == 1)
         config.vm.provision "shell" do |s|
+          s.path = scriptDir + "/apache_clear.sh"
+        end
+
+        config.vm.provision "shell" do |s|
           s.path = scriptDir + "/apache_install.sh"
         end
     end

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -3,7 +3,7 @@ ip: "192.168.10.10"
 memory: 2048
 cpus: 1
 provider: virtualbox
-srv:0
+use_apache: 0
 
 authorize: ~/.ssh/id_rsa.pub
 

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -3,6 +3,7 @@ ip: "192.168.10.10"
 memory: 2048
 cpus: 1
 provider: virtualbox
+srv:0
 
 authorize: ~/.ssh/id_rsa.pub
 


### PR DESCRIPTION
I just cannot imagine I'm the only one who prefers Apache over NginX...

With this update, one single setting in  `~/.homestead/Homestead.yaml` installs Apache, creates the VirtualHosts (:80 & :443) and adds the needed info the /etc/hosts:

```yaml
# ~/.homestead/Homestead.yaml 
use_apache: 1
```

There also is a script for cleaning up...  
This stops Apache (no uninstall), restarts NginX, restores `/etc/hosts` and removes all the VirtualHosts.

Nothing was changed in the actual vbox.

Documentation has been updated and submitted (pull request) in `laravel/documentation`.

Up to you to decide if you wish to merge this or not...