### PR TITLE
per-project installation - unprivileged `afterScript` provisioner

### DIFF
--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exists? afterScriptPath then
-        config.vm.provision "shell", path: afterScriptPath
+        config.vm.provision "shell", path: afterScriptPath, privileged: false
     end
 
     if defined? VagrantPlugins::HostsUpdater


### PR DESCRIPTION
I guess provisioning behaviour for [per-project installations](https://laravel.com/docs/homestead#per-project-installation) shoud be coherent with standard ones, and run as `vagrant` user.

This is the same change than merged PR #335, but for per-project generated Vagrantfile
