### PR TITLE
❄️ 🚑 ✅ Make command should respect Homestead config example file

### DIFF
--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -202,13 +202,13 @@ class MakeCommand extends Command
 
         if (! $this->exampleSettingsExists($format)) {
             $settings->updateName($options['name'])
-                     ->updateHostname($options['hostname']);
+                ->updateHostname($options['hostname']);
         }
 
         $settings->updateIpAddress($options['ip'])
-                 ->configureSites($this->projectName, $this->defaultName)
-                 ->configureSharedFolders($this->basePath, $this->defaultName)
-                 ->save("{$this->basePath}/Homestead.{$format}");
+            ->configureSites($this->projectName, $this->defaultName)
+            ->configureSharedFolders($this->basePath, $this->defaultName)
+            ->save("{$this->basePath}/Homestead.{$format}");
     }
 
     /**

--- a/src/Settings/HomesteadSettings.php
+++ b/src/Settings/HomesteadSettings.php
@@ -14,7 +14,7 @@ abstract class HomesteadSettings
     /**
      * JsonSettings constructor.
      *
-     * @param  array $attributes
+     * @param  array  $attributes
      */
     public function __construct($attributes)
     {
@@ -24,7 +24,7 @@ abstract class HomesteadSettings
     /**
      * Create an instance from a file.
      *
-     * @param  string $filename
+     * @param  string  $filename
      * @return static
      */
     abstract public static function fromFile($filename);
@@ -32,7 +32,7 @@ abstract class HomesteadSettings
     /**
      * Save the homestead settings.
      *
-     * @param  string $filename
+     * @param  string  $filename
      * @return void
      */
     abstract public function save($filename);
@@ -40,7 +40,7 @@ abstract class HomesteadSettings
     /**
      * Update the homestead settings.
      *
-     * @param  array $attributes
+     * @param  array  $attributes
      * @return static
      */
     public function update($attributes)
@@ -55,7 +55,7 @@ abstract class HomesteadSettings
     /**
      * Update the virtual machine's name.
      *
-     * @param  string $name
+     * @param  string  $name
      * @return static
      */
     public function updateName($name)
@@ -68,7 +68,7 @@ abstract class HomesteadSettings
     /**
      * Update the virtual machine's hostname.
      *
-     * @param  string $hostname
+     * @param  string  $hostname
      * @return static
      */
     public function updateHostname($hostname)
@@ -81,7 +81,7 @@ abstract class HomesteadSettings
     /**
      * Update the virtual machine's IP address.
      *
-     * @param  string $ip
+     * @param  string  $ip
      * @return static
      */
     public function updateIpAddress($ip)
@@ -94,8 +94,8 @@ abstract class HomesteadSettings
     /**
      * Configure the nginx sites.
      *
-     * @param  string $projectName
-     * @param  string $projectDirectory
+     * @param  string  $projectName
+     * @param  string  $projectDirectory
      * @return static
      */
     public function configureSites($projectName, $projectDirectory)
@@ -139,8 +139,8 @@ abstract class HomesteadSettings
     /**
      * Configure the shared folders.
      *
-     * @param  string $projectPath
-     * @param  string $projectDirectory
+     * @param  string  $projectPath
+     * @param  string  $projectDirectory
      * @return static
      */
     public function configureSharedFolders($projectPath, $projectDirectory)

--- a/src/Settings/HomesteadSettings.php
+++ b/src/Settings/HomesteadSettings.php
@@ -46,7 +46,7 @@ abstract class HomesteadSettings
     public function update($attributes)
     {
         $this->attributes = array_merge($this->attributes, array_filter($attributes, function ($attribute) {
-            return !is_null($attribute);
+            return ! is_null($attribute);
         }));
 
         return $this;
@@ -104,10 +104,10 @@ abstract class HomesteadSettings
             [
                 'map' => "{$projectName}.app",
                 'to' => "/home/vagrant/{$projectDirectory}/public",
-            ]
+            ],
         ];
 
