### PR TITLE
Support of older PHP versions

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -178,7 +178,7 @@ class Homestead
                 config.vm.provision "shell" do |s|
                     s.name = "Creating Site: " + site["map"]
                     s.path = scriptDir + "/serve-#{type}.sh"
-                    s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443"]
+                    s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", site["php"] ||= "7.1"]
                 end
 
                 # Configure The Cron Schedule

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -40,7 +40,7 @@ block="server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php${5}-fpm.sock;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;

--- a/src/stubs/Homestead.yaml
+++ b/src/stubs/Homestead.yaml
@@ -16,6 +16,7 @@ folders:
 sites:
     - map: homestead.app
       to: /home/vagrant/Code/Laravel/public
+      #php: "5.6"
 
 databases:
     - homestead


### PR DESCRIPTION
I have 100+ project from Laravel 3 to Laravel 5.4  in my homestead local environment  and some of them, the older one needs PHP 5.6 to work because of a lot of deprecated functions, mcrypt and other staffs in PHP 7. Sometimes I need to have the same PHP version on my local environment and the production server that is provided by the firm client and I have no rights to change the PHP version and so on. So I think it is a good idea to have more then one PHP version in your box and to have the ability to change the PHP version for some of the sites in  Homestead.yaml if needed.