### PR TITLE
Using credentials in mysql command as usual

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -9,4 +9,4 @@ EOF
 
 DB=$1;
 
-mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";
+mysql --user="root" --password="secret" -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
To avoid "Access denied" problem specifically for maridb installations, it is required to use the database credentials directly on the command.