### PR TITLE
add flip script and alias

### DIFF
--- a/scripts/flip-webserver.sh
+++ b/scripts/flip-webserver.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ps auxw | grep apache2 | grep -v grep > /dev/null
+
+if [ $? != 0 ]
+then
+        service nginx stop > /dev/null
+        echo 'nginx stopped'
+        service apache2 start > /dev/null
+        echo 'apache started'
+else
+        service apache2 stop > /dev/null
+        echo 'apache stopped'
+        service nginx start > /dev/null
+        echo 'nginx started'
+fi

--- a/src/stubs/aliases
+++ b/src/stubs/aliases
@@ -100,3 +100,7 @@ function share() {
         echo "  share domain -region=eu -subdomain=test1234"
     fi
 }
+
+function flip() {
+    sudo bash /vagrant/scripts/flip-webserver.sh
+}


### PR DESCRIPTION
the `flip` command allows the users to easily switch between the Nginx
and Apache web servers on their homestead boxes.

it does this by checking if apache is running, and then starting and
stopping the services depending on which is currently running.