### PR TITLE
Xdebug for PHP7

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -219,5 +219,15 @@ class Homestead
         ]
       end
     end
+
+    # Setup Xdebug if it has been set for this machine
+    if settings.has_key?("xdebug")
+      config.vm.provision "shell" do |s|
+        if (settings["xdebug"])
+          s.path = scriptDir + "/xdebug.sh"
+        end
+      end
+    end
+
   end
 end

--- a/scripts/xdebug.sh
+++ b/scripts/xdebug.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+TEMP_DIR="/home/vagrant/temp"
+XDEBUG_LINK="http://xdebug.org/files/xdebug-2.4.0rc3.tgz"
+XDEBUG_VERSION="xdebug-2.4.0RC3"
+XDEBUG_LOAD_LINE="[xdebug]
+zend_extension = /usr/lib/php/20151012/xdebug.so
+
+xdebug.remote_enable = 1
+xdebug.remote_connect_back = 1
+xdebug.remote_port = 9000
+xdebug.scream=0
+xdebug.cli_color=1
+xdebug.show_local_vars=1
+"
+XDEBUG_INI_PATH="/etc/php/7.0/fpm/conf.d/20-xdebug.ini"
+XDEBUG_CLI_INI_PATH="/etc/php/7.0/cli/conf.d/20-xdebug.ini"
+
+mkdir $TEMP_DIR
+wget $XDEBUG_LINK -O $TEMP_DIR"/xdebug.tgz" -q
+cd $TEMP_DIR
+tar -xzf xdebug.tgz
+cd $XDEBUG_VERSION
+phpize --silent
+./configure --silent
+make --silent
+sudo cp modules/xdebug.so /usr/lib/php/20151012
+sudo echo "$XDEBUG_LOAD_LINE" > "$XDEBUG_INI_PATH"
+sudo ln -s $XDEBUG_INI_PATH $XDEBUG_CLI_INI_PATH
+
+sudo service nginx restart
+sudo service php7.0-fpm restart
+
+sudo rm -rf $TEMP_DIR

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -32,3 +32,5 @@ databases:
 #     - send: 7777
 #       to: 777
 #       protocol: udp
+
+# xdebug: true


### PR DESCRIPTION
Hello,

I was looking for PHP7 ready vagrant box for my Symfony projects. After quite a long search and a lot of tries I came up with using Laravel homestead which is great and has great setup for project start. But it lacked of debugging tool like xdebug. So I decided to make a small script to integrate optional xdebug to homestead.

And now you can just add xdebug: true to the homestead yaml file and xdebug will be installed automatically.

Maybe implementation is not in the best way, but maybe after some suggestions it can be improved.