### PR TITLE
add headless selenium setup for homestead #516

### DIFF
--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -32,3 +32,6 @@ databases:
 #     - send: 7777
 #       to: 777
 #       protocol: udp
+
+# selenium: 
+#       - start-driver: 'yes'

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -293,5 +293,24 @@ class Homestead
                 ]
             end
         end
+
+        # Configure Headless Selenium
+        if settings.has_key?("selenium")
+
+            config.vm.provision "shell" do |s|
+                s.name = "Installing Selenium Dependencies"
+                s.path = scriptDir + "/selenium.sh"
+            end
+
+            # start virtual framebuffer on vagrant up
+            if (settings["selenium"][0]["start-driver"] == "yes")
+                config.vm.provision "shell", run: "always" do |s|
+                    s.name = "Starting Virtual Framebuffer"
+                    s.path = scriptDir + "/start-xvfb.sh"
+                end
+            end
+
+        end
+
     end
 end

--- a/scripts/selenium.sh
+++ b/scripts/selenium.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Bash script to setup headless Selenium for Homestead (uses Xvfb and Chrome)
+# Implemented from https://medium.com/@splatEric/laravel-dusk-on-homestead-dc5711987595#.wkl09lx2x
+
+sudo apt-get update
+sudo apt-get -y install libxpm4 libxrender1 libgtk2.0-0 libnss3 libgconf-2-4
+sudo apt-get -y install chromium-browser
+sudo apt-get -y install xvfb gtk2-engines-pixbuf
+sudo apt-get -y install xfonts-cyrillic xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable
+sudo apt-get -y install imagemagick x11-apps
+
+echo "Dependencies installed."

--- a/scripts/start-xvfb.sh
+++ b/scripts/start-xvfb.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#
+# Runs virtual frame buffer
+
+Xvfb -ac :0 -screen 0 1280x1024x16 &


### PR DESCRIPTION
I stumbled upon #516 when I was trying to get Dusk to work with Homestead and decided to take a whack at it. This pull request adds a headless Selenium setup for Homestead using Chrome and Xvfb. One of the issues brought up was that we don't want the framebuffer process running if the user is not using Dusk. So, I have added a Selenium config to the Homestead.yaml file which allows the user to enable or disable the process on startup.