-        if (isset($this->attributes['sites']) && !empty($this->attributes['sites'])) {
+        if (isset($this->attributes['sites']) && ! empty($this->attributes['sites'])) {
             foreach ($this->attributes['sites'] as $index => $user_site) {
                 if (isset($user_site['map'])) {
                     $sites[$index]['map'] = $user_site['map'];
@@ -149,10 +149,10 @@ abstract class HomesteadSettings
             [
                 'map' => $projectPath,
                 'to' => "/home/vagrant/{$projectDirectory}",
-            ]
+            ],
         ];
 
-        if (isset($this->attributes['folders']) && !empty($this->attributes['folders'])) {
+        if (isset($this->attributes['folders']) && ! empty($this->attributes['folders'])) {
             foreach ($this->attributes['folders'] as $index => $user_folder) {
                 if (isset($user_folder['to'])) {
                     $folders[$index]['to'] = $user_folder['to'];

--- a/src/Settings/HomesteadSettings.php
+++ b/src/Settings/HomesteadSettings.php
@@ -14,7 +14,7 @@ abstract class HomesteadSettings
     /**
      * JsonSettings constructor.
      *
-     * @param  array  $attributes
+     * @param  array $attributes
      */
     public function __construct($attributes)
     {
@@ -24,7 +24,7 @@ abstract class HomesteadSettings
     /**
      * Create an instance from a file.
      *
-     * @param  string  $filename
+     * @param  string $filename
      * @return static
      */
     abstract public static function fromFile($filename);
@@ -32,7 +32,7 @@ abstract class HomesteadSettings
     /**
      * Save the homestead settings.
      *
-     * @param  string  $filename
+     * @param  string $filename
      * @return void
      */
     abstract public function save($filename);
@@ -40,13 +40,13 @@ abstract class HomesteadSettings
     /**
      * Update the homestead settings.
      *
-     * @param  array  $attributes
+     * @param  array $attributes
      * @return static
      */
     public function update($attributes)
     {
         $this->attributes = array_merge($this->attributes, array_filter($attributes, function ($attribute) {
-            return ! is_null($attribute);
+            return !is_null($attribute);
         }));
 
         return $this;
@@ -55,7 +55,7 @@ abstract class HomesteadSettings
     /**
      * Update the virtual machine's name.
      *
-     * @param  string  $name
+     * @param  string $name
      * @return static
      */
     public function updateName($name)
@@ -68,7 +68,7 @@ abstract class HomesteadSettings
     /**
      * Update the virtual machine's hostname.
      *
-     * @param  string  $hostname
+     * @param  string $hostname
      * @return static
      */
     public function updateHostname($hostname)
@@ -81,7 +81,7 @@ abstract class HomesteadSettings
     /**
      * Update the virtual machine's IP address.
      *
-     * @param  string  $ip
+     * @param  string $ip
      * @return static
      */
     public function updateIpAddress($ip)
@@ -94,28 +94,44 @@ abstract class HomesteadSettings
     /**
      * Configure the nginx sites.
      *
-     * @param  string  $projectName
-     * @param  string  $projectDirectory
+     * @param  string $projectName
+     * @param  string $projectDirectory
      * @return static
      */
     public function configureSites($projectName, $projectDirectory)
     {
-        $site = [
-            'map' => "{$projectName}.app",
-            'to' => "/home/vagrant/{$projectDirectory}/public",
+        $sites = [
+            [
+                'map' => "{$projectName}.app",
+                'to' => "/home/vagrant/{$projectDirectory}/public",
+            ]
         ];
 
-        if (isset($this->attributes['sites']) && ! empty($this->attributes['sites'])) {
-            if (isset($this->attributes['sites'][0]['type'])) {
-                $site['type'] = $this->attributes['sites'][0]['type'];
-            }
+        if (isset($this->attributes['sites']) && !empty($this->attributes['sites'])) {
+            foreach ($this->attributes['sites'] as $index => $user_site) {
+                if (isset($user_site['map'])) {
+                    $sites[$index]['map'] = $user_site['map'];
+                }
 
-            if (isset($this->attributes['sites'][0]['schedule'])) {
-                $site['schedule'] = $this->attributes['sites'][0]['schedule'];
+                if (isset($user_site['to'])) {
+                    $sites[$index]['to'] = $user_site['to'];
+                }
+
+                if (isset($user_site['type'])) {
+                    $sites[$index]['type'] = $user_site['type'];
+                }
+
+                if (isset($user_site['schedule'])) {
+                    $sites[$index]['schedule'] = $user_site['schedule'];
+                }
+
+                if (isset($user_site['php'])) {
+                    $sites[$index]['php'] = $user_site['php'];
+                }
             }
         }
 
-        $this->update(['sites' => [$site]]);
+        $this->update(['sites' => $sites]);
 
         return $this;
     }
@@ -123,18 +139,32 @@ abstract class HomesteadSettings
     /**
      * Configure the shared folders.
      *
-     * @param  string  $projectPath
-     * @param  string  $projectDirectory
+     * @param  string $projectPath
+     * @param  string $projectDirectory
      * @return static
      */
     public function configureSharedFolders($projectPath, $projectDirectory)
     {
-        $folder = [
-            'map' => $projectPath,
-            'to' => "/home/vagrant/{$projectDirectory}",
+        $folders = [
+            [
+                'map' => $projectPath,
+                'to' => "/home/vagrant/{$projectDirectory}",
+            ]
         ];
 
-        $this->update(['folders' => [$folder]]);
+        if (isset($this->attributes['folders']) && !empty($this->attributes['folders'])) {
+            foreach ($this->attributes['folders'] as $index => $user_folder) {
+                if (isset($user_folder['to'])) {
+                    $folders[$index]['to'] = $user_folder['to'];
+                }
+
+                if (isset($user_folder['type'])) {
+                    $folders[$index]['type'] = $user_folder['type'];
+                }
+            }
+        }
+
+        $this->update(['folders' => $folders]);
 
         return $this;
     }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests;
 
-use Laravel\Homestead\Settings\JsonSettings;
 use Symfony\Component\Yaml\Yaml;
 use Laravel\Homestead\MakeCommand;
 use Tests\Traits\GeneratesTestDirectory;
@@ -435,8 +434,8 @@ class MakeCommandTest extends TestCase
         $settings = Yaml::parse(file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.yaml'));
 
         $this->assertEquals([
-            'map' => "homestead.app",
-            'to' => "/home/vagrant/Code/Laravel/public",
+            'map' => 'homestead.app',
+            'to' => '/home/vagrant/Code/Laravel/public',
         ], $settings['sites'][0]);
     }
 
@@ -454,8 +453,8 @@ class MakeCommandTest extends TestCase
         $settings = json_decode(file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.json'), true);
 
         $this->assertEquals([
-            'map' => "homestead.app",
-            'to' => "/home/vagrant/Code/Laravel/public",
+            'map' => 'homestead.app',
+            'to' => '/home/vagrant/Code/Laravel/public',
         ], $settings['sites'][0]);
     }
 
@@ -482,7 +481,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals("/home/vagrant/Code", $settings['folders'][0]['to']);
+        $this->assertEquals('/home/vagrant/Code', $settings['folders'][0]['to']);
         $this->assertEquals($projectName, $settings['name']);
         $this->assertEquals($projectName, $settings['hostname']);
     }
@@ -512,7 +511,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals("/home/vagrant/Code", $settings['folders'][0]['to']);
+        $this->assertEquals('/home/vagrant/Code', $settings['folders'][0]['to']);
         $this->assertEquals($projectName, $settings['name']);
         $this->assertEquals($projectName, $settings['hostname']);
     }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Laravel\Homestead\Settings\JsonSettings;
 use Symfony\Component\Yaml\Yaml;
 use Laravel\Homestead\MakeCommand;
 use Tests\Traits\GeneratesTestDirectory;
@@ -431,13 +432,11 @@ class MakeCommandTest extends TestCase
 
         $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.yaml');
 
-        $projectDirectory = basename(getcwd());
-        $projectName = $this->slug($projectDirectory);
         $settings = Yaml::parse(file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.yaml'));
 
         $this->assertEquals([
-            'map' => "{$projectDirectory}.app",
-            'to' => "/home/vagrant/{$projectName}/public",
+            'map' => "homestead.app",
+            'to' => "/home/vagrant/Code/Laravel/public",
         ], $settings['sites'][0]);
     }
 
@@ -452,13 +451,11 @@ class MakeCommandTest extends TestCase
 
         $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.json');
 
-        $projectDirectory = basename(getcwd());
-        $projectName = $this->slug($projectDirectory);
         $settings = json_decode(file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.json'), true);
 
         $this->assertEquals([
-            'map' => "{$projectDirectory}.app",
-            'to' => "/home/vagrant/{$projectName}/public",
+            'map' => "homestead.app",
+            'to' => "/home/vagrant/Code/Laravel/public",
         ], $settings['sites'][0]);
     }
 
@@ -485,7 +482,9 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals("/home/vagrant/{$projectName}", $settings['folders'][0]['to']);
+        $this->assertEquals("/home/vagrant/Code", $settings['folders'][0]['to']);
+        $this->assertEquals($projectName, $settings['name']);
+        $this->assertEquals($projectName, $settings['hostname']);
     }
 
     /** @test */
@@ -513,7 +512,9 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals("/home/vagrant/{$projectName}", $settings['folders'][0]['to']);
+        $this->assertEquals("/home/vagrant/Code", $settings['folders'][0]['to']);
+        $this->assertEquals($projectName, $settings['name']);
+        $this->assertEquals($projectName, $settings['hostname']);
     }
 
     /** @test */

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -116,7 +116,7 @@ class JsonSettingsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_configure_its_sites()
+    public function it_can_configure_its_sites_from_existing_settings()
     {
         $settings = new JsonSettings([
             'sites' => [
@@ -125,6 +125,7 @@ class JsonSettingsTest extends TestCase
                     'to' => '/home/vagrant/Laravel/public',
                     'type' => 'laravel',
                     'schedule' => true,
+                    'php' => '5.6',
                 ],
             ],
         ]);
@@ -133,10 +134,24 @@ class JsonSettingsTest extends TestCase
 
         $attributes = $settings->toArray();
         $this->assertEquals([
-            'map' => 'test.com.app',
-            'to' => '/home/vagrant/test-com/public',
+            'map' => 'homestead.app',
+            'to' => '/home/vagrant/Laravel/public',
             'type' => 'laravel',
             'schedule' => true,
+            'php' => '5.6',
+        ], $attributes['sites'][0]);
+    }
+
+    /** @test */
+    public function it_can_configure_its_sites_from_empty_settings()
+    {
+        $settings = new JsonSettings([]);
+        $settings->configureSites('test.com', 'test-com');
+
+        $attributes = $settings->toArray();
+        $this->assertEquals([
+            'map' => 'test.com.app',
+            'to' => '/home/vagrant/test-com/public',
         ], $attributes['sites'][0]);
     }
 

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -156,14 +156,32 @@ class JsonSettingsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_configure_its_shared_folders()
+    public function it_can_configure_its_shared_folders_from_existing_settings()
     {
         $settings = new JsonSettings([
             'folders' => [
-                'map' => '~/Code',
-                'to' => '/home/vagrant/',
+                [
+                    'map' => '~/Code',
+                    'to' => '/home/vagrant/Code',
+                    'type' => 'nfs',
+                ],
             ],
         ]);
+
+        $settings->configureSharedFolders('/a/path/for/project_name', 'project_name');
+
+        $attributes = $settings->toArray();
+        $this->assertEquals([
+            'map' => '/a/path/for/project_name',
+            'to' => '/home/vagrant/Code',
+            'type' => 'nfs',
+        ], $attributes['folders'][0]);
+    }
+
+    /** @test */
+    public function it_can_configure_its_shared_folders_from_empty_settings()
+    {
+        $settings = new JsonSettings([]);
 
         $settings->configureSharedFolders('/a/path/for/project_name', 'project_name');
 

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -117,8 +117,8 @@ class YamlSettingsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_configure_its_sites()
-    {
+    public function it_can_configure_its_sites_from_existing_settings()
+        {
         $settings = new YamlSettings([
             'sites' => [
                 [
@@ -126,6 +126,7 @@ class YamlSettingsTest extends TestCase
                     'to' => '/home/vagrant/Laravel/public',
                     'type' => 'laravel',
                     'schedule' => true,
+                    'php' => '5.6',
                 ],
             ],
         ]);
@@ -134,10 +135,24 @@ class YamlSettingsTest extends TestCase
 
         $attributes = $settings->toArray();
         $this->assertEquals([
-            'map' => 'test.com.app',
-            'to' => '/home/vagrant/test-com/public',
+            'map' => 'homestead.app',
+            'to' => '/home/vagrant/Laravel/public',
             'type' => 'laravel',
             'schedule' => true,
+            'php' => '5.6',
+        ], $attributes['sites'][0]);
+    }
+
+    /** @test */
+    public function it_can_configure_its_sites_from_empty_settings()
+    {
+        $settings = new YamlSettings([]);
+        $settings->configureSites('test.com', 'test-com');
+
+        $attributes = $settings->toArray();
+        $this->assertEquals([
+            'map' => 'test.com.app',
+            'to' => '/home/vagrant/test-com/public',
         ], $attributes['sites'][0]);
     }
 

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -157,14 +157,32 @@ class YamlSettingsTest extends TestCase
     }
 
     /** @test */
-    public function it_can_configure_its_shared_folders()
+    public function it_can_configure_its_shared_folders_from_existing_settings()
     {
         $settings = new YamlSettings([
             'folders' => [
-                'map' => '~/Code',
-                'to' => '/home/vagrant',
+                [
+                    'map' => '~/Code',
+                    'to' => '/home/vagrant/Code',
+                    'type' => 'nfs',
+                ],
             ],
         ]);
+
+        $settings->configureSharedFolders('/a/path/for/project_name', 'project_name');
+
+        $attributes = $settings->toArray();
+        $this->assertEquals([
+            'map' => '/a/path/for/project_name',
+            'to' => '/home/vagrant/Code',
+            'type' => 'nfs',
+        ], $attributes['folders'][0]);
+    }
+
+    /** @test */
+    public function it_can_configure_its_shared_folders_from_empty_settings()
+    {
+        $settings = new YamlSettings([]);
 
         $settings->configureSharedFolders('/a/path/for/project_name', 'project_name');
 

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -118,7 +118,7 @@ class YamlSettingsTest extends TestCase
 
     /** @test */
     public function it_can_configure_its_sites_from_existing_settings()
-        {
+    {
         $settings = new YamlSettings([
             'sites' => [
                 [


### PR DESCRIPTION
The make command should now correctly copy over all site options and folder options from an existing example file.


@DojoGeekRA Can I get you to have a look at this. A few of the tests changed because we're paying more attention to the example file VS default config.

/cc @dtirer