### PR TITLE
Add app_test.php for Symfony2

### DIFF
--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -30,7 +30,7 @@ block="server {
     client_max_body_size 100m;
 
     # DEV
-    location ~ ^/(app_dev|config)\.php(/|\$) {
+    location ~ ^/(app_dev|app_test|config)\.php(/|\$) {
         fastcgi_split_path_info ^(.+\.php)(/.+)\$;
         fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
         include fastcgi_params;


### PR DESCRIPTION
It's quite usual for devs to visit app_test.php when some acceptance tests fails, to reproduce the bug they have and gather some informations