### PR TITLE
only reload apache if it is active

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -156,4 +156,10 @@ then
 fi
 
 a2dissite 000-default
-service apache2 reload
+
+ps auxw | grep apache2 | grep -v grep > /dev/null
+
+if [ $? == 0 ]
+then
+    service apache2 reload
+fi


### PR DESCRIPTION
the command `service apache2 reload` will cause a fatal error if apache
is not loaded.

this update first checks to see if apache is active, before triggering
the reload