### PR TITLE
Fix 'vagrant ssh -c' usage.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -6,9 +6,6 @@ class Homestead
         # Configure Local Variable To Access Scripts From Remote Location
         scriptDir = File.dirname(__FILE__)
 
-        # Prevent TTY Errors
-        config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
-
         # Allow SSH Agent Forward from The Box
         config.ssh.forward_agent = true
 


### PR DESCRIPTION
After my initial attempt to fix `vagrant ssh -c` with before/after scripts in #687, I noticed it actually seems to work correctly when just removing the line altogether. 🤦‍♂️ It seems like the underlying problem has been fixed in hashicorp/vagrant#8291, which was released in [Vagrant 1.9.2](https://github.com/hashicorp/vagrant/blob/master/CHANGELOG.md#192-february-27-2017).