### PR TITLE
bindfs support added

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -138,6 +138,11 @@ class Homestead
         options.keys.each{|k| options[k.to_sym] = options.delete(k) }
 
         config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, **options
+
+        # bindfs support to fix shared folder (when nfs enabled) permission issue on mac osx
+        if Vagrant.has_plugin?("vagrant-bindfs")
+          config.bindfs.bind_folder folder["to"], folder["to"]
+        end
       end
     end
 


### PR DESCRIPTION
I was having permission issue (dialout) on shared folders (nfs enabled) when using Homestead on OSX 10.11.4.

After some searching, found out that vagrant-bindfs plugin can fix the problem and need to enable it on the folders. So, I write some codes to fix it automatically for me.