### PR TITLE
Update homestead.rb

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -36,6 +36,9 @@ class Homestead
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
       vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
     end
+    
+    # Set the vagrant name for this box from the settings file
+    config.vm.define settings["name"] ||= "homestead-7"
 
     # Configure A Few VMware Settings
     ["vmware_fusion", "vmware_workstation"].each do |vmware|


### PR DESCRIPTION
This update prevents vagrant "default" instance naming no matter what name one sets in the configuration file. If no name key is set in the Homestead.yaml/json then "homestead-7 is used consistent with virtualbox naming in the lines above the edit.