### PR TITLE
Xdebug and tweak for Symfony2

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -219,5 +219,11 @@ class Homestead
         ]
       end
     end
+
+    if settings.has_key?("xdebug")
+    	config.vm.provision "shell" do |s|
+        s.path = scriptDir + "/xdebug.sh"
+      end
+    end
   end
 end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -222,7 +222,8 @@ class Homestead
 
     if settings.has_key?("xdebug")
     	config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/xdebug.sh"
+    	if (settings["xdebug"])
+            s.path = scriptDir + "/xdebug.sh"
       end
     end
   end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -220,11 +220,14 @@ class Homestead
       end
     end
 
+    # Setup xdebug if it has been set for this machine
     if settings.has_key?("xdebug")
     	config.vm.provision "shell" do |s|
     	if (settings["xdebug"])
             s.path = scriptDir + "/xdebug.sh"
+        end
       end
     end
+
   end
 end

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+TEMP_DIR="~/temp"
+XDEBUG_LINK="http://xdebug.org/files/xdebug-2.4.0rc3.tgz"
+XDEBUG_VERSION="xdebug-2.4.0RC3"
+XDEBUG_LOAD_LINE="[xdebug]
+zend_extension = /usr/lib/php/20151012/xdebug.so
+"
+
+mkdir $TEMP_DIR
+wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz"
+cd $TEMP_DIR
+tar -xvzf xdebug.tgz
+cd $XDEBUG_VERSION
+phpize
+./configure
+make
+sudo cp modules/xdebug.so /usr/lib/php/20151012
+echo "$XDEBUG_LOAD_LINE" > "/etc/php/7.0/fpm/php.ini"
+
+service nginx restart
+service php7.0-fpm restart

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -5,7 +5,15 @@ XDEBUG_LINK="http://xdebug.org/files/xdebug-2.4.0rc3.tgz"
 XDEBUG_VERSION="xdebug-2.4.0RC3"
 XDEBUG_LOAD_LINE="[xdebug]
 zend_extension = /usr/lib/php/20151012/xdebug.so
+
+xdebug.remote_enable = 1
+xdebug.remote_connect_back = 1
+xdebug.remote_port = 9000
+xdebug.scream=0
+xdebug.cli_color=1
+xdebug.show_local_vars=1
 "
+XDEBUG_INI_PATH="/etc/php/7.0/fpm/conf.d/20-xdebug.ini"
 
 mkdir $TEMP_DIR
 wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz"
@@ -16,7 +24,8 @@ phpize
 ./configure
 make
 sudo cp modules/xdebug.so /usr/lib/php/20151012
-echo "$XDEBUG_LOAD_LINE" > "/etc/php/7.0/fpm/php.ini"
+sudo touch $XDEBUG_INI_PATH
+sudo echo "$XDEBUG_LOAD_LINE" > "$XDEBUG_INI_PATH"
 
 service nginx restart
 service php7.0-fpm restart

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TEMP_DIR="~/temp"
+TEMP_DIR="/home/vagrant/temp"
 XDEBUG_LINK="http://xdebug.org/files/xdebug-2.4.0rc3.tgz"
 XDEBUG_VERSION="xdebug-2.4.0RC3"
 XDEBUG_LOAD_LINE="[xdebug]
@@ -27,5 +27,7 @@ sudo cp modules/xdebug.so /usr/lib/php/20151012
 sudo touch $XDEBUG_INI_PATH
 sudo echo "$XDEBUG_LOAD_LINE" > "$XDEBUG_INI_PATH"
 
-service nginx restart
-service php7.0-fpm restart
+sudo service nginx restart
+sudo service php7.0-fpm restart
+
+sudo rm -rf $TEMP_DIR

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -18,7 +18,7 @@ XDEBUG_INI_PATH="/etc/php/7.0/fpm/conf.d/20-xdebug.ini"
 mkdir $TEMP_DIR
 wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz" -q
 cd $TEMP_DIR
-tar -xzf xdebug.tgz --silent
+tar -xzf xdebug.tgz
 cd $XDEBUG_VERSION
 phpize --silent
 ./configure --silent

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -14,6 +14,7 @@ xdebug.cli_color=1
 xdebug.show_local_vars=1
 "
 XDEBUG_INI_PATH="/etc/php/7.0/fpm/conf.d/20-xdebug.ini"
+XDEBUG_CLI_INI_PATH="/etc/php/7.0/cli/conf.d/20-xdebug.ini"
 
 mkdir $TEMP_DIR
 wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz" -q
@@ -24,8 +25,8 @@ phpize --silent
 ./configure --silent
 make --silent
 sudo cp modules/xdebug.so /usr/lib/php/20151012
-sudo touch $XDEBUG_INI_PATH
 sudo echo "$XDEBUG_LOAD_LINE" > "$XDEBUG_INI_PATH"
+sudo ln -s $XDEBUG_INI_PATH $XDEBUG_CLI_INI_PATH
 
 sudo service nginx restart
 sudo service php7.0-fpm restart

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -16,13 +16,13 @@ xdebug.show_local_vars=1
 XDEBUG_INI_PATH="/etc/php/7.0/fpm/conf.d/20-xdebug.ini"
 
 mkdir $TEMP_DIR
-wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz"
+wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz" -q
 cd $TEMP_DIR
-tar -xvzf xdebug.tgz
+tar -xzf xdebug.tgz --silent
 cd $XDEBUG_VERSION
-phpize
-./configure
-make
+phpize --silent
+./configure --silent
+make --silent
 sudo cp modules/xdebug.so /usr/lib/php/20151012
 sudo touch $XDEBUG_INI_PATH
 sudo echo "$XDEBUG_LOAD_LINE" > "$XDEBUG_INI_PATH"

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -32,3 +32,5 @@ databases:
 #     - send: 7777
 #       to: 777
 #       protocol: udp
+
+# xdebug: true

--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -32,3 +32,15 @@ function serve-hhvm() {
         echo "  serve-hhvm domain path"
     fi
 }
+
+function serve-symfony2() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo dos2unix /vagrant/scripts/serve-symfony2.sh
+        sudo bash /vagrant/scripts/serve-symfony2.sh "$1" "$2" 80
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-symfony2 domain path"
+    fi
+}


### PR DESCRIPTION
Hello,

I was looking for PHP7 ready vagrant box for my Symfony projects. After quite a long search and a lot of tries I came up with using Laravel homestead which is great and has great setup for project start. But it lacked of debugging tool like xdebug. So I decided to make a small script to integrate optional xdebug to homestead. 

And now you can just add ```xdebug: true``` to the homestead yaml file and xdebug will be installed automatically.

Maybe implementation is not in the best way, but maybe after some suggestions it can be improved.

Also I have added serve-symfony2 function to serve symfony projects easily.