### PR TITLE
Upgrade MariaDB version from 10.1 to 10.2 (stable)

### DIFF
--- a/scripts/install-maria.sh
+++ b/scripts/install-maria.sh
@@ -30,24 +30,20 @@ rm -rf /etc/mysql
 # Add Maria PPA
 
 sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-sudo add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.1/ubuntu xenial main'
+sudo add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.2/ubuntu xenial main'
 apt-get update
 
 # Set The Automated Root Password
 
 export DEBIAN_FRONTEND=noninteractive
 
-debconf-set-selections <<< "mariadb-server-10.1 mysql-server/data-dir select ''"
-debconf-set-selections <<< "mariadb-server-10.1 mysql-server/root_password password secret"
-debconf-set-selections <<< "mariadb-server-10.1 mysql-server/root_password_again password secret"
+debconf-set-selections <<< "mariadb-server-10.2 mysql-server/data-dir select ''"
+debconf-set-selections <<< "mariadb-server-10.2 mysql-server/root_password password secret"
+debconf-set-selections <<< "mariadb-server-10.2 mysql-server/root_password_again password secret"
 
 # Install MariaDB
 
 apt-get install -y mariadb-server
-
-# Configure Password Expiration
-
-echo "default_password_lifetime = 0" >> /etc/mysql/my.cnf
 
 # Configure Maria Remote Access
 


### PR DESCRIPTION
Note: This commit differs slightly from the initial attempt at https://github.com/laravel/homestead/pull/441/files in that this commit addresses the erroneous `default_password_lifetime` directive, too.

For the reasons described from https://github.com/laravel/homestead/issues/529#issuecomment-316290010 to the end of the thread, it seems appropriate to re-introduce Maria DB 10.2.x, now that the 10.2 series is marked GA/stable, per https://mariadb.com/kb/en/the-mariadb-library/changes-improvements-in-mariadb-102/ .

Also, according to https://mariadb.com/kb/en/the-mariadb-library/system-variable-differences-between-mariadb-101-and-mysql-57/ , the `default_password_lifetime` is a `MySQL-only variable determining how long passwords are valid for before expiring.`

With this directive present, Homestead (v6.1.0) provisioning fails with:

    ==> homestead-7: mysql: unknown variable 'default_password_lifetime=0'

Removing this directive resolves the problem.