### PR TITLE
Refactor MakeCommand

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -66,6 +66,10 @@ class MakeCommand extends Command
             copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
         }
 
+        if ($input->getOption('after') && ! $this->afterShellScriptExists()) {
+            $this->createAfterShellScript();
+        }
+
         $settingsFileExtension = $input->getOption('json') ? 'json' : 'yaml';
 
         if ($input->getOption('example') && ! $this->exampleSettingsExists($settingsFileExtension)) {
@@ -94,12 +98,6 @@ class MakeCommand extends Command
             }
         }
 
-        if ($input->getOption('after')) {
-            if (! file_exists($this->basePath.'/after.sh')) {
-                copy(__DIR__.'/stubs/after.sh', $this->basePath.'/after.sh');
-            }
-        }
-
         if ($input->getOption('aliases')) {
             if (! file_exists($this->basePath.'/aliases')) {
                 copy(__DIR__.'/stubs/aliases', $this->basePath.'/aliases');
@@ -109,6 +107,26 @@ class MakeCommand extends Command
         $this->configurePaths();
 
         $output->writeln('Homestead Installed!');
+    }
+
+    /**
+     * Determine if the after shell script exists.
+     *
+     * @return bool
+     */
+    protected function afterShellScriptExists()
+    {
+        return file_exists("{$this->basePath}/after.sh");
+    }
+
+    /**
+     * Create the after shell script.
+     *
+     * @return void
+     */
+    protected function createAfterShellScript()
+    {
+        copy(__DIR__.'/stubs/after.sh', "{$this->basePath}/after.sh");
     }
 
     /**

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -66,6 +66,10 @@ class MakeCommand extends Command
             copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
         }
 
+        if ($input->getOption('aliases') && ! $this->aliasesFileExists()) {
+            $this->createAliasesFile();
+        }
+
         if ($input->getOption('after') && ! $this->afterShellScriptExists()) {
             $this->createAfterShellScript();
         }
@@ -98,15 +102,29 @@ class MakeCommand extends Command
             }
         }
 
-        if ($input->getOption('aliases')) {
-            if (! file_exists($this->basePath.'/aliases')) {
-                copy(__DIR__.'/stubs/aliases', $this->basePath.'/aliases');
-            }
-        }
-
         $this->configurePaths();
 
         $output->writeln('Homestead Installed!');
+    }
+
+    /**
+     * Determine if the aliases file exists.
+     *
+     * @return bool
+     */
+    protected function aliasesFileExists()
+    {
+        return file_exists("{$this->basePath}/aliases");
+    }
+
+    /**
+     * Create aliases file.
+     *
+     * @return void
+     */
+    protected function createAliasesFile()
+    {
+        copy(__DIR__.'/stubs/aliases', "{$this->basePath}/aliases");
     }
 
     /**

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -49,7 +49,8 @@ class MakeCommand extends Command
             ->addOption('ip', null, InputOption::VALUE_OPTIONAL, 'The IP address of the virtual machine.')
             ->addOption('after', null, InputOption::VALUE_NONE, 'Determines if the after.sh file is created.')
             ->addOption('aliases', null, InputOption::VALUE_NONE, 'Determines if the aliases file is created.')
-            ->addOption('example', null, InputOption::VALUE_NONE, 'Determines if a Homestead.yaml.example file is created.');
+            ->addOption('example', null, InputOption::VALUE_NONE, 'Determines if a Homestead example file is created.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Determines if the Homestead settings file will be in json format.');
     }
 
     /**
@@ -63,6 +64,12 @@ class MakeCommand extends Command
     {
         if (! file_exists($this->basePath.'/Vagrantfile')) {
             copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
+        }
+
+        $settingsFileExtension = $input->getOption('json') ? 'json' : 'yaml';
+
+        if ($input->getOption('example') && ! $this->exampleSettingsExists($settingsFileExtension)) {
+            $this->createExampleSettings($settingsFileExtension);
         }
 
         if (! file_exists($this->basePath.'/Homestead.yaml') && ! file_exists($this->basePath.'/Homestead.yaml.example')) {
@@ -99,15 +106,34 @@ class MakeCommand extends Command
             }
         }
 
-        if ($input->getOption('example')) {
-            if (! file_exists($this->basePath.'/Homestead.yaml.example')) {
-                copy($this->basePath.'/Homestead.yaml', $this->basePath.'/Homestead.yaml.example');
-            }
-        }
-
         $this->configurePaths();
 
         $output->writeln('Homestead Installed!');
+    }
+
+    /**
+     * Determine if the example settings file exists.
+     *
+     * @param  string  $fileExtension
+     * @return bool
+     */
+    protected function exampleSettingsExists($fileExtension)
+    {
+        return file_exists("{$this->basePath}/Homestead.{$fileExtension}.example");
+    }
+
+    /**
+     * Create example settings file.
+     *
+     * @param  string  $fileExtension
+     * @return void
+     */
+    protected function createExampleSettings($fileExtension)
+    {
+        copy(
+            __DIR__."/stubs/Homestead.{$fileExtension}",
+            "{$this->basePath}/Homestead.{$fileExtension}.example"
+        );
     }
 
     /**

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -62,8 +62,8 @@ class MakeCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        if (! file_exists($this->basePath.'/Vagrantfile')) {
-            copy(__DIR__.'/stubs/LocalizedVagrantfile', $this->basePath.'/Vagrantfile');
+        if (! $this->vagrantfileExists()) {
+            $this->createVagrantfile();
         }
 
         if ($input->getOption('aliases') && ! $this->aliasesFileExists()) {
@@ -105,6 +105,26 @@ class MakeCommand extends Command
         $this->configurePaths();
 
         $output->writeln('Homestead Installed!');
+    }
+
+    /**
+     * Determine if the Vagrantfile exists.
+     *
+     * @return bool
+     */
+    protected function vagrantfileExists()
+    {
+        return file_exists("{$this->basePath}/Vagrantfile");
+    }
+
+    /**
+     * Create a Vagrantfile.
+     *
+     * @return void
+     */
+    protected function createVagrantfile()
+    {
+        copy(__DIR__.'/stubs/LocalizedVagrantfile', "{$this->basePath}/Vagrantfile");
     }
 
     /**

--- a/src/Settings/HomesteadSettings.php
+++ b/src/Settings/HomesteadSettings.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Laravel\Homestead\Settings;
+
+interface HomesteadSettings
+{
+    /**
+     * Save the homestead settings.
+     *
+     * @param  string  $filename
+     * @return void
+     */
+    public function save($filename);
+
+    /**
+     * Update the homestead settings.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function update($attributes);
+
+    /**
+     * Convert the homestead settings to an array.
+     *
+     * @return array
+     */
+    public function toArray();
+}

