### PR TITLE
Enable gzip in laravel nginx config

### DIFF
--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -33,6 +33,31 @@ block="server {
 
     client_max_body_size 100m;
 
+    gzip on;
+    gzip_disable “msie6”;
+
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_vary on;
+
+    gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/opentype
+        image/svg+xml
+        image/x-icon
+        text/css
+        text/plain
+        text/x-component;
+
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;


### PR DESCRIPTION
This will enable gzip in laravel projects. It's nice to see gzipped asset file sizes during development. The settings are the ones which forge is using.