### PR TITLE
Sign site-certificates with own root Certificate

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -3,19 +3,55 @@
 mkdir /etc/nginx/ssl 2>/dev/null
 
 PATH_SSL="/etc/nginx/ssl"
-PATH_CNF="${PATH_SSL}/${1}.cnf"
+PATH_CSR="${PATH_SSL}/${1}.csr"
+PATH_req_CNF="${PATH_SSL}/${1}_req.cnf"
+PATH_x509_CNF="${PATH_SSL}/${1}_x509.cnf"
 PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CRT="${PATH_SSL}/${1}.crt"
 
 # Only generate a certificate if there isn't one already there.
-if [ ! -f $PATH_CNF ] || [ ! -f $PATH_KEY ] || [ ! -f $PATH_CRT ]
+if [ ! -f $PATH_req_CNF ] || [ ! -f $PATH_x509_CNF ] || [ ! -f $PATH_KEY ] || [ ! -f $PATH_CRT ]
 then
 
     # Uncomment the global 'copy_extentions' OpenSSL option to ensure the SANs are copied into the certificate.
     sed -i '/copy_extensions\ =\ copy/s/^#\ //g' /etc/ssl/openssl.cnf
 
     # Generate an OpenSSL configuration file specifically for this certificate.
-    block="
+    if [ $# -gt 1 ]
+    then
+      block_req="
+          [ req ]
+          prompt = no
+          default_bits = 2048
+          default_md = sha256
+          distinguished_name = req_distinguished_name
+
+          [ req_distinguished_name ]
+          O=Vagrant
+          C=UN
+          CN=$1
+      "
+      echo "$block_req" > $PATH_req_CNF
+
+      block_x509="
+          authorityKeyIdentifier=keyid,issuer
+          basicConstraints=CA:FALSE
+          keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+          subjectAltName = @alt_names
+
+          [alt_names]
+          DNS.1 = $1
+      "
+      echo "$block_x509" > $PATH_x509_CNF
+
+
+      # First generate a new certificate request and private key
+      openssl req -new -sha256 -nodes -out "$PATH_CSR" -newkey rsa:2048 -keyout "$PATH_KEY" -config $PATH_req_CNF 2>/dev/null
+      # Finally generate and sign a new certificate
+      openssl x509 -req -in "$PATH_CSR" -CA $2 -CAkey $3 -CAcreateserial -out "$PATH_CRT" -days 3650 -sha256 -extfile $PATH_x509_CNF 2>/dev/null
+      rm $PATH_CSR
+    else
+      block="
         [ req ]
         prompt = no
         default_bits = 2048
@@ -24,25 +60,23 @@ then
         default_md = sha256
         distinguished_name = req_distinguished_name
         x509_extensions = v3_ca
-
         [ req_distinguished_name ]
         O=Vagrant
         C=UN
         CN=$1
-
         [ v3_ca ]
         basicConstraints=CA:FALSE
         subjectKeyIdentifier=hash
         authorityKeyIdentifier=keyid,issuer
         keyUsage = nonRepudiation, digitalSignature, keyEncipherment
         subjectAltName = @alternate_names
-
         [ alternate_names ]
         DNS.1 = $1
-    "
-    echo "$block" > $PATH_CNF
+      "
+      echo "$block" > $PATH_req_CNF
 
-    # Finally, generate the private key and certificate.
-    openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -x509 -config "$PATH_CNF" -out "$PATH_CRT" -days 365 2>/dev/null
+      openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
+      openssl req -new -x509 -config "$PATH_req_CNF" -out "$PATH_CRT" -days 365 2>/dev/null
+    fi
+
 fi

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -184,6 +184,11 @@ class Homestead
                     s.name = "Creating Certificate: " + site["map"]
                     s.path = scriptDir + "/create-certificate.sh"
                     s.args = [site["map"]]
+
+                    if site.include? 'rootCA'
+                      s.args.push(site['rootCA']['crt'])
+                      s.args.push(site['rootCA']['key'])
+                    end
                 end
 
                 type = site["type"] ||= "laravel"


### PR DESCRIPTION
Note: Helpful for the development of ServiceWorkers

Problem:
The developer calls a homestead-site via HTTPS. By default, the browser throws an error message like "ERR_CERT_AUTHORITY_INVALID", because the certificate is self-created and therefore not trustworthy.
If you use multiple sites in a homestead-box, each certificate must be imported manually into the local system.


Solution:
You create your own "root"-certificate and load it into your local certificate store. Then copy the certificate and its key into the box using the "copy"-parameter. Next, specify the copied certificate and the certificate key for each site using the "rootCA"-parameter.
The box now signs the certificate of each site with the certificate specified in "rootCA" during the "provision"-process.
If the developer now calls the site via HTTPS, no error message is generated and he does not have to load the corresponding certificate into his memory for each site.

Implementation:
I have added the parameter "rootCA" in homestead.rb. This expects two parameters "key" and "crt".
I also modified the create-certificate.sh so that it checks if a "rootCA"-parameter has been passed. If so, a new certificate is created and signed with the root certificate. Otherwise, the code already implemented will be executed.

Example:
Generate root CA:

`openssl genrsa -out ca.key 2048`
`openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.pem -subj "/C=<COUNTRY>/ST=<STATE>/L=<CITY>/O=<COMPANY NAME>/OU=<ORGANISATION UNIT>/emailAddress=<EMAIL ADDRESS>/CN=<COMMON NAME>"`

After that you have to import your generated CA in your local certificate store.

Now copy your certificate and key in your homestead-box and specify it for every site 
you will use it. (See attached homestead.yaml.txt)

Notice: I've must change the file-type because github doesn't accept *.yaml-files.

[Homestead.yaml.txt](https://github.com/laravel/homestead/files/1292594/Homestead.yaml.txt)


