### PR TITLE
Adds alias for php-cli with xdebug and auto remote connect

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -182,7 +182,7 @@ function dbimport() {
     echo "Done."
 }
 
-function xdebug() {
+function xphp() {
     (php -m | grep -q xdebug)
     if [[ $? -eq 0 ]]
     then

--- a/resources/aliases
+++ b/resources/aliases
@@ -181,3 +181,22 @@ function dbimport() {
 
     echo "Done."
 }
+
+function xdebug() {
+    (php -m | grep -q xdebug)
+    if [[ $? -eq 0 ]]
+    then
+        XDEBUG_ENABLED=true
+    else
+        XDEBUG_ENABLED=false
+    fi
+
+    if ! $XDEBUG_ENABLED; then xon; fi
+
+    php \
+        -dxdebug.remote_host=10.0.2.2 \
+        -dxdebug.remote_autostart=1 \
+        "$@"
+
+    if ! $XDEBUG_ENABLED; then xoff; fi
+}

--- a/resources/aliases
+++ b/resources/aliases
@@ -194,7 +194,7 @@ function xdebug() {
     if ! $XDEBUG_ENABLED; then xon; fi
 
     php \
-        -dxdebug.remote_host=10.0.2.2 \
+        -dxdebug.remote_host=192.168.10.1 \
         -dxdebug.remote_autostart=1 \
         "$@"
 


### PR DESCRIPTION
Following on from #544:

The problem is that out-the-box homestead 5.2.1 & box 2.1.0 do not configure xdebug on the cli to automatically connect to a remote xdebug server (listening in PHPStorm for example). It took me some time and research to figure out how to get this working. 

In the spirit of Laravel this PR should save users the headache by providing a simple command for running a php script on the cli (artisan for example) with xdebug configured to automatically connect back to a listening xdebug server with the default settings. I have used the bridge gateway IP (192.168.10.1) so hopefully this will work across all providers (I have tested with Virtualbox).

As mentioned this works with PHPStorm 2017.1 with default settings, simply toggling on the _Start listening for PHP Debug connections_ option.

Example use would be:

`xdebug artisan foo:bar`
