### PR TITLE
Fix for apache log dir variable and log file per site

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -30,8 +30,8 @@ block="<VirtualHost *:80>
     # modules, e.g.
     #LogLevel info ssl:warn
 
-    ErrorLog ${APACHE_LOG_DIR}/error.log
-    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    ErrorLog \${APACHE_LOG_DIR}/$1-error.log
+    CustomLog \${APACHE_LOG_DIR}/$1-access.log combined
 
     # For most configuration files from conf-available/, which are
     # enabled or disabled at a global level, it is possible to


### PR DESCRIPTION
Before my changes all logs was placed in root folder and all sites was saved to one file for access log and one for error log.