### PR TITLE
Added 'nolock' to default nfs mount_options

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -126,7 +126,7 @@ class Homestead
         mount_opts = []
 
         if (folder["type"] == "nfs")
-            mount_opts = folder["mount_options"] ? folder["mount_options"] : ['actimeo=1']
+            mount_opts = folder["mount_options"] ? folder["mount_options"] : ['actimeo=1', 'nolock']
         elsif (folder["type"] == "smb")
             mount_opts = folder["mount_options"] ? folder["mount_options"] : ['vers=3.02', 'mfsymlinks']
         end


### PR DESCRIPTION
Fixes `ErrorException: file_put_contents(): Exclusive locks are not supported for this stream in /home/vagrant/Code/project/vendor/laravel/framework/src/Illuminate/Filesystem/Filesystem.php:111` which causes `TokenMismatchException` ( because sessions are not writable? ) for homestead folders with nfs enabled.

System where I've experienced the issue: Host OS: Ubuntu 16.04. One colleague also experienced weird TokenMismatchExceptions on Windows 10 but disabled nfs as a workaround. ( Will try to test this on Windows a.s.a.p. )