### PR TITLE
Database import/export aliases

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -133,6 +133,14 @@ function __has_pv() {
     return $?
 }
 
+function __pv_install_message() {
+    if ! __has_pv; then
+        echo $1
+        echo "Install pv with \`sudo apt-get install -y pv\` then run this command again."
+        echo ""
+    fi
+}
+
 function dbexport() {
     FILE=${1:-/vagrant/mysqldump.sql.gz}
 
@@ -140,6 +148,8 @@ function dbexport() {
     # It appears that 80% is a good approximation of
     # the ratio of estimated size to actual size
     SIZE_QUERY="select ceil(sum(data_length) * 0.8) as size from information_schema.TABLES"
+
+    __pv_install_message "Want to see export progress?"
 
     echo "Exporting databases to '$FILE'"
 
@@ -158,6 +168,8 @@ function dbexport() {
 
 function dbimport() {
     FILE=${1:-/vagrant/mysqldump.sql.gz}
+
+    __pv_install_message "Want to see import progress?"
 
     echo "Importing databases from '$FILE'"
 

--- a/resources/aliases
+++ b/resources/aliases
@@ -126,3 +126,23 @@ function share() {
 function flip() {
     sudo bash /vagrant/scripts/flip-webserver.sh
 }
+
+function dbexport() {
+    FILE=${1:-/vagrant/mysqldump.sql.gz}
+
+    echo "Exporting databases to '$FILE'"
+
+    mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | gzip > "$FILE"
+
+    echo "Done."
+}
+
+function dbimport() {
+    FILE=${1:-/vagrant/mysqldump.sql.gz}
+
+    echo "Importing databases from '$FILE'"
+
+    cat "$FILE" | zcat | mysql -uhomestead -psecret 2>/dev/null
+
+    echo "Done."
+}

--- a/resources/aliases
+++ b/resources/aliases
@@ -136,10 +136,19 @@ function __has_pv() {
 function dbexport() {
     FILE=${1:-/vagrant/mysqldump.sql.gz}
 
+    # This gives an estimate of the size of the SQL file
+    # It appears that 80% is a good approximation of
+    # the ratio of estimated size to actual size
+    SIZE_QUERY="select ceil(sum(data_length) * 0.8) as size from information_schema.TABLES"
+
     echo "Exporting databases to '$FILE'"
 
     if __has_pv; then
-        mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | pv | gzip > "$FILE"
+        ADJUSTED_SIZE=$(mysql --vertical -uhomestead -psecret -e "$SIZE_QUERY" 2>/dev/null | grep 'size' | awk '{print $2}')
+        HUMAN_READABLE_SIZE=$(numfmt --to=iec-i --suffix=B --format="%.3f" $ADJUSTED_SIZE)
+
+        echo "Estimated uncompressed size: $HUMAN_READABLE_SIZE"
+        mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | pv  --size=$ADJUSTED_SIZE | gzip > "$FILE"
     else
         mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | gzip > "$FILE"
     fi

--- a/resources/aliases
+++ b/resources/aliases
@@ -127,12 +127,22 @@ function flip() {
     sudo bash /vagrant/scripts/flip-webserver.sh
 }
 
+function __has_pv() {
+    $(hash pv 2>/dev/null);
+    
+    return $?
+}
+
 function dbexport() {
     FILE=${1:-/vagrant/mysqldump.sql.gz}
 
     echo "Exporting databases to '$FILE'"
 
-    mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | gzip > "$FILE"
+    if __has_pv; then
+        mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | pv | gzip > "$FILE"
+    else
+        mysqldump -uhomestead -psecret --all-databases --skip-lock-tables 2>/dev/null | gzip > "$FILE"
+    fi
 
     echo "Done."
 }
@@ -142,7 +152,11 @@ function dbimport() {
 
     echo "Importing databases from '$FILE'"
 
-    cat "$FILE" | zcat | mysql -uhomestead -psecret 2>/dev/null
+    if __has_pv; then
+        pv "$FILE" --progress --eta | zcat | mysql -uhomestead -psecret 2>/dev/null
+    else
+        cat "$FILE" | zcat | mysql -uhomestead -psecret 2>/dev/null
+    fi
 
     echo "Done."
 }


### PR DESCRIPTION
I've added two commands to handle importing / exporting all databases from ones homestead virtual machine.

## Commands
### dbexport [file]

This exports a compressed dump of all databases to the given file.
If no file is given then `/vagrant/mysqldump.sql.gz` is assumed.

### dbimport [file]

This imports a compressed dump from the given file.
If no file is given then `/vagrant/mysqldump.sql.gz` is assumed.

## Progress reporting

I've also added support for optional progress reporting if you have the program `pv` installed. If not you can install it via `sudo apt-get install -y pv`. The commands output a note when running them about `pv` support like so:

### Installation Note
```
Want to see export progress?
Install pv with `sudo apt-get install -y pv` then run this command again.

Exporting databases to '/vagrant/mysqldump.sql.gz'
```

### During import
```
Importing databases from '/vagrant/mysqldump.sql.gz'
[=======>                                                      ]  10% ETA 0:05:37
```

### During export
```
Exporting databases to '/vagrant/mysqldump.sql.gz'
Estimated uncompressed size: 2.642GiB
63.6MiB 0:00:03 [24.1MiB/s] [=>                                ]  2% ETA 0:01:41
```
## Notes

- This would be rather useful when destroying the homestead machine if you have databases which have dummy or in progress data which may be non-trivial to recreate.
- The `/vagrant` directory is used as a default as it will persist even after destroying the machine since it is a shared folder.
- It would be kinda awesome to have `pv` installed by default in the homestead box.
