### PR TITLE
Add CAcert generation & signing for serve-scripts

### DIFF
--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -2,16 +2,28 @@
 
 mkdir /etc/nginx/ssl 2>/dev/null
 
+PATH_CA="/vagrant"
+PATH_CA_KEY="${PATH_CA}/ca.key"
+PATH_CA_CRT="${PATH_CA}/ca.crt"
+
+if [ ! -f $PATH_CA_KEY ] || [ ! -f $PATH_CA_CRT ]
+then
+    openssl genrsa -out "$PATH_CA_KEY" 2048 2>/dev/null
+    openssl req -new -x509 -days 365 -key "$PATH_CA_KEY" -out "$PATH_CA_CRT" -subj "/CN=homestead/O=Vagrant/C=UK" 2>/dev/null
+fi
+
 PATH_SSL="/etc/nginx/ssl"
 PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_BUNDLE="${PATH_SSL}/${1}-bundle.crt"
 
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ] || [ ! -f $PATH_BUNDLE ]
 then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+  openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -CA "$PATH_CA_CRT" -CAkey "$PATH_CA_KEY" -set_serial 01 -out "$PATH_CRT" 2>/dev/null
+  cat "$PATH_CRT" "$PATH_CA_CRT" > "$PATH_BUNDLE"
 fi
 
 block="server {
@@ -57,7 +69,7 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate     /etc/nginx/ssl/$1-bundle.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;
 }
 "

--- a/scripts/serve-proxy.sh
+++ b/scripts/serve-proxy.sh
@@ -2,16 +2,28 @@
 
 mkdir /etc/nginx/ssl 2>/dev/null
 
+PATH_CA="/vagrant"
+PATH_CA_KEY="${PATH_CA}/ca.key"
+PATH_CA_CRT="${PATH_CA}/ca.crt"
+
+if [ ! -f $PATH_CA_KEY ] || [ ! -f $PATH_CA_CRT ]
+then
+    openssl genrsa -out "$PATH_CA_KEY" 2048 2>/dev/null
+    openssl req -new -x509 -days 365 -key "$PATH_CA_KEY" -out "$PATH_CA_CRT" -subj "/CN=homestead/O=Vagrant/C=UK" 2>/dev/null
+fi
+
 PATH_SSL="/etc/nginx/ssl"
 PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_BUNDLE="${PATH_SSL}/${1}-bundle.crt"
 
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ] || [ ! -f $PATH_BUNDLE ]
 then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+  openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -CA "$PATH_CA_CRT" -CAkey "$PATH_CA_KEY" -set_serial 01 -out "$PATH_CRT" 2>/dev/null
+  cat "$PATH_CRT" "$PATH_CA_CRT" > "$PATH_BUNDLE"
 fi
 
 block="server {
@@ -32,7 +44,7 @@ block="server {
     access_log off;
     error_log  /var/log/nginx/$1-error.log error;
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate     /etc/nginx/ssl/$1-bundle.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;
 }
 "

--- a/scripts/serve-silverstripe.sh
+++ b/scripts/serve-silverstripe.sh
@@ -2,18 +2,29 @@
 
 mkdir /etc/nginx/ssl 2>/dev/null
 
+PATH_CA="/vagrant"
+PATH_CA_KEY="${PATH_CA}/ca.key"
+PATH_CA_CRT="${PATH_CA}/ca.crt"
+
+if [ ! -f $PATH_CA_KEY ] || [ ! -f $PATH_CA_CRT ]
+then
+    openssl genrsa -out "$PATH_CA_KEY" 2048 2>/dev/null
+    openssl req -new -x509 -days 365 -key "$PATH_CA_KEY" -out "$PATH_CA_CRT" -subj "/CN=homestead/O=Vagrant/C=UK" 2>/dev/null
+fi
+
 PATH_SSL="/etc/nginx/ssl"
 PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_BUNDLE="${PATH_SSL}/${1}-bundle.crt"
 
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ] || [ ! -f $PATH_BUNDLE ]
 then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+  openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -CA "$PATH_CA_CRT" -CAkey "$PATH_CA_KEY" -set_serial 01 -out "$PATH_CRT" 2>/dev/null
