### PR TITLE
Add option to disable natdnshostresolver via Homestead.yml config

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -34,7 +34,7 @@ class Homestead
       vb.customize ["modifyvm", :id, "--memory", settings["memory"] ||= "2048"]
       vb.customize ["modifyvm", :id, "--cpus", settings["cpus"] ||= "1"]
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
-      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", settings["natdnshostresolver"] ||= "on"]
       vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
       if settings.has_key?("gui") && settings["gui"]
           vb.gui = true
@@ -213,13 +213,13 @@ class Homestead
     if settings.has_key?("databases")
         settings["databases"].each do |db|
           config.vm.provision "shell" do |s|
-            s.name = "Creating MySQL Database: " + db
+            s.name = "Creating MySQL Database"
             s.path = scriptDir + "/create-mysql.sh"
             s.args = [db]
           end
 
           config.vm.provision "shell" do |s|
-            s.name = "Creating Postgres Database: " + db
+            s.name = "Creating Postgres Database"
             s.path = scriptDir + "/create-postgres.sh"
             s.args = [db]
           end


### PR DESCRIPTION
Fixes #409  

With this change, users can now set an option in Homestead.yaml that will disable the VirtualBox configuration setting `natdnshostresolver` for the VM's default `nat` interface.

```yaml
# Homestead.yaml
ip: "192.168.10.10"
memory: 2048
cpus: 1
provider: virtualbox
natdnshostresolver: "off"

authorize: ~/.ssh/id_rsa.pub
# ...
```

Note: the `Homestead.yaml` configuration value must be enclosed in quotes or on/off will parse as a boolean. The vagrant configuration syntax requires the string literal "off" or "on".

The optional setting was implemented this way over using a boolean and skipping the `modifyvm` call altogether since this allows toggling the `natdnshostresolver` option and running `vagrant reload`. If the setting is not explicitly set to "off", it will not be turned back to the VB default by simply removing the call to turn it on. In that scenario, the only way to toggle the option on or off would be to `vagrant destroy && vagrant up` or to use the `VBoxManage` cli tool directly as specified in the [VirtualBox docs](https://www.virtualbox.org/manual/ch09.html#nat_host_resolver_proxy).