### PR TITLE
Install Elasticsearch

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -254,6 +254,13 @@ class Homestead
             end
         end
 
+        # Install Elasticsearch If Necessary
+        if settings.has_key?("elasticsearch") && settings["elasticsearch"]
+            config.vm.provision "shell" do |s|
+                s.path = scriptDir + "/install-elasticsearch.sh"
+            end
+        end
+
         # Configure All Of The Configured Databases
         if settings.has_key?("databases")
             settings["databases"].each do |db|

--- a/scripts/install-elasticsearch.sh
+++ b/scripts/install-elasticsearch.sh
@@ -14,6 +14,8 @@ touch /home/vagrant/.elasticsearch
 
 sudo add-apt-repository -y ppa:webupd8team/java
 sudo apt-get update
+echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
 sudo apt-get -y install oracle-java8-installer
 
 # Install Elasticsearch 5

--- a/scripts/install-elasticsearch.sh
+++ b/scripts/install-elasticsearch.sh
@@ -32,3 +32,7 @@ sudo update-rc.d elasticsearch defaults 95 10
 # Update configuration to use 'homestead' as the cluster
 
 sudo sed -i "s/#cluster.name: my-application/cluster.name: homestead/" /etc/elasticsearch/elasticsearch.yml
+
+# Start Elasticsearch
+
+sudo service elasticsearch start

--- a/scripts/install-elasticsearch.sh
+++ b/scripts/install-elasticsearch.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Check if Elasticsearch has been installed
+
+if [ -f /home/vagrant/.elasticsearch ]
+then
+    echo "Elasticsearch already installed."
+    exit 0
+fi
+
+touch /home/vagrant/.elasticsearch
+
+# Install Java 8
+
+sudo add-apt-repository -y ppa:webupd8team/java
+sudo apt-get update
+sudo apt-get -y install oracle-java8-installer
+
+# Install Elasticsearch 5
+
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+echo "deb https://artifacts.elastic.co/packages/5.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-5.x.list
+sudo apt-get update
+sudo apt-get -y install elasticsearch
+
+# Start Elasticsearch on boot
+
+sudo update-rc.d elasticsearch defaults 95 10
+
+# Update configuration to use 'homestead' as the cluster
+
+sudo sed -i "s/#cluster.name: my-application/cluster.name: homestead/" /etc/elasticsearch/elasticsearch.yml


### PR DESCRIPTION
This PR gives the user the option to install Elasticsearch on their Homestead machine.

It is configured with a top level flag:

```yaml
box: laravel/homestead
ip: "192.168.20.20"
memory: 2048
cpus: 4
provider: virtualbox
mariadb: true
elasticsearch: true
```

It currently installs Java 8 and ES 5.  All installations are done silently, including accepting the Java license.

Upon successful installation it configures the service to start on boot, names the cluster 'homestead', and starts the service.

The default installation sets ES up with 2GB of memory.  ES recommends never giving more than half of the OS memory to ES, so ideally users running on this default installation will have 4GB on their machines.  I have used ES with 1GB of memory before, but anything below that will not work, so Homestead users wanting to use ES will need a minimum of 2GB on their machine.  I will be sure to note all of this in a docs PR.