### PR TITLE
Solving warning for credentials usage

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-cat > /home/vagrant/.my.cnf << EOF
+cat > /root/.my.cnf << EOF
 [client]
 user = homestead
 password = secret
 host = localhost
 EOF
 
+cp /root/.my.cnf /home/vagrant/.my.cnf
+
 DB=$1;
 
-mysql --user="root" --password="secret" -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";
+mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
Removing the credentials from the mysql command #407 . A copy of the .my.cnf file is created for the vagrant user, to allow easy access to the database.