### PR TITLE
Update aliases and after options

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -52,8 +52,8 @@ class MakeCommand extends Command
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The name of the virtual machine.', $this->defaultName)
             ->addOption('hostname', null, InputOption::VALUE_OPTIONAL, 'The hostname of the virtual machine.', $this->defaultName)
             ->addOption('ip', null, InputOption::VALUE_OPTIONAL, 'The IP address of the virtual machine.')
-            ->addOption('after', null, InputOption::VALUE_NONE, 'Determines if the after.sh file is created.')
-            ->addOption('aliases', null, InputOption::VALUE_NONE, 'Determines if the aliases file is created.')
+            ->addOption('no-after', null, InputOption::VALUE_NONE, 'Determines if the after.sh file is not created.')
+            ->addOption('no-aliases', null, InputOption::VALUE_NONE, 'Determines if the aliases file is not created.')
             ->addOption('example', null, InputOption::VALUE_NONE, 'Determines if a Homestead example file is created.')
             ->addOption('json', null, InputOption::VALUE_NONE, 'Determines if the Homestead settings file will be in json format.');
     }
@@ -71,11 +71,11 @@ class MakeCommand extends Command
             $this->createVagrantfile();
         }
 
-        if ($input->getOption('aliases') && ! $this->aliasesFileExists()) {
+        if (! $input->getOption('no-aliases') && ! $this->aliasesFileExists()) {
             $this->createAliasesFile();
         }
 
-        if ($input->getOption('after') && ! $this->afterShellScriptExists()) {
+        if (! $input->getOption('no-after') && ! $this->afterShellScriptExists()) {
             $this->createAfterShellScript();
         }
 

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -67,13 +67,11 @@ class MakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function an_aliases_file_is_created_if_requested()
+    public function an_aliases_file_is_created_by_default()
     {
         $tester = new CommandTester(new MakeCommand());
 
-        $tester->execute([
-            '--aliases' => true,
-        ]);
+        $tester->execute([]);
 
         $this->assertTrue(
             file_exists(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases')
@@ -93,9 +91,7 @@ class MakeCommandTest extends TestCase
         );
         $tester = new CommandTester(new MakeCommand());
 
-        $tester->execute([
-            '--aliases' => true,
-        ]);
+        $tester->execute([]);
 
         $this->assertTrue(
             file_exists(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases')
@@ -107,13 +103,25 @@ class MakeCommandTest extends TestCase
     }
 
     /** @test */
-    public function an_after_shell_script_is_created_if_requested()
+    public function an_aliases_file_is_not_created_if_it_is_explicitly_told_to()
     {
         $tester = new CommandTester(new MakeCommand());
 
         $tester->execute([
-            '--after' => true,
+            '--no-aliases' => true,
         ]);
+
+        $this->assertFalse(
+            file_exists(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases')
+        );
+    }
+
+    /** @test */
+    public function an_after_shell_script_is_created_by_default()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
 
         $this->assertTrue(
             file_exists(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh')
@@ -133,9 +141,7 @@ class MakeCommandTest extends TestCase
         );
         $tester = new CommandTester(new MakeCommand());
 
-        $tester->execute([
-            '--after' => true,
-        ]);
+        $tester->execute([]);
 
         $this->assertTrue(
             file_exists(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh')
@@ -143,6 +149,20 @@ class MakeCommandTest extends TestCase
         $this->assertEquals(
             'Already existing after.sh',
             file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh')
+        );
+    }
+
+    /** @test */
+    public function an_after_file_is_not_created_if_it_is_explicitly_told_to()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--no-after' => true,
+        ]);
+
+        $this->assertFalse(
+            file_exists(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh')
         );
     }
 


### PR DESCRIPTION
As requested in #559

* The Homestead make command should always copy aliases and after.sh if it doesn't exist. It should never overwrite already existing files.
* The Homestead make option for aliases should be changed to --no-aliases and not copy the file aliases if used
* The Homestead make option for after should be changed to --no-after and not copy the file after.sh if used