### PR TITLE
Add Samba share support to homestead on Windows

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -115,6 +115,8 @@ class Homestead
 
         if (folder["type"] == "nfs")
             mount_opts = folder["mount_options"] ? folder["mount_options"] : ['actimeo=1']
+        elsif (folder["type"] == "smb")
+            mount_opts = folder["mount_options"] ? folder["mount_options"] : ['vers=3.02', 'mfsymlinks']
         end
 
         # For b/w compatibility keep separate 'mount_opts', but merge with options


### PR DESCRIPTION
Add support for mounting shared folders using [samba](https://www.vagrantup.com/docs/synced-folders/smb.html) (NFS equivalent on Windows).

This solves the problem of reaching max path size on folders mounted inside the VM, also solves the issue with npm not being able to create symlinks inside the linux box, and supposedly makes IO faster on Windows.

The only downside of this is that `vagrant up` needs to be run as admin. Nevertheless vagrant lets you know about this if you ran it as a unprivileged user.