### PR TITLE
Allow autonetwork plugin to be used.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,10 +16,10 @@ class Homestead
         config.vm.hostname = settings["hostname"] ||= "homestead"
 
         # Configure A Private Network IP
-        if settings["ip"] == "autonetwork"
-            config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
-        else
+        if settings["ip"] != "autonetwork"
             config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
+        else
+            config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
         end
 
         # Configure Additional Networks

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -16,7 +16,11 @@ class Homestead
         config.vm.hostname = settings["hostname"] ||= "homestead"
 
         # Configure A Private Network IP
-        config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
+        if settings["ip"] == "autonetwork"
+            config.vm.network :private_network, :ip => "0.0.0.0", :auto_network => true
+        else
+            config.vm.network :private_network, ip: settings["ip"] ||= "192.168.10.10"
+        end
 
         # Configure Additional Networks
         if settings.has_key?("networks")


### PR DESCRIPTION
Auto network should allow developers to have several homestead boxes running at once without ever having to think about IP addresses.

This solves a particular issue for us, which means we can adopt Homestead as our Vagrant VM across the company. 