### PR TITLE
append `privileged: false` for `afterScript` provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exists? afterScriptPath then
-        config.vm.provision "shell", path: afterScriptPath
+        config.vm.provision "shell", path: afterScriptPath, privileged: false
     end
 
     if defined? VagrantPlugins::HostsUpdater


### PR DESCRIPTION
Realistically the shell provisioner script should be ran as `vagrant`, so that it could do things specific to `$USER` (which is only `vagrant` in homestead).

Using `sudo` to gain privilege is easy, but switching from `root` to another user is a mess -- and I couldn't get it working.

Based on this reason I think this `afterScript` should be ran as `privileged: false` by default.