### PR TITLE
Allow pimcore serve function to specify a PHP version

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -153,7 +153,7 @@ function serve-pimcore() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/serve-pimcore.sh
-        sudo bash /vagrant/scripts/serve-pimcore.sh "$1" "$2" 80
+        sudo bash /vagrant/scripts/serve-pimcore.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -153,7 +153,7 @@ function serve-pimcore() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/serve-pimcore.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-pimcore.sh "$1" "$2" 80
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/serve-pimcore.sh "$1" "$2" 80 443 "${3:-7.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "


### PR DESCRIPTION
As #631 and #634 were done at the same time, the Pimcore serve function is missing the changes from #631.