### PR TITLE
Fix 'vagrant ssh -c' usage.

### DIFF
--- a/scripts/end.sh
+++ b/scripts/end.sh
@@ -1,0 +1,2 @@
+# Re-enable IPv6 after provisioning is complete.
+mv /etc/sysctl.conf.bak /etc/sysctl.conf

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -6,8 +6,11 @@ class Homestead
         # Configure Local Variable To Access Scripts From Remote Location
         scriptDir = File.dirname(__FILE__)
 
-        # Prevent TTY Errors
-        config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+        # Start provisioning
+        config.vm.provision "shell" do |s|
+            s.name = "Start"
+            s.path = scriptDir + "/start.sh"
+        end
 
         # Allow SSH Agent Forward from The Box
         config.ssh.forward_agent = true
@@ -354,6 +357,12 @@ class Homestead
             s.path = scriptDir + "/create-ngrok.sh"
             s.args = [settings["ip"]]
             s.privileged = false
+        end
+
+        # Finish provisioning
+        config.vm.provision "shell" do |s|
+            s.name = "End"
+            s.path = scriptDir + "/end.sh"
         end
     end
 end

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,7 @@
+# Prevent TTY Errors by disabling IPv6 during apt-get.
+# See: https://github.com/hashicorp/vagrant/issues/1673#issuecomment-261041105
+sudo cp /etc/sysctl.conf /etc/sysctl.conf.bak
+echo "net.ipv6.conf.all.disable_ipv6 = 1" >> /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6 = 1" >>  /etc/sysctl.conf
+echo "net.ipv6.conf.lo.disable_ipv6 = 1" >>  /etc/sysctl.conf
+sudo sysctl -p


### PR DESCRIPTION
This is a potential fix for the issue described in #416 and #514.

According [this comment](https://github.com/hashicorp/vagrant/issues/1673#issuecomment-261041105) in an issue on `hashicorp/vagrant`, the errors are caused by a compatibility issue between `apt-get` and IPv6. From testing on my local, disabling IPv6 while provisioning removes the ugly "Inappropriate ioctl" errors while still allowing the `-c` argument for `vagrant ssh`.