### PR TITLE
Add Hyper-V support

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -2,7 +2,7 @@
     "ip": "192.168.10.10",
     "memory": 2048,
     "cpus": 1,
-    "provider": "virtualbox",
+    "provider": "hyperv",
     "authorize": "~/.ssh/id_rsa.pub",
     "keys": [
         "~/.ssh/id_rsa"

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -2,7 +2,7 @@
 ip: "192.168.10.10"
 memory: 2048
 cpus: 1
-provider: virtualbox
+provider: hyperv
 
 authorize: ~/.ssh/id_rsa.pub
 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -62,6 +62,11 @@ class Homestead
             v.cpus = settings["cpus"] ||= 1
         end
 
+        # Configure A Few Hyper-V Settings
+        config.vm.provider "hyperv" do |v|
+            #allow for Hyper-V config
+        end
+
         # Standardize Ports Naming Schema
         if (settings.has_key?("ports"))
             settings["ports"].each do |port|


### PR DESCRIPTION
I'm not sure if the issue should be added as a PR or an actual issue, but here is a PR with the files that I believe need to be changed (not sure).

My issue is that Vagrant says it [supports Hyper-V](https://www.vagrantup.com/docs/hyperv/index.html), but I'm not able to use homestead since it doesn't implement any adapter for it.

Please add support for Hyper-V as it works BEAUTIFULLY on a windows box. 

While Virtualbox is free I consistently have bugs with it and the machine complains, on shutdown, about a bug/issue with the Virtualbox Adapter drivers.