### PR TITLE
Allow user to create from Homestead.yaml.example with different IP.

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -81,6 +81,10 @@ class MakeCommand extends Command
             }
         } elseif (! file_exists($this->basePath.'/Homestead.yaml')) {
             copy($this->basePath.'/Homestead.yaml.example', $this->basePath.'/Homestead.yaml');
+
+            if ($input->getOption('ip')) {
+                $this->updateIpAddress($input->getOption('ip'));
+            }
         }
 
         if ($input->getOption('after')) {


### PR DESCRIPTION
This would allow user to run `homestead make --ip=x.x.x.x` and able to
change the default IP address when starting a project that include
`Homestead.yaml.example`.

Signed-off-by: crynobone <crynobone@gmail.com>