### PR TITLE
Allowing server_name to differ from the map name

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -136,7 +136,7 @@ class Homestead
 
       config.vm.provision "shell" do |s|
         s.path = scriptDir + "/serve-#{type}.sh"
-        s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+        s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", site["server_name"] ||= site["map"]]
       end
 
       # Configure The Cron Schedule

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -8,7 +8,7 @@ openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl;
-    server_name $1;
+    server_name $5;
     root \"$2\";
 
     index index.html index.htm index.php;

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -8,7 +8,7 @@ openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl;
-    server_name $1;
+    server_name $5;
     root \"$2\";
 
     index index.html index.htm index.php;

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -8,7 +8,7 @@ openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl;
-    server_name $1;
+    server_name $5;
     root \"$2\";
 
     index index.html index.htm index.php app.php;


### PR DESCRIPTION
Currently the sites map name is used to define the server_name in the nginx config. If you have a subdomain setup within the application adding something like "map: site.tld subdomain.site.tld" creates a bad nginx server config.

This change would allow for a new property in the Homestead config file "server_name" so that additional server names can be listed so that you can test any subdomain routes within the same application/site configuration. If no server_name is given it will default to the map property.