### PR TITLE
Escape ErrorLog and CustomLog

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -79,8 +79,8 @@ blockssl="<IfModule mod_ssl.c>
         # modules, e.g.
         #LogLevel info ssl:warn
 
-        ErrorLog ${APACHE_LOG_DIR}/error.log
-        CustomLog ${APACHE_LOG_DIR}/access.log combined
+        ErrorLog \${APACHE_LOG_DIR}/$1-error.log
+        CustomLog \${APACHE_LOG_DIR}/$1-access.log combined
 
         # For most configuration files from conf-available/, which are
         # enabled or disabled at a global level, it is possible to


### PR DESCRIPTION
VirtualHost section of both (SSL/ Non SSL) ErrorLog and CustomLog are not consistent. 

Currently the ${APACHE_LOG_DIR} is parsed as '' and results into: `ErrorLog /error.log`.

Escaping the APACHE_LOG_DIR and adding the site name prefix will write to same file and cause less confusion.