### PR TITLE
add Symfony4 nginx configuration

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -116,6 +116,19 @@ function serve-symfony2() {
     fi
 }
 
+function serve-symfony4() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/scripts/serve-symfony4.sh
+        sudo bash /vagrant/scripts/serve-symfony4.sh "$1" "$2" 80
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-symfony4 domain path"
+    fi
+}
+
 function share() {
     if [[ "$1" ]]
     then
@@ -124,7 +137,7 @@ function share() {
         echo "Error: missing required parameters."
         echo "Usage: "
         echo "  share domain"
-        echo "Invocation with extra params passed directly to ngrok" 
+        echo "Invocation with extra params passed directly to ngrok"
         echo "  share domain -region=eu -subdomain=test1234"
     fi
 }
@@ -135,7 +148,7 @@ function flip() {
 
 function __has_pv() {
     $(hash pv 2>/dev/null);
-    
+
     return $?
 }
 

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -116,6 +116,19 @@ function serve-symfony2() {
     fi
 }
 
+function serve-symfony4() {
+    if [[ "$1" && "$2" ]]
+    then
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
+        sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh "$1" "$2" 80
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  serve-symfony4 domain path"
+    fi
+}
+
 function share() {
     if [[ "$1" ]]
     then

--- a/scripts/serve-symfony4.sh
+++ b/scripts/serve-symfony4.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+block="server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name $1;
+    root \"$2\";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    location / {
+        try_files \$uri \$uri/ /index.php?\$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/$1-ssl-error.log error;
+
+    sendfile off;
+
+    client_max_body_size 100m;
+
+    # DEV
+    location ~ ^/index\.php(/|\$) {
+        fastcgi_split_path_info ^(.+\.php)(/.*)\$;
+        fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate_key /etc/nginx/ssl/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"


### PR DESCRIPTION
Symfony 4 and Symfony 3.3 use a single front controller script index.php instead of the app.php and app_dev.php. This PR alters the Symfony 2 configuration for use with Symfony 4. A single location block is needed as the .env file controls the environment dev versus prod. 

http://flexrecipes.org/recipes/symfony/framework-bundle
https://github.com/symfony/recipes/tree/master/symfony/framework-bundle/3.3/web