### PR TITLE
Vagrant >= 1.8.4 is not required anymore

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,6 @@ aliasesPath = confDir + "/aliases"
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
 
-Vagrant.require_version '>= 1.8.4'
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exists? aliasesPath then
         config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"


### PR DESCRIPTION
We dont need to force people to use Vagrant >= 1.8.4