### PR TITLE
Terminate execution if settings file doesn't exists

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         settings = YAML::load(File.read(homesteadYamlPath))
     elsif File.exist? homesteadJsonPath then
         settings = JSON.parse(File.read(homesteadJsonPath))
+    else
+        abort "Homestead settings file not found in #{confDir}"
     end
 
     Homestead.configure(config, settings)


### PR DESCRIPTION
Given that the `Homestead.yaml` has a new path where `Homestead` will look for it and that developers with already running `Homestead` instances are unlikely to run the `init.{sh|bash}` again (which creates the `Homestead.yaml` in the right location), will be helpful to provide a more friendly error message if the `Vagrantfile` doesn't find it.

*Previous error message:*

```
~/Homestead/scripts/homestead.rb:4:in `configure': undefined method `[]' for nil:NilClass
```

*New error message:*

```
Homestead settings file not found in /Users/robertoaguilar/Homestead
Homestead settings file not found in /Users/robertoaguilar/Homestead
```

The error message will be printed into `STDERR` and a `1` status code will be returned.

P.S. I don't know why the error message is printed twice, so a little help in that subject is appreciated.