### PR TITLE
Overhaul and update MongoDB installation script

### DIFF
--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -16,9 +16,6 @@ sudo apt-get update
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get -yq -o Dpkg::Options::="--force-confnew" install mongodb-org autoconf g++ make openssl libssl-dev libcurl4-openssl-dev pkg-config libsasl2-dev php-dev
 
-#sudo pecl update-channels
-#sudo pecl install mongodb
-
 sudo rm -rf /tmp/mongo-php-driver /usr/src/mongo-php-driver
 git clone -c advice.detachedHead=false -q -b '1.2.9' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
 sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -8,44 +8,52 @@ fi
 
 touch /home/vagrant/.mongo
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
 
-echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 
 sudo apt-get update
-sudo apt-get install -y --allow-unauthenticated  mongodb-org
 
-sudo sed -i -e 's/-C -n -q/-C -q/g' `which pecl`
+sudo DEBIAN_FRONTEND=noninteractive apt-get -yq -o Dpkg::Options::="--force-confnew" install mongodb-org autoconf g++ make openssl libssl-dev libcurl4-openssl-dev pkg-config libsasl2-dev php-dev
 
-sudo apt-get install -y autoconf g++ make openssl libssl-dev libcurl4-openssl-dev
-sudo apt-get install -y libcurl4-openssl-dev pkg-config
-sudo apt-get install -y libsasl2-dev
+#sudo pecl update-channels
+#sudo pecl install mongodb
 
-sudo pecl install mongodb
+sudo rm -rf /tmp/mongo-php-driver /usr/src/mongo-php-driver
+git clone -c advice.detachedHead=false -q -b '1.2.9' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
+sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver
+cd /usr/src/mongo-php-driver
+git submodule -q update --init
 
-sudo echo  "extension = mongodb.so" > /etc/php/7.1/mods-available/mongo.ini
-sudo ln -s /etc/php/7.1/mods-available/mongo.ini /etc/php/7.1/fpm/conf.d/mongo.ini
-sudo ln -s /etc/php/7.1/mods-available/mongo.ini /etc/php/7.1/cli/conf.d/mongo.ini
+phpize5.6
+./configure --with-php-config=/usr/bin/php-config5.6 > /dev/null
+make clean > /dev/null
+make >/dev/null 2>&1
+sudo make install
+sudo chmod 644 /usr/lib/php/20131226/mongodb.so
+sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/fpm/conf.d/20-mongo.ini
+sudo service php5.6-fpm restart
 
-cat > /etc/systemd/system/mongodb.service <<EOL
-[Unit]
-Description=High-performance, schema-free document-oriented database
-After=network.target
-[Service]
-User=mongodb
-ExecStart=/usr/bin/mongod --quiet --config /etc/mongod.conf
-[Install]
-WantedBy=multi-user.target
-EOL
+phpize7.0
+./configure --with-php-config=/usr/bin/php-config7.0 > /dev/null
+make clean > /dev/null
+make >/dev/null 2>&1
+sudo make install
+sudo chmod 644 /usr/lib/php/20151012/mongodb.so
+sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/fpm/conf.d/20-mongo.ini
+sudo service php7.0-fpm restart
 
-sudo systemctl start mongodb
-sudo systemctl status mongodb
-sudo systemctl enable mongodb
+phpize7.1
+./configure --with-php-config=/usr/bin/php-config7.1 > /dev/null
+make clean > /dev/null
+make >/dev/null 2>&1
+sudo make install
+sudo chmod 644 /usr/lib/php/20160303/mongodb.so
+sudo ln -s /etc/php/7.1/mods-available/mongo.ini /etc/php/7.1/fpm/conf.d/20-mongo.ini
+sudo service php7.1-fpm restart
+
 sudo ufw allow 27017
 sudo sed -i "s/bindIp: .*/bindIp: 0.0.0.0/" /etc/mongod.conf
 
-sudo service nginx restart
-
-sudo service php5.6-fpm restart
-sudo service php7.0-fpm restart
-sudo service php7.1-fpm restart
+sudo systemctl enable mongod
+sudo systemctl start mongod


### PR DESCRIPTION
The impetus for this rewrite is that from the initial commit, every php-cli invocation caused PHP to emit a warning. This can be tested/verified as follows:

    vagrant@homestead:~$ php -r 'echo "test\n";'
    PHP Warning:  Module 'mongodb' already loaded in Unknown on line 0
    test

The root-cause turned out to be that the PECL installer was adding `extension = mongodb.so` to the very top of `/etc/php/7.1/cli/php.ini` (along with entries for several other extensions, which in itself seems like a bug with the PECL installer).

Once I dug into the source, it became clear that the MongoDB driver was being installed only for PHP 7.1, and none of the other (earlier) PHP versions for which support was added recently. The only means by which to install the driver for all PHP versions is to build it from source for each version. This change addresses that need.

In any case, the nature of the proposed changes is as follows:

1. Upgrade MongoDB version from 3.2 to 3.4, and remove `--allow-unauthenticated` switch from `apt-get install` command (there should be no reason to use this switch).

2. Remove sed command that seems designed to modify /usr/bin/pecl directly, which seems like a "bad idea". Also, as of this writing, `/usr/bin/pecl` is untouched after the command is executed, so perhaps the bug it was designed to address has been fixed upstream.

3. Remove duplicate package names when installing packages required to build MongoDB PECL extension and consolidate into a single `apt-get` command.

4. Remove inline systemd init script for MongoDB, as the official package installs its own, and rename references to match common convention (convention is `mongod`, as in "Mongo Daemon", instead of `mongodb`). Also, remove needless call to `systemctl status mongodb`, as it produces "noise", and fix the order in which systemd calls are executed post-installation.

5. Build and enable mongodb PECL extension for all versions of PHP (not just 7.1). Previously, the extension was built and enabled only for PHP 7.1.

6. Remove needless call to restart nginx, as nginx is uninvolved with this process.