### PR TITLE
allow for multiple domain names per config

### DIFF
--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -2,15 +2,17 @@
 
 mkdir /etc/nginx/ssl 2>/dev/null
 
+safe_1=${1//\ /_}
+
 PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_KEY="${PATH_SSL}/${safe_1}.key"
+PATH_CSR="${PATH_SSL}/${safe_1}.csr"
+PATH_CRT="${PATH_SSL}/${safe_1}.crt"
 
 if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
 then
   openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=${safe_1}/O=Vagrant/C=UK" 2>/dev/null
   openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
 fi
 
@@ -32,7 +34,7 @@ block="server {
     location = /robots.txt  { access_log off; log_not_found off; }
 
     access_log off;
-    error_log  /var/log/nginx/$1-error.log error;
+    error_log  /var/log/nginx/${safe_1}-error.log error;
 
     sendfile off;
 
@@ -57,10 +59,10 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
-    ssl_certificate_key /etc/nginx/ssl/$1.key;
+    ssl_certificate     /etc/nginx/ssl/${safe_1}.crt;
+    ssl_certificate_key /etc/nginx/ssl/${safe_1}.key;
 }
 "
 
-echo "$block" > "/etc/nginx/sites-available/$1"
-ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+echo "$block" > "/etc/nginx/sites-available/${safe_1}"
+ln -fs "/etc/nginx/sites-available/${safe_1}" "/etc/nginx/sites-enabled/${safe_1}"


### PR DESCRIPTION
This patch allows for multiple domain names to be configured for nginx ssl-servers.

In order to do this, spaces are replaced with underscores for filenames that are generated in ```scripts/serve-laravel.sh```. The spaces are however __not__ replaced for the servername.

An example config in ```Homestead.yaml``` would be:

```yaml

sites:
   - map: example.org www.example.org example.com www.example.com
     to: /vagrant/Code/example-site/public

```