### PR TITLE
Add ability to easily switch xdebug on and off as required.

### DIFF
--- a/scripts/create-xdebug-switch.sh
+++ b/scripts/create-xdebug-switch.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+mkdir /home/vagrant/.xdebug-switch
+
+echo "zend_extension = xdebug.so
+xdebug.remote_enable=1
+xdebug.remote_host=10.20.1.1
+xdebug.remote_autostart=1" > /home/vagrant/.xdebug-switch/xdebug-autostart.sh
+
+echo "zend_extension = xdebug.so
+xdebug.remote_enable=1
+xdebug.remote_host=10.20.1.1" > /home/vagrant/.xdebug-switch/xdebug-on.sh
+
+echo "zend_extension = xdebug.so" > /home/vagrant/.xdebug-switch/xdebug-off.sh
+
+
+echo "#!/usr/bin/env bash
+
+function xdebug-autostart {
+    sudo cp /home/vagrant/.xdebug-switch/xdebug-autostart.sh /etc/php/7.1/fpm/conf.d/xdebug.ini
+    sudo service php7.1-fpm restart
+    echo \"xdebug is on - autostarting\"
+}
+
+function xdebug-on {
+    sudo cp /home/vagrant/.xdebug-switch/xdebug-on.sh /etc/php/7.1/fpm/conf.d/xdebug.ini
+    sudo service php7.1-fpm restart
+    echo \"xdebug is on\"
+}
+
+function xdebug-off {
+   sudo cp /home/vagrant/.xdebug-switch/xdebug-off.sh /etc/php/7.1/fpm/conf.d/xdebug.ini
+   sudo service php7.1-fpm restart
+   echo \"xdebug is off\"
+}
+
+function xdebug-autostart-cli {
+    sudo cp /home/vagrant/.xdebug-switch/xdebug-autostart.sh /etc/php/7.1/cli/conf.d/xdebug.ini
+    echo \"xdebug (for cli) is on - autostarting\"
+}
+
+function xdebug-on-cli {
+    sudo cp /home/vagrant/.xdebug-switch/xdebug-on.sh /etc/php/7.1/cli/conf.d/xdebug.ini
+    echo \"xdebug (for cli) is on\"
+}
+
+function xdebug-off-cli {
+   sudo cp /home/vagrant/.xdebug-switch/xdebug-off.sh /etc/php/7.1/cli/conf.d/xdebug.ini
+   echo \"xdebug (for cli) is off\"
+}
+
+
+" > tee /etc/profile.d/xdebug.sh
+
+sudo service php7.1-fpm start
+

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -357,5 +357,10 @@ class Homestead
             s.args = [settings["ip"]]
             s.privileged = false
         end
+
+        # Configure xdebug switch
+        config.vm.provision "shell" do |s|
+            s.path = scriptDir + "/create-xdebug-switch.sh"
+        end
     end
 end


### PR DESCRIPTION
This is a bit speculative, I've not considered what to do about php versions other than 7.1, and would appreciate thoughts on this for example.

Anyway, here's what you can do once you've fired up a homestead box with this running, and have ssh'd into the box.

These commands will work from any directory.

xdebug-off        - will switch off xDebug
xdebug-on         - will switch on xDebug
xdebug-autostart  - will switch on xDebug and set it to start automatically
xdebug-cli-off        - will switch off xDebug on php cli
xdebug-cli-on         - will switch on xDebug on php cli
xdebug-cli-autostart  - will switch on xDebug on php cli and set it to start automatically