### PR TITLE
Add automatic configuration for debugging scripts on the CLI with XDEBUG

### DIFF
--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -20,6 +20,16 @@ sites:
 databases:
     - homestead
 
+# xdebug:
+#     - key: XDEBUG_CONFIG
+#       value:
+#       - key: idekey
+#         value: PHPSTORM
+#     - key: PHP_IDE_CONFIG
+#       value:
+#       - key: serverName
+#         value: homestead
+
 # blackfire:
 #     - id: foo
 #       token: bar

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -321,6 +321,28 @@ class Homestead
             end
         end
 
+        if settings.has_key?("xdebug")
+            settings["xdebug"].each do |var|
+                config.vm.provision "shell" do |s|
+                    values = []
+                    var["value"].each do |xdebug|
+                        values.push(xdebug["key"] + "=" + xdebug["value"])
+                    end
+                    
+                    if var["key"] == "XDEBUG_CONFIG"
+                        my_ip = `ipconfig getifaddr en0`.chomp
+
+                        values.push("remote_host=" + my_ip)
+                        
+                    end
+                    val = values.join(" ")
+
+                    s.inline = "echo \"\n# Set Homestead Environment Variable\nexport $1=$2$3$2\" >> /home/vagrant/.profile"
+                    s.args = [var["key"], '"', val]
+                end
+            end
+        end
+
         # Update Composer On Every Provision
         config.vm.provision "shell" do |s|
             s.name = "Update Composer"


### PR DESCRIPTION
I made these edits and thought this might be handy for others. It allows you to enable debugging CLI scripts by editing the Homestead.yaml file.

