### PR TITLE
Create an ngrok config file that allows access to the web inspection …

### DIFF
--- a/scripts/create-ngrok.sh
+++ b/scripts/create-ngrok.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+PATH_NGROK="/home/vagrant/.ngrok2"
+PATH_CONFIG="${PATH_NGROK}/ngrok.yml"
+
+# Only create a ngrok config file if there isn't one already there.
+if [ ! -f $PATH_CONFIG ]
+then
+mkdir -p $PATH_NGROK && echo "web_addr: $1:4040" > $PATH_CONFIG
+fi

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -78,6 +78,7 @@ class Homestead
             80 => 8000,
             443 => 44300,
             3306 => 33060,
+            4040 => 4040,
             5432 => 54320,
             8025 => 8025,
             27017 => 27017
@@ -346,6 +347,13 @@ class Homestead
                     settings["blackfire"][0]["client-token"]
                 ]
             end
+        end
+
+        # Add config file for ngrok
+        config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/create-ngrok.sh"
+            s.args = [settings["ip"]]
+            s.privileged = false
         end
     end
 end


### PR DESCRIPTION
…feature.

Ngrok has a brilliant web inspector feature that allows you to view inbound packets to any site on homestead you might have shared.

This is especially useful for monitoring and replaying webhook dataloads etc. However the default setting when you launch ngrok in homestead is for it to bind the this feature to the localhost adapter, making it very hard to make a browser connection to it.

![image](https://user-images.githubusercontent.com/2513663/31322605-bd1be7b2-ac92-11e7-9e62-47403cd0e109.png)


This can be easily change/solved by creating a default ngrok config file, and telling ngrok to bind to the normal ip address used by homestead, allowing easy access to the web interface.

This PR attempts to do this. You should end up being able to do this:
![image](https://user-images.githubusercontent.com/2513663/31322616-f7536bd0-ac92-11e7-9879-3598b7b72e86.png)

Pros:
No changes needed to the share command.
Easily changeable
Allows for more options for advanced users


****
Note
****

I've never written a line of ruby code before in my life, the following is purely a guess from looking at other code in the homestead.rb script. Apologies if its terrible.