### PR TITLE
Terminate execution if settings file doesn't exists

### DIFF
--- a/src/stubs/LocalizedVagrantfile
+++ b/src/stubs/LocalizedVagrantfile
@@ -28,6 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         settings = YAML::load(File.read(homesteadYamlPath))
     elsif File.exist? homesteadJsonPath then
         settings = JSON.parse(File.read(homesteadJsonPath))
+    else
+        abort "Homestead settings file not found in #{confDir}"
     end
 
     Homestead.configure(config, settings)


### PR DESCRIPTION
Updates `LocalizedVagrantfile` to behave like the `Vagranfile`.

See #484 