### PR TITLE
Ensure Virtualbox connect the LAN cable

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -35,6 +35,7 @@ class Homestead
       vb.customize ["modifyvm", :id, "--cpus", settings["cpus"] ||= "1"]
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
       vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
       if settings.has_key?("gui") && settings["gui"]
           vb.gui = true


### PR DESCRIPTION
Somehow, Some friends and I are unable to create a working homestead with Virtualbox with just a `vagrant up`, because the LAN adapter has it's cable "disconnected" in VB settings. So we have to `vagrant up` to initialize our box, `vagrant halt` to shut it down, then go to VB settings to force the cable connection, and finally `vagrant up` to make it work. 

This simple line ensure that the cable will be connected in VB and solves our problem.