### PR TITLE
Remove the config.ssh.shell directive. This breaks the ability to run

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -6,9 +6,6 @@ class Homestead
     # Configure Local Variable To Access Scripts From Remote Location
     scriptDir = File.dirname(__FILE__)
 
-    # Prevent TTY Errors
-    config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
-
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
 


### PR DESCRIPTION
    vagrant ssh -c command

This was added to prevent an error message from appearing when
sshing into a vagrant box.  It was a red herring because there
was no actual problem.

If users wand to get rid of the message then the can add

    config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"

to their Vagrantfile