### PR TITLE
Fix bash typo in create-certificate.sh

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -8,7 +8,7 @@ PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CRT="${PATH_SSL}/${1}.crt"
 
 # Only generate a certificate if there isn't one already there.
-if [ ! -f $PATH_CNF ] || ! -f $PATH_KEY ] || [ ! -f $PATH_CRT ]
+if [ ! -f $PATH_CNF ] || [ ! -f $PATH_KEY ] || [ ! -f $PATH_CRT ]
 then
 
     # Uncomment the global 'copy_extentions' OpenSSL option to ensure the SANs are copied into the certificate.


### PR DESCRIPTION
Without this, typical output for each certificate is:
==> homestead: /tmp/vagrant-shell: line 11: -f: command not found
and existing certificates are regenerated unnecessarily.

(NB: I hope I'm on the right branch, `2.0` seems older)

