### PR TITLE
Vagrantfiles coherence

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 require 'json'
 require 'yaml'
 
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION ||= "2"
 confDir = $confDir ||= File.expand_path("~/.homestead")
 
 homesteadYamlPath = confDir + "/Homestead.yaml"

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -1,3 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 require 'json'
 require 'yaml'
 

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -17,19 +17,19 @@ require File.expand_path(confDir + '/scripts/homestead.rb')
 Vagrant.require_version '>= 1.8.4'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    if File.exists? aliasesPath then
+    if File.exist? aliasesPath then
         config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"
     end
 
-    if File.exists? homesteadYamlPath then
+    if File.exist? homesteadYamlPath then
         settings = YAML::load(File.read(homesteadYamlPath))
-    elsif File.exists? homesteadJsonPath then
+    elsif File.exist? homesteadJsonPath then
         settings = JSON.parse(File.read(homesteadJsonPath))
     end
 
     Homestead.configure(config, settings)
 
-    if File.exists? afterScriptPath then
+    if File.exist? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false
     end
 

--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -14,6 +14,8 @@ aliasesPath = "aliases"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
 
+Vagrant.require_version '>= 1.8.4'
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exists? aliasesPath then
         config.vm.provision "file", source: aliasesPath, destination: "~/.bash_aliases"


### PR DESCRIPTION
Base `Vagrantfile` and per-project `LocalizedVagrantfile` underwent "asymmetric" modifications.
However, most changes would be pertinent on both sides.
This puts back both files as close as possible, applying all "missed" changes.