### PR TITLE
Use full path to Homestead config file

### DIFF
--- a/resources/LocalizedVagrantfile
+++ b/resources/LocalizedVagrantfile
@@ -7,8 +7,8 @@ require 'yaml'
 VAGRANTFILE_API_VERSION ||= "2"
 confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname(__FILE__))
 
-homesteadYamlPath = "Homestead.yaml"
-homesteadJsonPath = "Homestead.json"
+homesteadYamlPath = File.expand_path("Homestead.yaml", File.dirname(__FILE__))
+homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
 aliasesPath = "aliases"
 


### PR DESCRIPTION
This allows us to halt the VM from anywhere on the system.

Otherwise you'll get this:

```bash
$ vagrant halt c67044b
Homestead settings file not found in /Users/driesvints/Sites/laravelio/vendor/laravel/homestead
```