### PR TITLE
Added site queue key to setup supervisor workers.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -185,6 +185,19 @@ class Homestead
           end
         end
 
+        # Configure Supervisor Queue Workers
+        if (site.has_key?("queue"))
+          config.vm.provision "shell" do |s|
+            if (site["queue"])
+              s.path = scriptDir + "/queue-worker.sh"
+              s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
+            else
+              s.inline = "rm -f /etc/supervisor/conf.d/$1-worker.conf"
+              s.args = [site["map"].tr('^A-Za-z0-9', '')]
+            end
+          end
+        end
+
       end
     end
 

--- a/scripts/queue-worker.sh
+++ b/scripts/queue-worker.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+mkdir /etc/supervisor/conf.d 2>/dev/null
+
+worker="[program:$1-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php $2/../artisan queue:work --sleep=3 --tries=3 --daemon
+autostart=true
+autorestart=true
+user=vagrant
+numprocs=8
+redirect_stderr=true
+stdout_logfile=$2/worker.log"
+
+echo "$worker" > "/etc/supervisor/conf.d/$1-worker.conf"
+
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo supervisorctl start all


### PR DESCRIPTION
To save having to manually set up queue worker processes using supervisor, this PR adds a new `queue` key which triggers an automatic worker config file and starts the process with supervisor.

```
sites:
	- map: homestead.app
	  to: /home/vagrant/Code/Laravel/public
	  queue: true
```

The worker conf file is setup in `/etc/supervisor/conf.d` and follows the following stub:

```
[program:$1-worker]
process_name=%(program_name)s_%(process_num)02d
command=php $2/../artisan queue:work --sleep=3 --tries=3 --daemon
autostart=true
autorestart=true
user=vagrant
numprocs=8
redirect_stderr=true
stdout_logfile=$2/worker.log
```


Tested on homestead 3.0.2 and it appears to work ok :)