### PR TITLE
use Symfony yaml component instead of yaml PHP extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "symfony/console": "~2.3|~3.0",
-        "symfony/process": "~2.3|~3.0"
+        "symfony/process": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "d247cc58d6f1801a8abb61bee055bd7a",
+    "content-hash": "6bd9edb735fe556c257bcc5c80adfeb8",
     "packages": [
         {
             "name": "psr/log",
@@ -280,6 +280,61 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "time": "2017-02-03T12:11:38+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "reference": "9724c684646fcb5387d579b4bfaa63ee0b0c64c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/console": "~2.8|~3.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-02-16T22:46:52+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Settings/YamlSettings.php
+++ b/src/Settings/YamlSettings.php
@@ -2,6 +2,8 @@
 
 namespace Laravel\Homestead\Settings;
 
+use Symfony\Component\Yaml\Yaml;
+
 class YamlSettings implements HomesteadSettings
 {
     /**
@@ -25,7 +27,7 @@ class YamlSettings implements HomesteadSettings
      */
     public function __construct($filename)
     {
-        $this->attributes = yaml_parse_file($filename);
+        $this->attributes = Yaml::parse(file_get_contents($filename));
     }
 
     /**
@@ -38,7 +40,7 @@ class YamlSettings implements HomesteadSettings
     {
         $this->filename = $filename;
 
-        yaml_emit_file($filename, $this->attributes, YAML_UTF8_ENCODING);
+        file_put_contents($filename, Yaml::dump($this->attributes));
     }
 
     /**

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Symfony\Component\Yaml\Yaml;
 use Laravel\Homestead\MakeCommand;
 use PHPUnit\Framework\TestCase as TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -316,7 +317,7 @@ class MakeCommandTest extends TestCase
     {
         file_put_contents(
             self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml.example',
-            'message: Already existing Homestead.yaml.example'
+            "message: 'Already existing Homestead.yaml.example'"
         );
         $tester = new CommandTester(new MakeCommand());
 
@@ -328,7 +329,7 @@ class MakeCommandTest extends TestCase
             file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
         );
         $this->assertContains(
-            'message: Already existing Homestead.yaml.example',
+            "message: 'Already existing Homestead.yaml.example'",
             file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml')
         );
     }
@@ -371,7 +372,7 @@ class MakeCommandTest extends TestCase
         $this->assertContains('Homestead Installed!', $tester->getDisplay());
         $this->assertEquals(0, $tester->getStatusCode());
         $this->assertTrue(file_exists(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml'));
-        $settings = yaml_parse_file(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml');
+        $settings = Yaml::parse(file_get_contents(self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml'));
         $this->assertEquals('test_name', $settings['name']);
         $this->assertEquals('test_hostname', $settings['hostname']);
         $this->assertEquals('127.0.0.1', $settings['ip']);
@@ -407,7 +408,7 @@ class MakeCommandTest extends TestCase
         );
         file_put_contents(
             self::$testFolder.DIRECTORY_SEPARATOR.'Homestead.yaml',
-            'message: Already existing Homestead.yaml'
+            "message: 'Already existing Homestead.yaml'"
         );
         $tester = new CommandTester(new MakeCommand());
 

--- a/tests/Settings/HomesteadJsonSettingsTest.php
+++ b/tests/Settings/HomesteadJsonSettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Settings;
+
 use PHPUnit\Framework\TestCase as TestCase;
 use Laravel\Homestead\Settings\JsonSettings;
 

--- a/tests/Settings/HomesteadYamlSettingsTest.php
+++ b/tests/Settings/HomesteadYamlSettingsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Tests\Settings;
+
 use Symfony\Component\Yaml\Yaml;
 use PHPUnit\Framework\TestCase as TestCase;
 use Laravel\Homestead\Settings\YamlSettings;

--- a/tests/Settings/HomesteadYamlSettingsTest.php
+++ b/tests/Settings/HomesteadYamlSettingsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Symfony\Component\Yaml\Yaml;
 use PHPUnit\Framework\TestCase as TestCase;
 use Laravel\Homestead\Settings\YamlSettings;
 
@@ -47,7 +48,7 @@ class HomesteadYamlSettingsTest extends TestCase
         $settings->save($filename);
 
         $this->assertTrue(file_exists($filename));
-        $attributes = yaml_parse_file($filename);
+        $attributes = Yaml::parse(file_get_contents($filename));
         $this->assertEquals('192.168.10.10', $attributes['ip']);
         $this->assertEquals('2048', $attributes['memory']);
         $this->assertEquals(1, $attributes['cpus']);


### PR DESCRIPTION
It now uses `Symfony yaml` component to handle `yaml` parsing.

This have also has the advantage that the developers doesn't need the `php-yaml` extension in their systems.