### PR TITLE
Add aliases for easy switching between PHP versions

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -5,6 +5,10 @@ alias h='cd ~'
 alias c='clear'
 alias art=artisan
 
+alias php56=php56
+alias php70=php70
+alias php71=php71
+
 alias phpspec='vendor/bin/phpspec'
 alias phpunit='vendor/bin/phpunit'
 alias serve=serve-laravel
@@ -12,9 +16,19 @@ alias serve=serve-laravel
 alias xoff='sudo phpdismod -s cli xdebug'
 alias xon='sudo phpenmod -s cli xdebug'
 
-alias php56=php56
-alias php70=php70
-alias php71=php71
+function artisan() {
+    php artisan "$@"
+}
+
+function dusk() {
+    pids=$(pidof /usr/bin/Xvfb)
+
+    if [ ! -n "$pids" ]; then
+        Xvfb :0 -screen 0 1280x960x24 &
+    fi
+
+    php artisan dusk "$@"
+}
 
 function php56() {
     sudo rm /usr/bin/php
@@ -29,20 +43,6 @@ function php70() {
 function php71() {
     sudo rm /usr/bin/php
     sudo ln -s /usr/bin/php7.1 /usr/bin/php
-}
-
-function artisan() {
-    php artisan "$@"
-}
-
-function dusk() {
-    pids=$(pidof /usr/bin/Xvfb)
-
-    if [ ! -n "$pids" ]; then
-        Xvfb :0 -screen 0 1280x960x24 &
-    fi
-
-    php artisan dusk "$@"
 }
 
 function serve-apache() {

--- a/resources/aliases
+++ b/resources/aliases
@@ -12,6 +12,25 @@ alias serve=serve-laravel
 alias xoff='sudo phpdismod -s cli xdebug'
 alias xon='sudo phpenmod -s cli xdebug'
 
+alias php56=php56
+alias php70=php70
+alias php71=php71
+
+function php56() {
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/php5.6 /usr/bin/php
+}
+
+function php70() {
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/php7.0 /usr/bin/php
+}
+
+function php71() {
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/php7.1 /usr/bin/php
+}
+
 function artisan() {
     php artisan "$@"
 }

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -5,6 +5,10 @@ alias h='cd ~'
 alias c='clear'
 alias art=artisan
 
+alias php56=php56
+alias php70=php70
+alias php71=php71
+
 alias phpspec='vendor/bin/phpspec'
 alias phpunit='vendor/bin/phpunit'
 alias serve=serve-laravel
@@ -12,9 +16,19 @@ alias serve=serve-laravel
 alias xoff='sudo phpdismod -s cli xdebug'
 alias xon='sudo phpenmod -s cli xdebug'
 
-alias php56=php56
-alias php70=php70
-alias php71=php71
+function artisan() {
+    php artisan "$@"
+}
+
+function dusk() {
+    pids=$(pidof /usr/bin/Xvfb)
+
+    if [ ! -n "$pids" ]; then
+        Xvfb :0 -screen 0 1280x960x24 &
+    fi
+
+    php artisan dusk "$@"
+}
 
 function php56() {
     sudo rm /usr/bin/php
@@ -29,20 +43,6 @@ function php70() {
 function php71() {
     sudo rm /usr/bin/php
     sudo ln -s /usr/bin/php7.1 /usr/bin/php
-}
-
-function artisan() {
-    php artisan "$@"
-}
-
-function dusk() {
-    pids=$(pidof /usr/bin/Xvfb)
-
-    if [ ! -n "$pids" ]; then
-        Xvfb :0 -screen 0 1280x960x24 &
-    fi
-
-    php artisan dusk "$@"
 }
 
 function serve-apache() {

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -12,6 +12,25 @@ alias serve=serve-laravel
 alias xoff='sudo phpdismod -s cli xdebug'
 alias xon='sudo phpenmod -s cli xdebug'
 
+alias php56=php56
+alias php70=php70
+alias php71=php71
+
+function php56() {
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/php5.6 /usr/bin/php
+}
+
+function php70() {
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/php7.0 /usr/bin/php
+}
+
+function php71() {
+    sudo rm /usr/bin/php
+    sudo ln -s /usr/bin/php7.1 /usr/bin/php
+}
+
 function artisan() {
     php artisan "$@"
 }


### PR DESCRIPTION
This adds 3 aliases for switching between 3 PHP versions provided by Homestead: php5.6, php7.0 and php7.1.

This is useful when using Homestead for multiple projects with the same Homestead configuration.