### PR TITLE
Install HHVM if the user wants, when using MariaDB.

### DIFF
--- a/install-hhvm.sh
+++ b/install-hhvm.sh
@@ -1,0 +1,12 @@
+# install HHVM
+sudo apt-get -y install hhvm
+
+# ensure webserver can talk to HHVM over FastCGI
+sudo /usr/share/hhvm/install_fastcgi.sh
+sudo /etc/init.d/nginx restart
+
+# ensure hhvm starts up at boot
+sudo update-rc.d hhvm defaults
+
+# enable the system use HHVM for /usr/bin/php
+sudo /usr/bin/update-alternatives --install /usr/bin/php php /usr/bin/hhvm 60

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -198,6 +198,17 @@ class Homestead
       config.vm.provision "shell" do |s|
         s.path = scriptDir + "/install-maria.sh"
       end
+
+      #re-install HHVM
+      if settings.include? 'sites'
+        settings["sites"].each do |site|
+          if (site.has_key?("hhvm") && site["hhvm"])
+            config.vm.provision "shell" do |s|
+              s.path = scriptDir + "/install-hhvm.sh"
+            end
+          end
+        end
+      end
     end
 
 


### PR DESCRIPTION
During the course of uninstalling MySQL when the user selects to use MariaDB, HHVM is also uninstalled.

This script that is added here is used to get HHVM back

Responded to your concerns here - https://github.com/laravel/homestead/pull/360