--- a/src/Settings/JsonSettings.php
+++ b/src/Settings/JsonSettings.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Homestead\Settings;
+
+class JsonSettings implements HomesteadSettings
+{
+    /**
+     * Settings attributes.
+     *
+     * @var array
+     */
+    protected $attributes;
+
+    /**
+     * Settings filename.
+     *
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * JsonSettings constructor.
+     *
+     * @param  string  $filename
+     */
+    public function __construct($filename)
+    {
+        $this->attributes = json_decode(file_get_contents($filename), true);
+    }
+
+    /**
+     * Save the homestead settings.
+     *
+     * @param  string  $filename
+     * @return void
+     */
+    public function save($filename)
+    {
+        $this->filename = $filename;
+
+        file_put_contents($filename, json_encode($this->attributes, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Update the homestead settings.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public function update($attributes)
+    {
+        $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Convert the homestead settings to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->attributes;
+    }
+}

--- a/src/Settings/YamlSettings.php
+++ b/src/Settings/YamlSettings.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Laravel\Homestead\Settings;
+
+class YamlSettings implements HomesteadSettings
+{
+    /**
+     * Settings attributes.
+     *
+     * @var array
+     */
+    protected $attributes;
+
+    /**
+     * Settings filename.
+     *
+     * @var string
+     */
+    protected $filename;
+
+    /**
+     * YamlSettings constructor.
+     *
+     * @param  string  $filename
+     */
+    public function __construct($filename)
+    {
+        $this->attributes = yaml_parse_file($filename);
+    }
+
+    /**
+     * Save the homestead settings.
+     *
+     * @param  string  $filename
+     * @return void
+     */
+    public function save($filename)
+    {
+        $this->filename = $filename;
+
+        yaml_emit_file($filename, $this->attributes, YAML_UTF8_ENCODING);
+    }
+
+    /**
+     * Update the homestead settings.
+     *
+     * @param  array  $attributes
+     * @return static
+     */
+    public function update($attributes)
+    {
+        $this->attributes = array_merge($this->attributes, $attributes);
+
+        return $this;
+    }
+
+    /**
+     * Convert the homestead settings to an array.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->attributes;
+    }
+}

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -47,6 +47,50 @@ class MakeCommandTest extends TestCase
     }
 
     /** @test */
+    public function an_aliases_file_is_created_if_requested()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--aliases' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'aliases')
+        );
+        $this->assertEquals(
+            file_get_contents(__DIR__.'/../src/stubs/aliases'),
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'aliases')
+        );
+    }
+
+    /** @test */
+    public function an_existing_aliases_file_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'aliases',
+            'Already existing aliases'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--aliases' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'aliases')
+        );
+        $this->assertEquals(
+            'Already existing aliases',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'aliases')
+        );
+    }
+
+    /** @test */
     public function an_after_shell_script_is_created_if_requested()
     {
         $tester = new CommandTester(new MakeCommand());

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -22,8 +22,12 @@ class MakeCommandTest extends TestCase
 
     public static function tearDownAfterClass()
     {
-        array_map('unlink', glob(self::$testFolder.DIRECTORY_SEPARATOR.'*'));
         rmdir(self::$testFolder);
+    }
+
+    public function tearDown()
+    {
+        array_map('unlink', glob(self::$testFolder.DIRECTORY_SEPARATOR.'*'));
     }
 
     /** @test */
@@ -165,10 +169,6 @@ class MakeCommandTest extends TestCase
         $this->assertTrue(
             file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
         );
-        $this->assertEquals(
-            file_get_contents(__DIR__.'/../src/stubs/Homestead.yaml'),
-            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
-        );
     }
 
     /** @test */
