### PR TITLE
Http2 Support

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -164,10 +164,21 @@ class Homestead
           type = "symfony2"
         end
 
+        http2 = (site.has_key?("http2") && site["http2"]) ? 1 : 0
+
+        httpsOnly = (site.has_key?("httpsOnly") && site["httpsOnly"]) ? 1 : 0
+
         config.vm.provision "shell" do |s|
           s.name = "Creating Site: " + site["map"]
           s.path = scriptDir + "/serve-#{type}.sh"
-          s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+          s.args = [
+            site["map"],
+            site["to"],
+            site["port"] ||= "80",
+            site["ssl"] ||= "443",
+            http2,
+            httpsOnly
+          ]
         end
 
         # Configure The Cron Schedule

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -14,7 +14,7 @@ class Homestead
 
     # Configure The Box
     config.vm.box = settings["box"] ||= "laravel/homestead"
-    config.vm.box_version = settings["version"] ||= ">= 0.4.0"
+    config.vm.box_version = settings["version"] ||= ">= 0.5.0"
     config.vm.hostname = settings["hostname"] ||= "homestead"
 
     # Configure A Private Network IP

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -14,9 +14,41 @@ then
   openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
 fi
 
-block="server {
+block=""
+
+# Redirect all http requests to https if the httpsOnly flag is true
+if [[ $6 > 0 ]]
+then
+  block="server {
     listen ${3:-80};
-    listen ${4:-443} ssl;
+    server_name $1;
+    return 301 https://\$server_name\$request_uri;
+}
+
+"
+fi
+
+block="${block}server {
+"
+
+# Listen to http if httpsOnly flag is false
+if [[ $6 < 1 ]]
+then
+  block="${block}    listen ${3:-80};
+"
+fi
+
+# Enable http2
+if [[ $5 > 0 ]]
+then
+  block="${block}    listen ${4:-443} ssl http2;
+"
+else
+  block="${block}    listen ${4:-443} ssl;
+"
+fi
+
+block="${block}
     server_name $1;
     root \"$2\";
 

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -14,8 +14,30 @@ then
   openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
 fi
 
-block="server {
+block=""
+
+# Redirect all http requests to https if the httpsOnly flag is true
+if [ $6 > 0 ]
+then
+  block="server {
     listen ${3:-80};
+    server_name $1;
+    return 301 https://\$server_name\$request_uri;
+}
+
+"
+fi
+
+block="${block}server {"
+
+# Listen to http only if httpsOnly flag is false
+if [ $6 == 0 ]
+then
+  block="    listen ${3:-80};
+"
+fi
+
+block="${block}
     listen ${4:-443} ssl;
     server_name $1;
     root \"$2\";

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -17,7 +17,7 @@ fi
 block=""
 
 # Redirect all http requests to https if the httpsOnly flag is true
-if [ $6 > 0 ]
+if [[ $6 > 0 ]]
 then
   block="server {
     listen ${3:-80};
@@ -28,17 +28,27 @@ then
 "
 fi
 
-block="${block}server {"
+block="${block}server {
+"
 
-# Listen to http only if httpsOnly flag is false
-if [ $6 == 0 ]
+# Listen to http if httpsOnly flag is false
+if [[ $6 < 1 ]]
 then
-  block="    listen ${3:-80};
+  block="${block}    listen ${3:-80};
+"
+fi
+
+# Enable http2
+if [[ $5 > 0 ]]
+then
+  block="${block}    listen ${4:-443} ssl http2;
+"
+else
+  block="${block}    listen ${4:-443} ssl;
 "
 fi
 
 block="${block}
-    listen ${4:-443} ssl;
     server_name $1;
     root \"$2\";
 


### PR DESCRIPTION
Http2 is now supported by [major browsers](http://caniuse.com/#search=http2) and it should be taken into consideration when developing for the web. I wanted to test some laravel application under http2 and since homestead already supports https it is really easy to setup.

This changes allows you to setup http2 support from the homestead setting file. I added an "httpsOnly" flag to automatically redirect to https version of the site (since http2 works only on https for the majority of browsers).

Example:
```yaml
sites:
    - map: homestead.app
      to: "/home/vagrant/laravel/public"
      http2: true
      httpsOnly: true
```

I have to apologies for the quite bad bash syntax, I would like to tight them up but I'm not good enough in bash (I know only the basics). I commented some of the statement that might look confusing, let me know if I have to edit something, I'll be happy to do so.

Note:
Requiring homestead >= 0.5 is optional. On Ubuntu 14.04 http2 won't work in Chrome because of ALPN protocol. More detailed reason can be found [here](http://serverfault.com/a/733556).