### PR TITLE
Adding an extra alias parameter to sites

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -156,6 +156,7 @@ class Homestead
     if settings.include? 'sites'
       settings["sites"].each do |site|
         type = site["type"] ||= "laravel"
+        reference = site["alias"] ||= site["map"]
 
         if (site.has_key?("hhvm") && site["hhvm"])
           type = "hhvm"
@@ -166,9 +167,9 @@ class Homestead
         end
 
         config.vm.provision "shell" do |s|
-          s.name = "Creating Site: " + site["map"]
+          s.name = "Creating Site: #{reference}"
           s.path = scriptDir + "/serve-#{type}.sh"
-          s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+          s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", reference]
         end
 
         # Configure The Cron Schedule
@@ -178,10 +179,10 @@ class Homestead
 
             if (site["schedule"])
               s.path = scriptDir + "/cron-schedule.sh"
-              s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
+              s.args = [reference.tr('^A-Za-z0-9', ''), site["to"]]
             else
               s.inline = "rm -f /etc/cron.d/$1"
-              s.args = [site["map"].tr('^A-Za-z0-9', '')]
+              s.args = [reference.tr('^A-Za-z0-9', '')]
             end
           end
         end

--- a/scripts/serve-hhvm.sh
+++ b/scripts/serve-hhvm.sh
@@ -3,14 +3,14 @@
 mkdir /etc/nginx/ssl 2>/dev/null
 
 PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_KEY="${PATH_SSL}/${5}.key"
+PATH_CSR="${PATH_SSL}/${5}.csr"
+PATH_CRT="${PATH_SSL}/${5}.crt"
 
 if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
 then
   openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$5/O=Vagrant/C=UK" 2>/dev/null
   openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
 fi
 
@@ -32,7 +32,7 @@ block="server {
     location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
-    error_log  /var/log/nginx/$1-error.log error;
+    error_log  /var/log/nginx/$5-error.log error;
 
     sendfile off;
 
@@ -48,11 +48,11 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
-    ssl_certificate_key /etc/nginx/ssl/$1.key;
+    ssl_certificate     /etc/nginx/ssl/$5.crt;
+    ssl_certificate_key /etc/nginx/ssl/$5.key;
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+echo "$block" > "/etc/nginx/sites-available/$5"
+ln -fs "/etc/nginx/sites-available/$5" "/etc/nginx/sites-enabled/$5"
 service hhvm restart

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -3,14 +3,14 @@
 mkdir /etc/nginx/ssl 2>/dev/null
 
 PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_KEY="${PATH_SSL}/${5}.key"
+PATH_CSR="${PATH_SSL}/${5}.csr"
+PATH_CRT="${PATH_SSL}/${5}.crt"
 
 if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
 then
   openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$5/O=Vagrant/C=UK" 2>/dev/null
   openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
 fi
 
@@ -32,7 +32,7 @@ block="server {
     location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
-    error_log  /var/log/nginx/$1-error.log error;
+    error_log  /var/log/nginx/$5-error.log error;
 
     sendfile off;
 
@@ -57,10 +57,10 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
-    ssl_certificate_key /etc/nginx/ssl/$1.key;
+    ssl_certificate     /etc/nginx/ssl/$5.crt;
+    ssl_certificate_key /etc/nginx/ssl/$5.key;
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+echo "$block" > "/etc/nginx/sites-available/$5"
+ln -fs "/etc/nginx/sites-available/$5" "/etc/nginx/sites-enabled/$5"

--- a/scripts/serve-proxy.sh
+++ b/scripts/serve-proxy.sh
@@ -3,14 +3,14 @@
 mkdir /etc/nginx/ssl 2>/dev/null
 
 PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_KEY="${PATH_SSL}/${5}.key"
+PATH_CSR="${PATH_SSL}/${5}.csr"
+PATH_CRT="${PATH_SSL}/${5}.crt"
 
 if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
 then
   openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$5/O=Vagrant/C=UK" 2>/dev/null
   openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
 fi
 
@@ -27,12 +27,12 @@ block="server {
     }
 
     access_log off;