@@ -176,7 +176,7 @@ class MakeCommandTest extends TestCase
     {
         file_put_contents(
             self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example',
-            'Already existing Homestead.yaml.example'
+            'name: Already existing Homestead.yaml.example'
         );
         $tester = new CommandTester(new MakeCommand());
 
@@ -190,7 +190,7 @@ class MakeCommandTest extends TestCase
             file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
         );
         $this->assertEquals(
-            'Already existing Homestead.yaml.example',
+            'name: Already existing Homestead.yaml.example',
             file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
         );
     }
@@ -210,10 +210,6 @@ class MakeCommandTest extends TestCase
         $this->assertTrue(
             file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
         );
-        $this->assertEquals(
-            file_get_contents(__DIR__.'/../src/stubs/Homestead.json'),
-            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
-        );
     }
 
     /** @test */
@@ -221,7 +217,7 @@ class MakeCommandTest extends TestCase
     {
         file_put_contents(
             self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example',
-            'Already existing Homestead.json.example'
+            '{"name": "Already existing Homestead.json.example"}'
         );
         $tester = new CommandTester(new MakeCommand());
 
@@ -236,8 +232,169 @@ class MakeCommandTest extends TestCase
             file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
         );
         $this->assertEquals(
-            'Already existing Homestead.json.example',
+            '{"name": "Already existing Homestead.json.example"}',
             file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
         );
