### PR TITLE
✨ ❄️ 💡 ⚡️ Instead of creating ~/.homestead, just use the repo folder instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /vendor
 /.vagrant
 phpunit.xml
+/Homestead.yaml
+/after.sh
+/aliases

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ require 'json'
 require 'yaml'
 
 VAGRANTFILE_API_VERSION ||= "2"
-confDir = $confDir ||= File.expand_path(File.join(Dir.home, ".homestead"))
+confDir = $confDir ||= File.expand_path(File.dirname(__FILE__))
 
 homesteadYamlPath = confDir + "/Homestead.yaml"
 homesteadJsonPath = confDir + "/Homestead.json"

--- a/init.bat
+++ b/init.bat
@@ -1,12 +1,7 @@
 @echo off
 
-set homesteadRoot=%HOMEDRIVE%%HOMEPATH%\.homestead
+copy /-y src\stubs\Homestead.yaml Homestead.yaml
+copy /-y src\stubs\after.sh after.sh
+copy /-y src\stubs\aliases aliases
 
-mkdir "%homesteadRoot%"
-
-copy /-y src\stubs\Homestead.yaml "%homesteadRoot%\Homestead.yaml"
-copy /-y src\stubs\after.sh "%homesteadRoot%\after.sh"
-copy /-y src\stubs\aliases "%homesteadRoot%\aliases"
-
-set homesteadRoot=
 echo Homestead initialized!

--- a/init.sh
+++ b/init.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-homesteadRoot=~/.homestead
-
-mkdir -p "$homesteadRoot"
-
-cp -i src/stubs/Homestead.yaml "$homesteadRoot/Homestead.yaml"
-cp -i src/stubs/after.sh "$homesteadRoot/after.sh"
-cp -i src/stubs/aliases "$homesteadRoot/aliases"
+cp -i src/stubs/Homestead.yaml Homestead.yaml
+cp -i src/stubs/after.sh after.sh
+cp -i src/stubs/aliases aliases
 
 echo "Homestead initialized!"


### PR DESCRIPTION
RE: #465 

Instead of creating ~/.homestead, just use the repo folder instead

* Users would no longer have `~/.homestead`
* Upgrade path: 

```
cp ~/.homestead/aliases .
cp ~/.homestead/after.sh .
cp ~/.homestead/Homestead.yaml .
```
