### PR TITLE
Accept custom_dir parameter on each sites's config

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -136,7 +136,7 @@ class Homestead
       type = site["type"] ||= "laravel"
  
       # If informed, will use a custom config file for the serve script.
-      custom_conf = site["custom_conf"] || scriptDir
+      custom_dir = site["custom_dir"] || scriptDir
 
       if (site.has_key?("hhvm") && site["hhvm"])
         type = "hhvm"
@@ -147,7 +147,7 @@ class Homestead
       end
 
       config.vm.provision "shell" do |s|
-        s.path = scriptDir + "/serve-#{type}.sh"
+        s.path = custom_dir + "/serve-#{type}.sh"
         s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
       end
 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -96,8 +96,7 @@ class Homestead
         end
       end
     end
-
-    # Copy The SSH Private Keys To The Box
+# Copy The SSH Private Keys To The Box
     if settings.include? 'keys'
       settings["keys"].each do |key|
         config.vm.provision "shell" do |s|
@@ -135,6 +134,9 @@ class Homestead
 
     settings["sites"].each do |site|
       type = site["type"] ||= "laravel"
+ 
+      # If informed, will use a custom config file for the serve script.
+      custom_conf = site["custom_conf"] || scriptDir
 
       if (site.has_key?("hhvm") && site["hhvm"])
         type = "hhvm"


### PR DESCRIPTION
Homestead.yaml file will accept custom_dir parameter, for runing different serve scripts for each site.

Script will then be run on folder informed in Homestead.yaml file.

- Name of the script must match serve-**site_name**.sh

### Example
On Homestead.yaml file

```
sites:
    - map: homestead.app
      to: /var/www/htdocs
      type: 'mysite'
      custom_dir: 'C:\conf\'
```

**Folder C:\conf\ should have a serve-mysite.sh**



