### PR TITLE
Fix a few more issues with MongoDB provisioning.

### DIFF
--- a/scripts/create-mongo.sh
+++ b/scripts/create-mongo.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 
-mongo admin --eval "db.createUser({user:'homestead',pwd:'secret',roles:['root']})"
 mongo $1 --eval "db.test.insert({name:'db creation'})"
 sudo service mongod restart

--- a/scripts/create-mongo.sh
+++ b/scripts/create-mongo.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
 mongo $1 --eval "db.test.insert({name:'db creation'})"
-sudo service mongod restart

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -60,3 +60,5 @@ sudo sed -i "s/bindIp: .*/bindIp: 0.0.0.0/" /etc/mongod.conf
 
 sudo systemctl enable mongod
 sudo systemctl start mongod
+
+mongo admin --eval "db.createUser({user:'homestead',pwd:'secret',roles:['root']})"

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -8,7 +8,7 @@ fi
 
 touch /home/vagrant/.mongo
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6 2>&1
 
 echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -16,6 +16,9 @@ sudo apt-get update
 
 sudo DEBIAN_FRONTEND=noninteractive apt-get -yq -o Dpkg::Options::="--force-confnew" install mongodb-org autoconf g++ make openssl libssl-dev libcurl4-openssl-dev pkg-config libsasl2-dev php-dev
 
+sudo systemctl enable mongod
+sudo systemctl start mongod
+
 sudo rm -rf /tmp/mongo-php-driver /usr/src/mongo-php-driver
 git clone -c advice.detachedHead=false -q -b '1.2.9' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
 sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver
@@ -57,8 +60,5 @@ sudo service php7.1-fpm restart
 
 sudo ufw allow 27017
 sudo sed -i "s/bindIp: .*/bindIp: 0.0.0.0/" /etc/mongod.conf
-
-sudo systemctl enable mongod
-sudo systemctl start mongod
 
 mongo admin --eval "db.createUser({user:'homestead',pwd:'secret',roles:['root']})"


### PR DESCRIPTION
This pull request fixes a few more issues I've run into with MongoDB on Homestead:

👤 Creates the `homestead` MongoDB user during the "install" script, rather than each time we provision a database (since that would [repeatedly error](https://user-images.githubusercontent.com/583202/31398840-46d4203e-adb8-11e7-8865-1fc00bc2f594.png) when trying to re-create the same user).

🔃 Removes the "restart" step when creating a Mongo database, since it shouldn't be necessary and would cause [a "start request repeated too quickly" error](https://user-images.githubusercontent.com/583202/31398124-e2844cc8-adb5-11e7-8293-45db9224fce9.png) when provisioning a lot of databases.
 
🗝 Finally, fixes a tiny issue where adding the MongoDB public key would display as an error by suppressing output for that particular command from stderr. This just removes [some ugly red text](https://user-images.githubusercontent.com/583202/31397827-002559a8-adb5-11e7-9a7b-bd20f6889932.png) from the provisioning output.