### PR TITLE
Turn on HTTPS for Apache

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -164,6 +164,10 @@ ps auxw | grep apache2 | grep -v grep > /dev/null
 
 # Assume user wants mode_rewrite support
 sudo a2enmod rewrite
+
+# Turn on HTTPS support
+sudo a2enmod ssl
+
 service apache2 restart
 
 if [ $? == 0 ]


### PR DESCRIPTION
Seems like a lot of work went into getting HTTPS support for Apache. But it's not turned on by default.

So, turn it on.