### PR TITLE
Fixes for MongoDB installation bugs on v6.2.0.

### DIFF
--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -28,6 +28,7 @@ make clean > /dev/null
 make >/dev/null 2>&1
 sudo make install
 sudo chmod 644 /usr/lib/php/20131226/mongodb.so
+sudo bash -c "echo 'extension=mongodb.so' > /etc/php/5.6/mods-available/mongo.ini"
 sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/fpm/conf.d/20-mongo.ini
 sudo service php5.6-fpm restart
 
@@ -37,6 +38,7 @@ make clean > /dev/null
 make >/dev/null 2>&1
 sudo make install
 sudo chmod 644 /usr/lib/php/20151012/mongodb.so
+sudo bash -c "echo 'extension=mongodb.so' > /etc/php/7.0/mods-available/mongo.ini"
 sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/fpm/conf.d/20-mongo.ini
 sudo service php7.0-fpm restart
 
@@ -46,6 +48,7 @@ make clean > /dev/null
 make >/dev/null 2>&1
 sudo make install
 sudo chmod 644 /usr/lib/php/20160303/mongodb.so
+sudo bash -c "echo 'extension=mongodb.so' > /etc/php/7.1/mods-available/mongo.ini"
 sudo ln -s /etc/php/7.1/mods-available/mongo.ini /etc/php/7.1/fpm/conf.d/20-mongo.ini
 sudo service php7.1-fpm restart
 

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -29,6 +29,7 @@ make >/dev/null 2>&1
 sudo make install
 sudo chmod 644 /usr/lib/php/20131226/mongodb.so
 sudo bash -c "echo 'extension=mongodb.so' > /etc/php/5.6/mods-available/mongo.ini"
+sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/cli/conf.d/20-mongo.ini
 sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/fpm/conf.d/20-mongo.ini
 sudo service php5.6-fpm restart
 
@@ -39,6 +40,7 @@ make >/dev/null 2>&1
 sudo make install
 sudo chmod 644 /usr/lib/php/20151012/mongodb.so
 sudo bash -c "echo 'extension=mongodb.so' > /etc/php/7.0/mods-available/mongo.ini"
+sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/cli/conf.d/20-mongo.ini
 sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/fpm/conf.d/20-mongo.ini
 sudo service php7.0-fpm restart
 
@@ -49,6 +51,7 @@ make >/dev/null 2>&1
 sudo make install
 sudo chmod 644 /usr/lib/php/20160303/mongodb.so
 sudo bash -c "echo 'extension=mongodb.so' > /etc/php/7.1/mods-available/mongo.ini"
+sudo ln -s /etc/php/7.1/mods-available/mongo.ini /etc/php/7.1/cli/conf.d/20-mongo.ini
 sudo ln -s /etc/php/7.1/mods-available/mongo.ini /etc/php/7.1/fpm/conf.d/20-mongo.ini
 sudo service php7.1-fpm restart
 


### PR DESCRIPTION
Hello! I tested out the latest release with MongoDB and noticed two potential bugs. I'm running Virtualbox 5.1.26, Vagrant 1.9.7, and the latest release of the Homestead box.

1. The `mods-available/mongo.ini` file for each PHP version never seems to be created, so the symlink on the following line points to a missing file. [Creating that file](https://github.com/DFurnes/homestead/commit/f770cfb4182c86f899938d25382157dcf3830e02) resolves some `Class 'MongoDB\Driver\Manager' not found` errors.
2. The Mongo extension is not symlinked for the PHP CLI, so any Artisan commands that need Mongo (like database migrations) don't work. [Adding that symlink](https://github.com/DFurnes/homestead/commit/e0a2dce2ade96a0ae48aa9a68aab280e6f458a8b) fixed things up for me.

