### PR TITLE
Assist syntax highlighters w/Vagrantfile language

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 require 'json'
 require 'yaml'
 


### PR DESCRIPTION
This is a pretty common practice. 

We do it in our Ansible-driven provisioning and deployment project: https://github.com/roots/trellis/blob/master/Vagrantfile