### PR TITLE
✨ 💡 Do not use the `Code` subfolder in vagrant, should use top level

### DIFF
--- a/src/Settings/HomesteadSettings.php
+++ b/src/Settings/HomesteadSettings.php
@@ -102,7 +102,7 @@ abstract class HomesteadSettings
     {
         $site = [
             'map' => "{$projectName}.app",
-            'to' => "/home/vagrant/Code/{$projectDirectory}/public",
+            'to' => "/home/vagrant/{$projectDirectory}/public",
         ];
 
         if (isset($this->attributes['sites']) && ! empty($this->attributes['sites'])) {
@@ -131,7 +131,7 @@ abstract class HomesteadSettings
     {
         $folder = [
             'map' => $projectPath,
-            'to' => "/home/vagrant/Code/{$projectDirectory}",
+            'to' => "/home/vagrant/{$projectDirectory}",
         ];
 
         $this->update(['folders' => [$folder]]);

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -437,7 +437,7 @@ class MakeCommandTest extends TestCase
 
         $this->assertEquals([
             'map' => "{$projectDirectory}.app",
-            'to' => "/home/vagrant/Code/{$projectName}/public",
+            'to' => "/home/vagrant/{$projectName}/public",
         ], $settings['sites'][0]);
     }
 
@@ -458,7 +458,7 @@ class MakeCommandTest extends TestCase
 
         $this->assertEquals([
             'map' => "{$projectDirectory}.app",
-            'to' => "/home/vagrant/Code/{$projectName}/public",
+            'to' => "/home/vagrant/{$projectName}/public",
         ], $settings['sites'][0]);
     }
 
@@ -485,7 +485,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals("/home/vagrant/Code/{$projectName}", $settings['folders'][0]['to']);
+        $this->assertEquals("/home/vagrant/{$projectName}", $settings['folders'][0]['to']);
     }
 
     /** @test */
@@ -513,7 +513,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals("/home/vagrant/Code/{$projectName}", $settings['folders'][0]['to']);
+        $this->assertEquals("/home/vagrant/{$projectName}", $settings['folders'][0]['to']);
     }
 
     /** @test */

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -122,7 +122,7 @@ class JsonSettingsTest extends TestCase
             'sites' => [
                 [
                     'map' => 'homestead.app',
-                    'to' => '/home/vagrant/Code/Laravel/public',
+                    'to' => '/home/vagrant/Laravel/public',
                     'type' => 'laravel',
                     'schedule' => true,
                 ],
@@ -134,7 +134,7 @@ class JsonSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => 'test.com.app',
-            'to' => '/home/vagrant/Code/test-com/public',
+            'to' => '/home/vagrant/test-com/public',
             'type' => 'laravel',
             'schedule' => true,
         ], $attributes['sites'][0]);
@@ -146,7 +146,7 @@ class JsonSettingsTest extends TestCase
         $settings = new JsonSettings([
             'folders' => [
                 'map' => '~/Code',
-                'to' => '/home/vagrant/Code',
+                'to' => '/home/vagrant/',
             ],
         ]);
 
@@ -155,7 +155,7 @@ class JsonSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => '/a/path/for/project_name',
-            'to' => '/home/vagrant/Code/project_name',
+            'to' => '/home/vagrant/project_name',
         ], $attributes['folders'][0]);
     }
 }

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -123,7 +123,7 @@ class YamlSettingsTest extends TestCase
             'sites' => [
                 [
                     'map' => 'homestead.app',
-                    'to' => '/home/vagrant/Code/Laravel/public',
+                    'to' => '/home/vagrant/Laravel/public',
                     'type' => 'laravel',
                     'schedule' => true,
                 ],
@@ -135,7 +135,7 @@ class YamlSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => 'test.com.app',
-            'to' => '/home/vagrant/Code/test-com/public',
+            'to' => '/home/vagrant/test-com/public',
             'type' => 'laravel',
             'schedule' => true,
         ], $attributes['sites'][0]);
@@ -147,7 +147,7 @@ class YamlSettingsTest extends TestCase
         $settings = new YamlSettings([
             'folders' => [
                 'map' => '~/Code',
-                'to' => '/home/vagrant/Code',
+                'to' => '/home/vagrant',
             ],
         ]);
 
@@ -156,7 +156,7 @@ class YamlSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => '/a/path/for/project_name',
-            'to' => '/home/vagrant/Code/project_name',
+            'to' => '/home/vagrant/project_name',
         ], $attributes['folders'][0]);
     }
 }


### PR DESCRIPTION
There is no reason to add another folder inside vagrant that we map our projects to. This change will eliminate sites being placed in `/home/vagrant/Code/` and place them in `/home/vagrant/`

/cc @DojoGeekRA 