### PR TITLE
🚑 Fixing site params not being read correctly from serve scripts

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
     for element in "${!params[@]}"
     do
         paramsTXT="${paramsTXT}

--- a/scripts/serve-elgg.sh
+++ b/scripts/serve-elgg.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}

--- a/scripts/serve-silverstripe.sh
+++ b/scripts/serve-silverstripe.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}

--- a/scripts/serve-spa.sh
+++ b/scripts/serve-spa.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}

--- a/scripts/serve-statamic.sh
+++ b/scripts/serve-statamic.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-declare -A params=$5     # Create an associative array
+declare -A params=$6     # Create an associative array
 paramsTXT=""
-if [ -n "$5" ]; then
+if [ -n "$6" ]; then
     for element in "${!params[@]}"
     do
         paramsTXT="${paramsTXT}


### PR DESCRIPTION
While debugging #625 I noticed params weren't being set correctly because we added the php version to the site params bumping the params to $6 instead of $5