### PR TITLE
Symlink support for VirtualBox shares with Windows host

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -35,6 +35,7 @@ class Homestead
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
       vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
+      vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//vagrant", "1"]
     end
 
     # Configure A Few VMware Settings
@@ -144,6 +145,15 @@ class Homestead
           config.bindfs.bind_folder folder["to"], folder["to"]
         end
       end
+
+      config.vm.provider "virtualbox" do |vb|
+        config.vm.synced_folders.each do |i, folder|
+          unless folder.include? 'type'
+            vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate//#{i}", "1"]
+          end
+        end
+      end
+
     end
 
     # Install All The Configured Nginx Sites


### PR DESCRIPTION
This adds symlink support for VirtualBox shares with Windows host.

After adding this and running `vagrant up` **with administrator privileges** it is possible to run something like `npm install` without using `--no-bin-links`