### PR TITLE
🔐 Self-Signed Wildcard Certificates

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -39,6 +39,7 @@ then
 
         [ alternate_names ]
         DNS.1 = $1
+        DNS.2 = *.$1
     "
     echo "$block" > $PATH_CNF
 

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -12,7 +12,7 @@ fi
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
-    server_name $1;
+    server_name .$1;
     root \"$2\";
 
     index index.html index.htm index.php;

--- a/scripts/serve-proxy.sh
+++ b/scripts/serve-proxy.sh
@@ -3,7 +3,7 @@
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl;
-    server_name $1;
+    server_name .$1;
 
     location / {
         proxy_set_header X-Real-IP \$remote_addr;


### PR DESCRIPTION
Automatically generated self-signed certificates will now have a DNS wildcard attached to that domain, and will also point all subdomains to the same server block inside NGINX.

**Screenshots**

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1L1x2P3K3m3S0I2I3c1h/%5B03729c34038e0dff2d0f5145e0fb732f%5D_Screen%2520Shot%25202017-10-18%2520at%25208.11.25%2520PM.png)

![](https://d3vv6lp55qjaqc.cloudfront.net/items/0r25132P2K1M1j0j2m27/%5B88deaa07cf36130972cc9eb2a4adf4f2%5D_Screen%2520Shot%25202017-10-18%2520at%25208.11.58%2520PM.png)