### PR TITLE
Added .my.cnf file to get rid of security warning

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+cat > ~/.my.cnf << EOF
+[client]
+user = homestead
+password = secret
+host = localhost
+EOF
+
 DB=$1;
 
-mysql -uhomestead -psecret -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";
+mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
Current MySQL provision scripts provide the following warning about giving passwords from the command line. I modified the provision script to create a .my.cnf file in the home directory so that you don't have to pass the default Homestead password and username to the mysql client. You could also use the [mysql_config_editor](http://dev.mysql.com/doc/refman/5.7/en/mysql-config-editor.html) to create an encrypted file, but I don't see the point in this use case.

```
==> default: mysql:
==> default: [Warning] Using a password on the command line interface can be insecure.
```

This is also handy if you sometimes need to use the mysql client inside the Vagrant box. Now you don't have to give the username and password anymore.