### PR TITLE
Fixed issue with the new vagrant 1.9.3

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -87,7 +87,7 @@ class Homestead
         unless settings.has_key?("default_ports") && settings["default_ports"] == false
             default_ports.each do |guest, host|
                 unless settings["ports"].any? { |mapping| mapping["guest"] == guest }
-                    config.vm.network "forwarded_port", guest: guest, host: host, auto_correct: true
+                    config.vm.network "forwarded_port", guest: guest, host: host, host_ip: "127.0.0.1", auto_correct: true
                 end
             end
         end
@@ -95,7 +95,7 @@ class Homestead
         # Add Custom Ports From Configuration
         if settings.has_key?("ports")
             settings["ports"].each do |port|
-                config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"], auto_correct: true
+                config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], protocol: port["protocol"], host_ip: "127.0.0.1", auto_correct: true
             end
         end
 


### PR DESCRIPTION
vagrant up not working - Errno::EADDRNOTAVAIL. Fixed the issue by adding host_ip: "127.0.0.1" parameter for each of the "forwarded_port" network configuration.