### PR TITLE
Add custom script feature

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -268,5 +268,17 @@ class Homestead
         ]
       end
     end
+
+    if settings.has_key?("scripts")
+      settings["scripts"].each do |script|
+          config.vm.provision "shell" do |s|
+            s.name = script["name"]
+            s.path = script["path"]
+            if script.has_key?("args")
+              s.args = script["args"]
+            end
+          end
+      end
+    end
   end
 end


### PR DESCRIPTION
This update will add the ability to add custom scripts, allowing to add any additional dependencies into homestead that you might need your you application.

Basically it adds extra options to the `Homestead.yaml` that lets you add your own custom scripts that will be run during provisioning.

The syntax is like so:

```
scripts:
    - name: "Custom Script"
      path: "path/to/script/custom.sh"
      args:
          - "test"
```

The args are optional and it can handle multiple or just run as a string of args.

```
scripts:
    - name: "Custom Script"
      path: "path/to/script/custom.sh"
      args: "test"
```

The scripts will run last and the `path` refers to the hosts path, not the VM's path.

I have tested it extensively with VMware and have not noticed any issues. I have not tested on any other provider yet though.

Here is a simple bash script to test it out. Just add it into your project directory and change the `path` to point to it and it should install imagick and then output the argument.

```
#!/usr/bin/env bash

ARG1=$1

apt-get install php-imagick -y

echo ${ARG1}
```

Effectively all that is happening is I have extended vagrants shell provisioner into the `Homestead.yaml`
https://www.vagrantup.com/docs/provisioning/shell.html