### PR TITLE
lowercase 'code' directory

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -9,14 +9,14 @@
     ],
     "folders": [
         {
-            "map": "~/Code",
-            "to": "/home/vagrant/Code"
+            "map": "~/code",
+            "to": "/home/vagrant/code"
         }
     ],
     "sites": [
         {
             "map": "homestead.app",
-            "to": "/home/vagrant/Code/public"
+            "to": "/home/vagrant/code/public"
         }
     ],
     "databases": [

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -10,12 +10,12 @@ keys:
     - ~/.ssh/id_rsa
 
 folders:
-    - map: ~/Code
-      to: /home/vagrant/Code
+    - map: ~/code
+      to: /home/vagrant/code
 
 sites:
     - map: homestead.app
-      to: /home/vagrant/Code/public
+      to: /home/vagrant/code/public
 
 databases:
     - homestead

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -435,7 +435,7 @@ class MakeCommandTest extends TestCase
 
         $this->assertEquals([
             'map' => 'homestead.app',
-            'to' => '/home/vagrant/Code/public',
+            'to' => '/home/vagrant/code/public',
         ], $settings['sites'][0]);
     }
 
@@ -454,7 +454,7 @@ class MakeCommandTest extends TestCase
 
         $this->assertEquals([
             'map' => 'homestead.app',
-            'to' => '/home/vagrant/Code/public',
+            'to' => '/home/vagrant/code/public',
         ], $settings['sites'][0]);
     }
 
@@ -481,7 +481,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals('/home/vagrant/Code', $settings['folders'][0]['to']);
+        $this->assertEquals('/home/vagrant/code', $settings['folders'][0]['to']);
         $this->assertEquals($projectName, $settings['name']);
         $this->assertEquals($projectName, $settings['hostname']);
     }
@@ -511,7 +511,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals('/home/vagrant/Code', $settings['folders'][0]['to']);
+        $this->assertEquals('/home/vagrant/code', $settings['folders'][0]['to']);
         $this->assertEquals($projectName, $settings['name']);
         $this->assertEquals($projectName, $settings['hostname']);
     }

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -161,8 +161,8 @@ class JsonSettingsTest extends TestCase
         $settings = new JsonSettings([
             'folders' => [
                 [
-                    'map' => '~/Code',
-                    'to' => '/home/vagrant/Code',
+                    'map' => '~/code',
+                    'to' => '/home/vagrant/code',
                     'type' => 'nfs',
                 ],
             ],
@@ -173,7 +173,7 @@ class JsonSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => '/a/path/for/project_name',
-            'to' => '/home/vagrant/Code',
+            'to' => '/home/vagrant/code',
             'type' => 'nfs',
         ], $attributes['folders'][0]);
     }

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -162,8 +162,8 @@ class YamlSettingsTest extends TestCase
         $settings = new YamlSettings([
             'folders' => [
                 [
-                    'map' => '~/Code',
-                    'to' => '/home/vagrant/Code',
+                    'map' => '~/code',
+                    'to' => '/home/vagrant/code',
                     'type' => 'nfs',
                 ],
             ],
@@ -174,7 +174,7 @@ class YamlSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => '/a/path/for/project_name',
-            'to' => '/home/vagrant/Code',
+            'to' => '/home/vagrant/code',
             'type' => 'nfs',
         ], $attributes['folders'][0]);
     }


### PR DESCRIPTION
not sure why this was uppercase originally, but it's an unnecessary extra keystroke