### PR TITLE
Keep the native colors from the provisioning scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exist? afterScriptPath then
-        config.vm.provision "shell", path: afterScriptPath, privileged: false
+        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
 
     if defined? VagrantPlugins::HostsUpdater

--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exist? afterScriptPath then
-        config.vm.provision "shell", path: afterScriptPath, privileged: false
+        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
 
     if defined? VagrantPlugins::HostsUpdater


### PR DESCRIPTION
As stated in the vagrant documentation, by default, vagrant automatically colors output in green and red depending on wheter the output is from stdout or stderr. The `keep_color` option allows to maintain the original colors outputted by the provisioning scripts.

Documentation: https://www.vagrantup.com/docs/provisioning/shell.html

Before:

![captura de pantalla 2017-10-18 a la s 16 25 17](https://user-images.githubusercontent.com/5356595/31744267-ca6f58ac-b423-11e7-8f26-7ccf6147f053.png)

After:

![captura de pantalla 2017-10-18 a la s 16 25 02](https://user-images.githubusercontent.com/5356595/31744275-d073c9ea-b423-11e7-8df7-a446e3e6ab0c.png)

As you can see, the red output from the composer command is still red as the original.

If you doubt that the green is bad, take a look at the noise of an `apt update` execution

![captura de pantalla 2017-10-18 a la s 16 51 08](https://user-images.githubusercontent.com/5356595/31744496-95d113f0-b424-11e7-8a41-bab4c24f4f98.png)