+    }
+
+    /** @test */
+    public function a_homestead_yaml_settings_is_created_if_it_is_does_not_exists()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
+        );
+    }
+
+    /** @test */
+    public function an_existing_homestead_yaml_settings_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml',
+            'name: Already existing Homestead.yaml'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
+        );
+        $this->assertEquals(
+            'name: Already existing Homestead.yaml',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
+        );
+    }
+
+        /** @test */
+    public function a_homestead_json_settings_is_created_if_it_is_requested_and_it_does_not_exists()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--json' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json')
+        );
+    }
+
+    /** @test */
+    public function an_existing_homestead_json_settings_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json',
+            '{"message": "Already existing Homestead.json"}'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json')
+        );
+        $this->assertEquals(
+            '{"message": "Already existing Homestead.json"}',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json')
+        );
+    }
+
+    /** @test */
+    public function a_homestead_yaml_settings_is_created_from_a_homestead_yaml_example_if_it_exists()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example',
+            'message: Already existing Homestead.yaml.example'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
+        );
+        $this->assertContains(
+            'message: Already existing Homestead.yaml.example',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
+        );
+    }
+
+    /** @test */
+    public function a_homestead_json_settings_is_created_from_a_homestead_json_example_if_is_requested_and_if_it_exists()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example',
+            '{"message": "Already existing Homestead.json.example"}'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--json' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json')
+        );
+        $this->assertContains(
+            '"message": "Already existing Homestead.json.example"',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json')
+        );
+    }
+
+    /** @test */
+    public function a_homestead_yaml_settings_can_be_created_with_some_command_options_overrides()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--name' => 'test_name',
+            '--hostname' => 'test_hostname',
+            '--ip' => '127.0.0.1',
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml'));
+        $settings = yaml_parse_file(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml');
+        $this->assertEquals('test_name', $settings['name']);
+        $this->assertEquals('test_hostname', $settings['hostname']);
+        $this->assertEquals('127.0.0.1', $settings['ip']);
+    }
+
+    /** @test */
+    public function a_homestead_json_settings_can_be_created_with_some_command_options_overrides()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--json' => true,
+            '--name' => 'test_name',
+            '--hostname' => 'test_hostname',
+            '--ip' => '127.0.0.1',
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json'));
+        $settings = json_decode(file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json'), true);
+        $this->assertEquals('test_name', $settings['name']);
+        $this->assertEquals('test_hostname', $settings['hostname']);
+        $this->assertEquals('127.0.0.1', $settings['ip']);
     }
 }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -45,4 +45,94 @@ class MakeCommandTest extends TestCase
         $this->assertContains('Homestead Installed!', $tester->getDisplay());
         $this->assertEquals(0, $tester->getStatusCode());
     }
+
+    /** @test */
+    public function an_example_homestead_yaml_settings_is_created_if_requested()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--example' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
+        );
+        $this->assertEquals(
+            file_get_contents(__DIR__.'/../src/stubs/Homestead.yaml'),
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
+        );
+    }
+
+    /** @test */
+    public function an_existing_example_homestead_yaml_settings_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example',
+            'Already existing Homestead.yaml.example'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--example' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
+        );
+        $this->assertEquals(
+            'Already existing Homestead.yaml.example',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example')
+        );
+    }
+
+    /** @test */
+    public function an_example_homestead_json_settings_is_created_if_requested()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--example' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
+        );
+        $this->assertEquals(
+            file_get_contents(__DIR__.'/../src/stubs/Homestead.json'),
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
+        );
+    }
+
+    /** @test */
+    public function an_existing_example_homestead_json_settings_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example',
+            'Already existing Homestead.json.example'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--example' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
+        );
+        $this->assertEquals(
+            'Already existing Homestead.json.example',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json.example')
+        );
+    }
 }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -47,6 +47,50 @@ class MakeCommandTest extends TestCase
     }
 
     /** @test */
