### PR TITLE
Use native Ruby function to determine home directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION ||= "2"
-confDir = $confDir ||= File.expand_path("~/.homestead")
+confDir = $confDir ||= File.expand_path(File.join(Dir.home, ".homestead"))
 
 homesteadYamlPath = confDir + "/Homestead.yaml"
 homesteadJsonPath = confDir + "/Homestead.json"


### PR DESCRIPTION
Running "vagrant up" on native Windows shell will result an error because the Windows shell does not use the ~ as an reference to the home directory. Ruby actually offers a Dir.home method that handles this issue in different platforms. It basically uses the %HOMEDRIVE% and %HOMEPATH% variables on Windows and the ~ on *nix platforms. So this would at least fix the issue with Windows users not needing to run Git bash or cygwin.

http://ruby-doc.org/core-2.0.0/Dir.html#method-c-home