### PR TITLE
Run composer self-update from vagrant user

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -245,7 +245,9 @@ class Homestead
 
     # Update Composer On Every Provision
     config.vm.provision "shell" do |s|
-      s.inline = "/usr/local/bin/composer self-update"
+      s.name = "Update Composer"
+      s.inline = "sudo /usr/local/bin/composer self-update && sudo chown -R vagrant:vagrant /home/vagrant/.composer/"
+      s.privileged = false
     end
 
     # Configure Blackfire.io


### PR DESCRIPTION
Before this fix `composer self-update` was run directly as root and didn't add the missing keys to `/home/vagrant/.composer` (`keys.dev.pub` and `keys.tags.pub`)

if you try run `composer diagnose` before this fix then you will see that it shows error of missing keys