### PR TITLE
Only create postgres db if it doesn't exists

### DIFF
--- a/scripts/create-postgres.sh
+++ b/scripts/create-postgres.sh
@@ -2,4 +2,7 @@
 
 DB=$1;
 # su postgres -c "dropdb $DB --if-exists"
-su postgres -c "createdb -O homestead '$DB' || true"
+
+if ! su postgres -c "psql $DB -c '\q' 2>/dev/null"; then
+    su postgres -c "createdb -O homestead '$DB'"
+fi


### PR DESCRIPTION
This prevents the following provisioning error:

```
createdb: database creation failed: ERROR:  database "homestead" already exists
```

Not critical since #130, but less red errors when provisioning.