### PR TITLE
set netmask on networks setting

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -21,7 +21,7 @@ class Homestead
         # Configure Additional Networks
         if settings.has_key?("networks")
             settings["networks"].each do |network|
-                config.vm.network network["type"], ip: network["ip"], bridge: network["bridge"] ||= nil
+                config.vm.network network["type"], ip: network["ip"], bridge: network["bridge"] ||= nil, netmask: network["netmask"] ||= "255.255.255.0"
             end
         end
 


### PR DESCRIPTION
my public_network has `172.16.0.0/16` ip segment.
I think that it is desirable to be able to specify netmask with `network["netmask"]`
(However, the default value would be `/24`)

so I write set netmask on networks settings.