### PR TITLE
Make the config directory compliant with the XDG specification.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,9 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION = "2"
-confDir = $confDir ||= File.expand_path("~/.homestead")
+
+# https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+confDir = $confDir ||= ((ENV['XDG_CONFIG_HOME'] || File.expand_path('~/.config')) + '/homestead')
 
 homesteadYamlPath = confDir + "/Homestead.yaml"
 homesteadJsonPath = confDir + "/Homestead.json"

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-homesteadRoot=~/.homestead
+# https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables
+homesteadRoot="${XDG_CONFIG_HOME:-$HOME/.config}/homestead"
 
 mkdir -p "$homesteadRoot"
 


### PR DESCRIPTION
The vagrant box (0.4.2, virtual box) has this problem too, at the end of the .profile file, the composer bin directory is added as follows:

PATH="/home/vagrant/.composer/vendor/bin:$PATH"

but composer is following the XDG specification too, the actual directory is:

/home/vagrant/.config/composer/vendor/bin