### PR TITLE
Map site domains to hosts-updater plugin aliases

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,12 +17,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if File.exists? homesteadYamlPath then
-        Homestead.configure(config, YAML::load(File.read(homesteadYamlPath)))
+        settings = YAML::load(File.read(homesteadYamlPath))
     elsif File.exists? homesteadJsonPath then
-        Homestead.configure(config, JSON.parse(File.read(homesteadJsonPath)))
+        settings = JSON.parse(File.read(homesteadJsonPath))
     end
+
+    Homestead.configure(config, settings)
 
     if File.exists? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath
     end
+
+    if defined? VagrantPlugins::HostsUpdater
+		config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
+	end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if defined? VagrantPlugins::HostsUpdater
-		config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
-	end
+        config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
+    end
 end


### PR DESCRIPTION
To make Homestead even easier to use, the site domains (defined in the settings file) could be automatically be updated on `vagrant up/halt`, if the HostsUpdater plugin is installed on the host OS.

If backwards compatibility is an issue, maybe an additional `update_hosts: true` flag could be added.

That way only the settings file has to be touched in order to use the HostsUpdater plugin (and not the `Vagrantfile` itself).