### PR TITLE
✨ 💡 ✅ Add --json flag for Make Command. Add test coverage for make command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ php:
   - 7.0
   - 7.1
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-cache search php | grep yaml
+  - sudo apt-get install -y php$(phpenv version-name)-yaml
+
 before_script:
   - composer install --no-interaction
 

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -44,5 +44,45 @@ class MakeCommandTest extends TestCase
 
         $this->assertContains('Homestead Installed!', $tester->getDisplay());
         $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml'));
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile'));
+
+        // remove files so we can run the command again on a clean folder
+        unlink(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml');
+        unlink(self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile');
+    }
+
+    /**
+     * @test
+     */
+    public function testExecuteMakeWithOptions()
+    {
+        $makeCommand = new MakeCommand();
+
+        $tester = new CommandTester($makeCommand);
+        $tester->execute([
+            '--name' => 'fooname',
+            '--hostname' => 'foohost',
+            '--ip' => '127.0.0.1',
+            '--after' => true,
+            '--aliases' => true,
+            '--example' => true,
+            '--json' => true,
+        ], []);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json'));
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example'));
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile'));
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'aliases'));
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'after.sh'));
+
+        $config = file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json');
+        $config = json_decode($config, true);
+
+        $this->assertTrue($config['ip'] === '127.0.0.1');
+        $this->assertTrue($config['name'] === 'fooname');
+        $this->assertTrue($config['hostname'] === 'foohost');
     }
 }


### PR DESCRIPTION
Freely admitting that I took the easy way out on supporting JSON flag here.

Generate Yaml as usual -> Did the user ask for JSON? (--json) -> Convert Yaml to Json!

Added test coverage by verifying files are created in the test directory as expected and ensuring that values for name, hostname, and IP are properly set.

/cc @DojoGeekRA 