### PR TITLE
Move php-fpm env to pool configuration

### DIFF
--- a/scripts/clear-variables.sh
+++ b/scripts/clear-variables.sh
@@ -3,6 +3,6 @@
 # Clear The Old Environment Variables
 
 sed -i '/# Set Homestead Environment Variable/,+1d' /home/vagrant/.profile
-sed -i '/env\[.*/,+1d' /etc/php/5.6/fpm/php-fpm.conf
-sed -i '/env\[.*/,+1d' /etc/php/7.0/fpm/php-fpm.conf
-sed -i '/env\[.*/,+1d' /etc/php/7.1/fpm/php-fpm.conf
+sed -i '/env\[.*/,+1d' /etc/php/5.6/fpm/pool.d/www.conf
+sed -i '/env\[.*/,+1d' /etc/php/7.0/fpm/pool.d/www.conf
+sed -i '/env\[.*/,+1d' /etc/php/7.1/fpm/pool.d/www.conf

--- a/scripts/clear-variables.sh
+++ b/scripts/clear-variables.sh
@@ -6,3 +6,4 @@ sed -i '/# Set Homestead Environment Variable/,+1d' /home/vagrant/.profile
 sed -i '/env\[.*/,+1d' /etc/php/5.6/fpm/pool.d/www.conf
 sed -i '/env\[.*/,+1d' /etc/php/7.0/fpm/pool.d/www.conf
 sed -i '/env\[.*/,+1d' /etc/php/7.1/fpm/pool.d/www.conf
+sed -i '/env\[.*/,+1d' /etc/php/7.2/fpm/pool.d/www.conf

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -305,22 +305,22 @@ class Homestead
         if settings.has_key?("variables")
             settings["variables"].each do |var|
                 config.vm.provision "shell" do |s|
-                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/5.6/fpm/php-fpm.conf"
+                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/5.6/fpm/pool.d/www.conf"
                     s.args = [var["key"], var["value"]]
                 end
 
                 config.vm.provision "shell" do |s|
-                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.0/fpm/php-fpm.conf"
+                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.0/fpm/pool.d/www.conf"
                     s.args = [var["key"], var["value"]]
                 end
 
                 config.vm.provision "shell" do |s|
-                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.1/fpm/php-fpm.conf"
+                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.1/fpm/pool.d/www.conf"
                     s.args = [var["key"], var["value"]]
                 end
 
                 config.vm.provision "shell" do |s|
-                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.2/fpm/php-fpm.conf"
+                    s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/7.2/fpm/pool.d/www.conf"
                     s.args = [var["key"], var["value"]]
                 end
 


### PR DESCRIPTION
Setting environment variables in php-fpm.conf via the env[] array is
broken in PHP 5.6. Moving the setting to the /etc/php/*/php-fpm/pool.d/www.conf
works perfectly fine. Fixes #625, fixes #710.