### PR TITLE
Use MariaDB Xenial PPA

### DIFF
--- a/scripts/install-maria.sh
+++ b/scripts/install-maria.sh
@@ -21,8 +21,8 @@ rm -rf /etc/mysql
 
 # Add Maria PPA
 
-apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
-add-apt-repository 'deb [arch=amd64,i386] http://ftp.osuosl.org/pub/mariadb/repo/10.1/ubuntu trusty main'
+apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
+add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.1/ubuntu xenial main'
 apt-get update
 
 # Set The Automated Root Password


### PR DESCRIPTION
Hi !

Today I updated my Homestead box to 0.5.0 and activated MariaDB.
This didn't work because the MariaDB PPA is still for Ubuntu Trusty !

I updated to Xenial MariaDB PPA and now it works after a vagrant provision !

