### PR TITLE
Add gui to vmware and virtualbox

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -36,6 +36,9 @@ class Homestead
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
       vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
+      if settings.has_key?("gui") && settings["gui"]
+          vb.gui = true
+      end
     end
 
     # Configure A Few VMware Settings
@@ -45,6 +48,9 @@ class Homestead
         v.vmx["memsize"] = settings["memory"] ||= 2048
         v.vmx["numvcpus"] = settings["cpus"] ||= 1
         v.vmx["guestOS"] = "ubuntu-64"
+        if settings.has_key?("gui") && settings["gui"]
+            v.gui = true
+        end
       end
     end
 


### PR DESCRIPTION
This just allows a new homestead option to use the "gui" right from the `Homestead.yaml` file. I have run into problems more specifically to vmware where the errors are not descriptive enough from the vagrant API alone to let you diagnose the problem.

This allows a new option:

```
gui: true
```

That will tell homestead to enable the gui option, allowing for better debugging without needing to manually edit the homestead package.