### PR TITLE
Automatically set the users /etc/hosts or Windows hosts file with the 

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,7 +16,10 @@ class Homestead
     config.vm.box = settings["box"] ||= "laravel/homestead"
     config.vm.box_version = settings["version"] ||= ">= 0.4.0"
     config.vm.hostname = settings["hostname"] ||= "homestead"
-
+    
+    # Using https://github.com/cogitatio/vagrant-hostsupdater Alias are done automatically for you
+    config.hostsupdater.aliases = settings["aliases"]
+    
     # Configure A Private Network IP
     config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
 

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -9,6 +9,8 @@ authorize: ~/.ssh/id_rsa.pub
 keys:
     - ~/.ssh/id_rsa
 
+aliases: ["homestead.app"]
+
 folders:
     - map: ~/Code
       to: /home/vagrant/Code


### PR DESCRIPTION
help of https://github.com/cogitatio/vagrant-hostsupdater

I post here https://alfrednutile.info/posts/184 some very easy steps to using this library. Also I link to http://sherriflemings.blogspot.ca/2015/03/laravel-homestead-on-windows-8.html which shows it being used in Windows (and I used it there a bit).

Just thought if this was part of the Homestead install docs it might be a nice addition.