### PR TITLE
✨ Add support for update_guest_tools in Homestead.yaml defaults to false

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -57,7 +57,7 @@ class Homestead
     # Configure A Few Parallels Settings
     config.vm.provider "parallels" do |v|
       v.name = settings["name"] ||= "homestead-7"
-      v.update_guest_tools = true
+      v.update_guest_tools = settings["update_parallels_tools"] ||= false
       v.memory = settings["memory"] ||= 2048
       v.cpus = settings["cpus"] ||= 1
     end


### PR DESCRIPTION
Ran into this issue when building the parallels box. The base box has outdated guest tools, but folder syncing is still working fine. Default to false, when left to true it just sits for ~20+ minutes before I gave up waiting for it.