### PR TITLE
Fix "Please use --connect-expired-password option" issue by resetting DB password first.

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -2,4 +2,6 @@
 
 DB=$1;
 
+mysql -uhomestead -psecret --connect-expired-password -e "SET password=PASSWORD('secret')";
+
 mysql -uhomestead -psecret -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci";


### PR DESCRIPTION
Fixes this error that causes the `vagrant up` command to exit:
```
==> default: Please use --connect-expired-password option or invoke mysql in interactive mode.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

The origin of this issue seems to have been uncovered in [this Stack Overflow answer](http://stackoverflow.com/a/40497052/1217620).