### PR TITLE
Feature/json settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.vagrant
 phpunit.xml
 /Homestead.yaml
+/Homestead.json
 /after.sh
 /aliases

--- a/src/stubs/Homestead.json
+++ b/src/stubs/Homestead.json
@@ -1,0 +1,25 @@
+{
+    "ip": "192.168.10.10",
+    "memory": 2048,
+    "cpus": 1,
+    "provider": "virtualbox",
+    "authorize": "~/.ssh/id_rsa.pub",
+    "keys": [
+        "~/.ssh/id_rsa"
+    ],
+    "folders": [
+        {
+            "map": "~/Code",
+            "to": "/home/vagrant/Code"
+        }
+    ],
+    "sites": [
+        {
+            "map": "homestead.app",
+            "to": "/home/vagrant/Code/Laravel/public"
+        }
+    ],
+    "databases": [
+        "homestead"
+    ]
+}


### PR DESCRIPTION
Given that `Homestead` supports the settings file in `json` out of the box will be helpful to have a `Homestead.json` stub to use right away instead of converting the `Homestead.yaml` every time.