### PR TITLE
Add support for the vagrant-hostmanager plugin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
 
-    if defined? VagrantPlugins::HostsUpdater
+    if Vagrant.has_plugin?('vagrant-hostsupdater')
         config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
+    elsif Vagrant.has_plugin?('vagrant-hostmanager')
+        config.hostmanager.enabled = true
+        config.hostmanager.manage_host = true
+        config.hostmanager.aliases = settings['sites'].map { |site| site['map'] }
     end
 end


### PR DESCRIPTION
I used a similar approach as the geerlingguy/drupal-vm project to support both `vagrant-hostsupdater` and `vagrant-hostmanager`.