### PR TITLE
Update mariadb mirror.

### DIFF
--- a/scripts/install-maria.sh
+++ b/scripts/install-maria.sh
@@ -22,7 +22,7 @@ rm -rf /etc/mysql
 # Add Maria PPA
 
 apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.1/ubuntu xenial main'
+add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu xenial main'
 apt-get update
 
 # Set The Automated Root Password


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/470793/16587843/75252c4c-429a-11e6-95a1-f80ba44f2edc.png)

After an upgrade to 0.5.0 the mariadb was consistently failing install.  I have modified the source list to pull from a good mirror.