### PR TITLE
Refactor cron schedule script

### DIFF
--- a/scripts/cron-schedule.sh
+++ b/scripts/cron-schedule.sh
@@ -4,8 +4,11 @@ if [ ! -d /etc/cron.d ]; then
     mkdir /etc/cron.d
 fi
 
-cron="* * * * * vagrant /usr/bin/php $2/../artisan schedule:run >> /dev/null 2>&1"
+SITE_DOMAIN=$1
+SITE_PUBLIC_DIRECTORY=$2
 
-echo "$cron" > "/etc/cron.d/$1"
+cron="* * * * * vagrant /usr/bin/php $SITE_PUBLIC_DIRECTORY/../artisan schedule:run >> /dev/null 2>&1"
+
+echo "$cron" > "/etc/cron.d/$SITE_DOMAIN"
 
 service cron restart

--- a/scripts/cron-schedule.sh
+++ b/scripts/cron-schedule.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-mkdir /etc/cron.d 2>/dev/null
+if [ ! -d /etc/cron.d ]; then
+    mkdir /etc/cron.d
+fi
 
 cron="* * * * * vagrant /usr/bin/php $2/../artisan schedule:run >> /dev/null 2>&1"
 
 echo "$cron" > "/etc/cron.d/$1"
+
 service cron restart

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -12,7 +12,7 @@ class Homestead
         # Configure The Box
         config.vm.define settings["name"] ||= "homestead-7"
         config.vm.box = settings["box"] ||= "laravel/homestead"
-       config.vm.box_version = settings["version"] ||= ">= 4.0.0"
+        config.vm.box_version = settings["version"] ||= ">= 4.0.0"
         config.vm.hostname = settings["hostname"] ||= "homestead"
 
         # Configure A Private Network IP


### PR DESCRIPTION
It will now create the `/etc/cron.d` directory only if it does not exists.

Also it creates some variables to improve script readability based on `create-mysql.sh` and `create-postgres.sh` as a precedent for this.