+  cat "$PATH_CRT" "$PATH_CA_CRT" > "$PATH_BUNDLE"
 fi
-
 
 block="server {
     listen ${3:-80};
@@ -112,7 +123,7 @@ block="server {
         fastcgi_buffers 4 32k;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate     /etc/nginx/ssl/$1-bundle.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;
 }
 "

--- a/scripts/serve-statamic.sh
+++ b/scripts/serve-statamic.sh
@@ -2,16 +2,28 @@
 
 mkdir /etc/nginx/ssl 2>/dev/null
 
+PATH_CA="/vagrant"
+PATH_CA_KEY="${PATH_CA}/ca.key"
+PATH_CA_CRT="${PATH_CA}/ca.crt"
+
+if [ ! -f $PATH_CA_KEY ] || [ ! -f $PATH_CA_CRT ]
+then
+    openssl genrsa -out "$PATH_CA_KEY" 2048 2>/dev/null
+    openssl req -new -x509 -days 365 -key "$PATH_CA_KEY" -out "$PATH_CA_CRT" -subj "/CN=homestead/O=Vagrant/C=UK" 2>/dev/null
+fi
+
 PATH_SSL="/etc/nginx/ssl"
 PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CSR="${PATH_SSL}/${1}.csr"
 PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_BUNDLE="${PATH_SSL}/${1}-bundle.crt"
 
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ] || [ ! -f $PATH_BUNDLE ]
 then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
+  openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -CA "$PATH_CA_CRT" -CAkey "$PATH_CA_KEY" -set_serial 01 -out "$PATH_CRT" 2>/dev/null
+  cat "$PATH_CRT" "$PATH_CA_CRT" > "$PATH_BUNDLE"
 fi
 
 block="server {
@@ -58,7 +70,7 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate     /etc/nginx/ssl/$1-bundle.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;
 }
 "

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -1,9 +1,30 @@
 #!/usr/bin/env bash
 
 mkdir /etc/nginx/ssl 2>/dev/null
-openssl genrsa -out "/etc/nginx/ssl/$1.key" 2048 2>/dev/null
-openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
+
+PATH_CA="/vagrant"
+PATH_CA_KEY="${PATH_CA}/ca.key"
+PATH_CA_CRT="${PATH_CA}/ca.crt"
+
+if [ ! -f $PATH_CA_KEY ] || [ ! -f $PATH_CA_CRT ]
+then
+    openssl genrsa -out "$PATH_CA_KEY" 2048 2>/dev/null
+    openssl req -new -x509 -days 365 -key "$PATH_CA_KEY" -out "$PATH_CA_CRT" -subj "/CN=homestead/O=Vagrant/C=UK" 2>/dev/null
+fi
+
+PATH_SSL="/etc/nginx/ssl"
+PATH_KEY="${PATH_SSL}/${1}.key"
+PATH_CSR="${PATH_SSL}/${1}.csr"
+PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_BUNDLE="${PATH_SSL}/${1}-bundle.crt"
+
+if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ] || [ ! -f $PATH_BUNDLE ]
+then
+  openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+  openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
+  openssl x509 -req -days 365 -in "$PATH_CSR" -CA "$PATH_CA_CRT" -CAkey "$PATH_CA_KEY" -set_serial 01 -out "$PATH_CRT" 2>/dev/null
+  cat "$PATH_CRT" "$PATH_CA_CRT" > "$PATH_BUNDLE"
+fi
 
 block="server {
     listen ${3:-80};
@@ -58,7 +79,7 @@ block="server {
         deny all;
     }
 
-    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate     /etc/nginx/ssl/$1-bundle.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;
 }
 "


### PR DESCRIPTION
Get rid of that annoying SSL Security warnings...

The creation of a CAcert allows you to trust a single certificate and get every host trusted.