### PR TITLE
Remove code directory

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -10,7 +10,7 @@
     "folders": [
         {
             "map": "~/code",
-            "to": "/home/vagrant/code"
+            "to": "/home/vagrant"
         }
     ],
     "sites": [

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -11,7 +11,7 @@ keys:
 
 folders:
     - map: ~/code
-      to: /home/vagrant/code
+      to: /home/vagrant
 
 sites:
     - map: homestead.app

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -481,7 +481,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals('/home/vagrant/code', $settings['folders'][0]['to']);
+        $this->assertEquals('/home/vagrant', $settings['folders'][0]['to']);
         $this->assertEquals($projectName, $settings['name']);
         $this->assertEquals($projectName, $settings['hostname']);
     }
@@ -511,7 +511,7 @@ class MakeCommandTest extends TestCase
         // The curious thing is that both directories point to the same location.
         //
         $this->assertRegExp("/{$projectDirectory}/", $settings['folders'][0]['map']);
-        $this->assertEquals('/home/vagrant/code', $settings['folders'][0]['to']);
+        $this->assertEquals('/home/vagrant', $settings['folders'][0]['to']);
         $this->assertEquals($projectName, $settings['name']);
         $this->assertEquals($projectName, $settings['hostname']);
     }

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -162,7 +162,7 @@ class JsonSettingsTest extends TestCase
             'folders' => [
                 [
                     'map' => '~/code',
-                    'to' => '/home/vagrant/code',
+                    'to' => '/home/vagrant',
                     'type' => 'nfs',
                 ],
             ],
@@ -173,7 +173,7 @@ class JsonSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => '/a/path/for/project_name',
-            'to' => '/home/vagrant/code',
+            'to' => '/home/vagrant',
             'type' => 'nfs',
         ], $attributes['folders'][0]);
     }

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -163,7 +163,7 @@ class YamlSettingsTest extends TestCase
             'folders' => [
                 [
                     'map' => '~/code',
-                    'to' => '/home/vagrant/code',
+                    'to' => '/home/vagrant',
                     'type' => 'nfs',
                 ],
             ],
@@ -174,7 +174,7 @@ class YamlSettingsTest extends TestCase
         $attributes = $settings->toArray();
         $this->assertEquals([
             'map' => '/a/path/for/project_name',
-            'to' => '/home/vagrant/code',
+            'to' => '/home/vagrant',
             'type' => 'nfs',
         ], $attributes['folders'][0]);
     }


### PR DESCRIPTION
This will allow to share everything inside the `~/code` from the host OS directly into the vagrant shared directory `/home/vagrant`.

This complements the work in the PR #601