+    public function an_after_shell_script_is_created_if_requested()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--after' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'after.sh')
+        );
+        $this->assertEquals(
+            file_get_contents(__DIR__.'/../src/stubs/after.sh'),
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'after.sh')
+        );
+    }
+
+    /** @test */
+    public function an_existing_after_shell_script_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'after.sh',
+            'Already existing after.sh'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--after' => true,
+        ]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'after.sh')
+        );
+        $this->assertEquals(
+            'Already existing after.sh',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'after.sh')
+        );
+    }
+
+    /** @test */
     public function an_example_homestead_yaml_settings_is_created_if_requested()
     {
         $tester = new CommandTester(new MakeCommand());

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -8,6 +8,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class MakeCommandTest extends TestCase
 {
+    /**
+     * @var string
+     */
     protected static $testFolder;
 
     public static function setUpBeforeClass()
@@ -23,27 +26,41 @@ class MakeCommandTest extends TestCase
         rmdir(self::$testFolder);
     }
 
-    /**
-     * @test
-     */
-    public function testConstructor()
+    /** @test */
+    public function a_vagrantfile_is_created_if_it_does_not_exists()
     {
-        $makeCommand = new MakeCommand();
-        $this->assertInstanceOf(MakeCommand::class, $makeCommand);
-    }
+        $tester = new CommandTester(new MakeCommand());
 
-    /**
-     * @test
-     */
-    public function testExecuteMake()
-    {
-        $makeCommand = new MakeCommand();
-
-        $tester = new CommandTester($makeCommand);
-        $tester->execute([], []);
+        $tester->execute([]);
 
         $this->assertContains('Homestead Installed!', $tester->getDisplay());
         $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertTrue(
+            file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile')
+        );
+        $this->assertEquals(
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile'),
+            file_get_contents(__DIR__.'/../src/stubs/LocalizedVagrantfile')
+        );
+    }
+
+    /** @test */
+    public function an_existing_vagrantfile_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile',
+            'Already existing Vagrantfile'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertContains('Homestead Installed!', $tester->getDisplay());
+        $this->assertEquals(0, $tester->getStatusCode());
+        $this->assertEquals(
+            'Already existing Vagrantfile',
+            file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Vagrantfile')
+        );
     }
 
     /** @test */

--- a/tests/Settings/HomesteadJsonSettingsTest.php
+++ b/tests/Settings/HomesteadJsonSettingsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Laravel\Homestead\Settings\JsonSettings;
+
+class HomesteadJsonSettingsTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected static $testFolder;
+
+    public static function setUpBeforeClass()
+    {
+        self::$testFolder = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('homestead_settings_', true);
+        mkdir(self::$testFolder);
+        chdir(self::$testFolder);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        rmdir(self::$testFolder);
+    }
+
+    public function tearDown()
+    {
+        array_map('unlink', glob(self::$testFolder.DIRECTORY_SEPARATOR.'*'));
+    }
+
+    /** @test */
+    public function it_can_be_created_from_a_filename()
+    {
+        $settings = new JsonSettings(__DIR__.'/../../src/stubs/Homestead.json');
+
+        $attributes = $settings->toArray();
+        $this->assertEquals('192.168.10.10', $attributes['ip']);
+        $this->assertEquals('2048', $attributes['memory']);
+        $this->assertEquals(1, $attributes['cpus']);
+    }
+
+    /** @test */
+    public function it_can_be_saved_to_a_file()
+    {
+        $settings = new JsonSettings(__DIR__.'/../../src/stubs/Homestead.json');
+        $filename = self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.json';
+
+        $settings->save($filename);
+
+        $this->assertTrue(file_exists($filename));
+        $attributes = json_decode(file_get_contents($filename), true);
+        $this->assertEquals('192.168.10.10', $attributes['ip']);
+        $this->assertEquals('2048', $attributes['memory']);
+        $this->assertEquals(1, $attributes['cpus']);
+    }
+
+    /** @test */
+    public function it_can_update_its_attributes()
+    {
+        $settings = new JsonSettings(__DIR__.'/../../src/stubs/Homestead.json');
+
+        $settings->update([
+            'ip' => '127.0.0.1',
+            'memory' => '4096',
+            'cpus' => 2,
+        ]);
+
+        $attributes = $settings->toArray();
+        $this->assertEquals('127.0.0.1', $attributes['ip']);
+        $this->assertEquals('4096', $attributes['memory']);
+        $this->assertEquals(2, $attributes['cpus']);
+    }
+}

