### PR TITLE
Fix npm problems for windows users

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -39,6 +39,7 @@ class Homestead
             if settings.has_key?("gui") && settings["gui"]
                 vb.gui = true
             end
+            vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
         end
 
         # Configure A Few VMware Settings


### PR DESCRIPTION
Fix symlinks problem for windows user so they don't have to use `--no-bin-links` evertime they use `npm`.