### PR TITLE
The .my.cnf could be available for vagrant user

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -7,6 +7,8 @@ password = secret
 host = localhost
 EOF
 
+cp ~/.my.cnf /home/vagrant/.my.cnf
+
 DB=$1;
 
 mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";

--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 
-cat > ~/.my.cnf << EOF
+cat > /home/vagrant/.my.cnf << EOF
 [client]
 user = homestead
 password = secret
 host = localhost
 EOF
-
-cp ~/.my.cnf /home/vagrant/.my.cnf
 
 DB=$1;
 


### PR DESCRIPTION
Currently, this configuration is only available for the root user. Making it available for the vagrant user, may provide easy access to the database command line inside the virtual machine.

With this, after SSH into the virtual machine, the developer can easily issue: `mysql `to get into the database command line, instead of `mysql -u homestead -p`