### PR TITLE
Updates SSL Certificate Generation

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+mkdir /etc/nginx/ssl 2>/dev/null
+
+PATH_SSL="/etc/nginx/ssl"
+PATH_CNF="${PATH_SSL}/${1}.cnf"
+PATH_KEY="${PATH_SSL}/${1}.key"
+PATH_CRT="${PATH_SSL}/${1}.crt"
+
+# Only generate a certificate if there isn't one already there.
+if [ ! -f $PATH_CNF ] || ! -f $PATH_KEY ] || [ ! -f $PATH_CRT ]
+then
+
+    # Uncomment the global 'copy_extentions' OpenSSL option to ensure the SANs are copied into the certificate.
+    sed -i '/copy_extensions\ =\ copy/s/^#\ //g' /etc/ssl/openssl.cnf
+
+    # Generate an OpenSSL configuration file specifically for this certificate.
+    block="
+        [ req ]
+        prompt = no
+        default_bits = 2048
+        default_keyfile = $PATH_KEY
+        encrypt_key = no
+        default_md = sha256
+        distinguished_name = req_distinguished_name
+        x509_extensions = v3_ca
+
+        [ req_distinguished_name ]
+        O=Vagrant
+        C=UN
+        CN=$1
+
+        [ v3_ca ]
+        basicConstraints=CA:FALSE
+        subjectKeyIdentifier=hash
+        authorityKeyIdentifier=keyid,issuer
+        keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+        subjectAltName = @alternate_names
+
+        [ alternate_names ]
+        DNS.1 = $1
+    "
+    echo "$block" > $PATH_CNF
+
+    # Finally, generate the private key and certificate.
+    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+    openssl req -new -x509 -config "$PATH_CNF" -out "$PATH_CRT" -days 365 2>/dev/null
+fi

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -169,6 +169,14 @@ class Homestead
 
         if settings.include? 'sites'
             settings["sites"].each do |site|
+
+                # Create SSL certificate
+                config.vm.provision "shell" do |s|
+                    s.name = "Creating Certificate: " + site["map"]
+                    s.path = scriptDir + "/create-certificate.sh"
+                    s.args = [site["map"]]
+                end
+
                 type = site["type"] ||= "laravel"
 
                 if (type == "symfony")

--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -4,18 +4,6 @@ apt-get update
 apt-get install -y apache2 libapache2-mod-php7.1
 sed -i "s/www-data/vagrant/" /etc/apache2/envvars
 
-PATH_SSL="/etc/apache2/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
-
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
-then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
-fi
-
 block="<VirtualHost *:80>
     # The ServerName directive sets the request scheme, hostname and port that
     # the server uses to identify itself. This is used when creating

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -1,19 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir /etc/nginx/ssl 2>/dev/null
-
-PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
-
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
-then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
-fi
-
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;

--- a/scripts/serve-proxy.sh
+++ b/scripts/serve-proxy.sh
@@ -1,19 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir /etc/nginx/ssl 2>/dev/null
-
-PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
-
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
-then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
-fi
-
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl;

--- a/scripts/serve-silverstripe.sh
+++ b/scripts/serve-silverstripe.sh
@@ -1,20 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir /etc/nginx/ssl 2>/dev/null
-
-PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
-
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
-then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
-fi
-
-
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;

--- a/scripts/serve-statamic.sh
+++ b/scripts/serve-statamic.sh
@@ -1,19 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir /etc/nginx/ssl 2>/dev/null
-
-PATH_SSL="/etc/nginx/ssl"
-PATH_KEY="${PATH_SSL}/${1}.key"
-PATH_CSR="${PATH_SSL}/${1}.csr"
-PATH_CRT="${PATH_SSL}/${1}.crt"
-
-if [ ! -f $PATH_KEY ] || [ ! -f $PATH_CSR ] || [ ! -f $PATH_CRT ]
-then
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -key "$PATH_KEY" -out "$PATH_CSR" -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-    openssl x509 -req -days 365 -in "$PATH_CSR" -signkey "$PATH_KEY" -out "$PATH_CRT" 2>/dev/null
-fi
-
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-mkdir /etc/nginx/ssl 2>/dev/null
-openssl genrsa -out "/etc/nginx/ssl/$1.key" 2048 2>/dev/null
-openssl req -new -key /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.csr -subj "/CN=$1/O=Vagrant/C=UK" 2>/dev/null
-openssl x509 -req -days 365 -in /etc/nginx/ssl/$1.csr -signkey /etc/nginx/ssl/$1.key -out /etc/nginx/ssl/$1.crt 2>/dev/null
-
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;


### PR DESCRIPTION
This changes a few things regarding SSL certificates and how they’re generated. First, the code to generate a certificate has been removed from each of the `serve-[whatever]` scripts and into it’s own script. The certificate generation code was duplicated 6 times, and in one instance (Symfony2) the checks to see whether or not a certificate was already created weren’t included, like they were in the others. So this change should help prevent things like that from happening again.

Second big change is to the way the certificates are actually generated with OpenSSL. We’re now using an OpenSSL configuration file for each certificate that’s generated. They’re saved along-side the certificates. We’re doing this because the certificates must be generated using the `subjectAltName` property to list domains, and that property can only be added via configuration file. The `subjectAltName` property is the primary property that is used in validating domains. Historically, the CN (commonName) value was used to validate domains (as a fall-back), but apparently this was never to specification and recent browsers are removing that decade long oversight(?)

A small change worth mentioning is the removal of the CSR (Certificate Signing Request). Since these are self-signed certificates, we don’t need to send a request to an authority to have the certificates created. We can just skip that step and create the certificate using the key.

Resolves issue #526 