### PR TITLE
Add Vagrant.require_version to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,8 @@ aliasesPath = confDir + "/aliases"
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
 
+Vagrant.require_version '>= 1.8.4'
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exists? aliasesPath then
         config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"


### PR DESCRIPTION
Forces to use Vagrant 1.8.4 and greater