### PR TITLE
allow serve functions to specify a php version

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -31,7 +31,7 @@ function serve-apache() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-apache.sh
-        sudo bash /vagrant/scripts/serve-apache.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-apache.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -44,7 +44,7 @@ function serve-laravel() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-laravel.sh
-        sudo bash /vagrant/scripts/serve-laravel.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-laravel.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -56,7 +56,7 @@ function serve-proxy() {
     if [[ "$1" && "$2" ]]
     then
         sudo dos2unix /vagrant/scripts/serve-proxy.sh
-        sudo bash /vagrant/scripts/serve-proxy.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-proxy.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -69,7 +69,7 @@ function serve-silverstripe() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-silverstripe.sh
-        sudo bash /vagrant/scripts/serve-silverstripe.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-silverstripe.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -82,7 +82,7 @@ function serve-spa() {
   then
     sudo bash /vagrant/scripts/create-certificate.sh "$1"
     sudo dos2unix /vagrant/scripts/serve-spa.sh
-    sudo bash /vagrant/scripts/serve-spa.sh "$1" "$2" 80
+    sudo bash /vagrant/scripts/serve-spa.sh "$1" "$2" 80 443 "${3:-7.1}"
   else
     echo "Error: missing required parameters."
     echo "Usage: "
@@ -95,7 +95,7 @@ function serve-statamic() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-statamic.sh
-        sudo bash /vagrant/scripts/serve-statamic.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-statamic.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -108,7 +108,7 @@ function serve-symfony2() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-symfony2.sh
-        sudo bash /vagrant/scripts/serve-symfony2.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-symfony2.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -121,7 +121,7 @@ function serve-symfony4() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-symfony4.sh
-        sudo bash /vagrant/scripts/serve-symfony4.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-symfony4.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -31,7 +31,7 @@ function serve-apache() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-apache.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-apache.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-apache.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -44,7 +44,7 @@ function serve-laravel() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-laravel.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-laravel.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-laravel.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -56,7 +56,7 @@ function serve-proxy() {
     if [[ "$1" && "$2" ]]
     then
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-proxy.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-proxy.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-proxy.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -69,7 +69,7 @@ function serve-silverstripe() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-silverstripe.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-silverstripe.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-silverstripe.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -82,7 +82,7 @@ function serve-spa() {
   then
     sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
     sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-spa.sh
-    sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-spa.sh "$1" "$2" 80
+    sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-spa.sh "$1" "$2" 80 443 "${3:-7.1}"
   else
     echo "Error: missing required parameters."
     echo "Usage: "
@@ -95,7 +95,7 @@ function serve-statamic() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-statamic.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-statamic.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-statamic.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -108,7 +108,7 @@ function serve-symfony2() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-symfony2.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony2.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony2.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -121,7 +121,7 @@ function serve-symfony4() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-symfony4.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "


### PR DESCRIPTION
a little bug introduced by the recent ability to specify PHP verions.

the `serve` functions are currently failing because they do not specify a PHP version, and there is no default.

this PR allows the `serve` functions to specify a specific PHP version (5.6, 7.0, or 7.1 currently) or omit it and be given a default.

2 thoughts for the future:

- not sure if there's a better place to define the default so we're not hardcoding it in everywhere here.
- probably should write a test to avoid this regression again.