### PR TITLE
Apache reload

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -156,4 +156,16 @@ then
 fi
 
 a2dissite 000-default
-service apache2 reload
+
+ps auxw | grep apache2 | grep -v grep > /dev/null
+
+if [ $? == 0 ]
+then
+    service apache2 reload
+else
+    service nginx stop
+    service apache2 start
+    service apache2 reload
+    service apache2 stop
+    service nginx start
+fi


### PR DESCRIPTION
if we try to run `service apache2 reload` with apache not running, we get the fatal error ‘apache2.service is not active, cannot reload.’ and it kills the rest of the provisioning script.

this update first checks if apache is running. if it is, we reload like normal.  if it isn’t, we first turn off nginx, then start apache, then perform the reload, and finally turn nginx back on.

not sure if this is the best way to do this, or if we should just ignore the reload if apache isn't started. open to suggestions.