-    error_log  /var/log/nginx/$1-error.log error;
+    error_log  /var/log/nginx/$5-error.log error;
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
-    ssl_certificate_key /etc/nginx/ssl/$1.key;
+    ssl_certificate     /etc/nginx/ssl/$5.crt;
+    ssl_certificate_key /etc/nginx/ssl/$5.key;
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+echo "$block" > "/etc/nginx/sites-available/$5"
+ln -fs "/etc/nginx/sites-available/$5" "/etc/nginx/sites-enabled/$5"

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 mkdir /etc/nginx/ssl 2>/dev/null
-openssl genrsa -out "/etc/nginx/ssl/$1.key" 2048 2>/dev/null
-openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
+openssl genrsa -out "/etc/nginx/ssl/$5.key" 2048 2>/dev/null
+openssl req -new -key /etc/nginx/ssl/$5.key -out /etc/nginx/ssl/$5.csr -subj "/CN=$5/O=Vagrant/C=UK" 2>/dev/null
+openssl x509 -req -days 365 -in /etc/nginx/ssl/$5.csr -signkey /etc/nginx/ssl/$5.key -out /etc/nginx/ssl/$5.crt 2>/dev/null
 
 block="server {
     listen ${3:-80};
@@ -23,7 +23,7 @@ block="server {
     location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
-    error_log  /var/log/nginx/$1-ssl-error.log error;
+    error_log  /var/log/nginx/$5-ssl-error.log error;
 
     sendfile off;
 
@@ -58,10 +58,10 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
-    ssl_certificate_key /etc/nginx/ssl/$1.key;
+    ssl_certificate     /etc/nginx/ssl/$5.crt;
+    ssl_certificate_key /etc/nginx/ssl/$5.key;
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+echo "$block" > "/etc/nginx/sites-available/$5"
+ln -fs "/etc/nginx/sites-available/$5" "/etc/nginx/sites-enabled/$5"


### PR DESCRIPTION
I've added an extra optional alias parameter to sites in homestead.yaml.
When provided, this alias will be used as the name for files (both SSL and Nginx) being generated.
This change allows users to use complex regular expressions as the map parameter when adding sites without causing errors because of invalid file names.

**input:**
```
sites:
    - map: '~^(www\.)?((?!-)[A-Za-z0-9-]+(?<!-)\.)*(?<domain>(?!-)[A-Za-z0-9-]+(?<!-))\.test$'
      to: /home/vagrant/Code/\$domain/public
      alias: wildcard-test
```

**generated file in sites-available (named wildcard-test in this example):**
```
server {
    listen 80;
    listen 443 ssl http2;
    server_name ~^(www\.)?((?!-)[A-Za-z0-9-]+(?<!-)\.)*(?<domain>(?!-)[A-Za-z0-9-]+(?<!-))\.test$;
    root "/home/vagrant/Code/$domain/public";

    index index.html index.htm index.php;

    charset utf-8;

    location / {
        try_files $uri $uri/ /index.php?$query_string;
    }

    location = /favicon.ico { access_log off; log_not_found off; }
    location = /robots.txt  { access_log off; log_not_found off; }

    access_log off;
    error_log  /var/log/nginx/wildcard-test-error.log error;

    sendfile off;

    client_max_body_size 100m;

    location ~ \.php$ {
        fastcgi_split_path_info ^(.+\.php)(/.+)$;
        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
        fastcgi_index index.php;
        include fastcgi_params;
        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;

        fastcgi_intercept_errors off;
        fastcgi_buffer_size 16k;
        fastcgi_buffers 4 16k;
        fastcgi_connect_timeout 300;
        fastcgi_send_timeout 300;
        fastcgi_read_timeout 300;
    }

    location ~ /\.ht {
        deny all;
    }

    ssl_certificate     /etc/nginx/ssl/wildcard-test.crt;
    ssl_certificate_key /etc/nginx/ssl/wildcard-test.key;
}
```

The extra alias parameter is only taken into account when using Nginx and is completely ignored when using Apache. When not provided, everything works as usual with the map parameter being used for file naming.