--- a/tests/Settings/HomesteadYamlSettingsTest.php
+++ b/tests/Settings/HomesteadYamlSettingsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use PHPUnit\Framework\TestCase as TestCase;
+use Laravel\Homestead\Settings\YamlSettings;
+
+class HomesteadYamlSettingsTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected static $testFolder;
+
+    public static function setUpBeforeClass()
+    {
+        self::$testFolder = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('homestead_settings_', true);
+        mkdir(self::$testFolder);
+        chdir(self::$testFolder);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        rmdir(self::$testFolder);
+    }
+
+    public function tearDown()
+    {
+        array_map('unlink', glob(self::$testFolder.DIRECTORY_SEPARATOR.'*'));
+    }
+
+    /** @test */
+    public function it_can_be_created_from_a_filename()
+    {
+        $settings = new YamlSettings(__DIR__.'/../../src/stubs/Homestead.yaml');
+
+        $attributes = $settings->toArray();
+        $this->assertEquals('192.168.10.10', $attributes['ip']);
+        $this->assertEquals('2048', $attributes['memory']);
+        $this->assertEquals(1, $attributes['cpus']);
+    }
+
+    /** @test */
+    public function it_can_be_saved_to_a_file()
+    {
+        $settings = new YamlSettings(__DIR__.'/../../src/stubs/Homestead.yaml');
+        $filename = self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml';
+
+        $settings->save($filename);
+
+        $this->assertTrue(file_exists($filename));
+        $attributes = yaml_parse_file($filename);
+        $this->assertEquals('192.168.10.10', $attributes['ip']);
+        $this->assertEquals('2048', $attributes['memory']);
+        $this->assertEquals(1, $attributes['cpus']);
+    }
+
+    /** @test */
+    public function it_can_update_its_attributes()
+    {
+        $settings = new YamlSettings(__DIR__.'/../../src/stubs/Homestead.yaml');
+
+        $settings->update([
+            'ip' => '127.0.0.1',
+            'memory' => '4096',
+            'cpus' => 2,
+        ]);
+
+        $attributes = $settings->toArray();
+        $this->assertEquals('127.0.0.1', $attributes['ip']);
+        $this->assertEquals('4096', $attributes['memory']);
+        $this->assertEquals(2, $attributes['cpus']);
+    }
+}


### PR DESCRIPTION
@svpernova09 sorry for the delay, i see that you already merged #489 but like you mentioned, there was some technical debt in there, so instead of just patching the command i heavily refactored it.

In this new version the following goals are reached:

* Improved the readability of the `execute` method extracting implementation details into methods.
* The make command no longer deals with the `json` or `yaml` create or update tasks, it now delegates that to the `JsonSettings` and `YamlSettings` objects through strategy pattern.
* The make command is now 100% test covered 🤘 (thank you very much @ezimuel for your awesome test `setUp` and `tearDown` features, without them achieve this one would have been very hard). The following scenarios are now tested:

  * A `Vagrantfile` is created if not already exists
  * An existing `Vagranfile` is not overwritten
  * An `alises` file is created if requested
  * An existing `aliases` file is not overwritten
  * An `after.sh` file is created if requested
  * An existing `after.sh` is not overwritten
  * An `Homestead.{yaml|json}.example` is created if requested
  * An existing `Homestead.{yaml|json}.example` is not overwritten
  * A `Homestead.{yaml|json}` is created if not already exists
    * It can be created in `yaml` or in `json` format.
    * If the `Homestead.{yaml|json}.example` exists, `the Homestead.{yaml|json}` is created from it
    * If the `Homestead.{yaml|json}.example` doesn't exists, `the Homestead.{yaml|json}` is created from the stub.
  * A `Homestead.{yaml|json}` can be overwritten with the command options: `name`, `hostname` and `ip`

The new features are:
  * The `Homestead.{yaml|json}.example` now can be updated with the same command options as the `Homestead.{yaml|json}` (`name`, `hostname` and `ip`)
  * If an `Homestead.{yaml|json}.example` is requested it is created, but also it will create the `Homestead.{yaml|json}` with exactly the same content.

The missing features (work in progress):
  * Implement the previous `configurePaths` method to update the `folders` and `sites`
  * I'm not 100% sure, but seems [Symfony Yaml component](like http://symfony.com/doc/current/components/yaml.html) doesn't require the php-yaml extension so this can solve the TravisCI problem.
  * Beautify the code. I have been drafting and iterating over this a LOT, i just have to make sure that everything is consistent and properly arranged.