### PR TITLE
Fix for cron.service: Start request repeated too quickly.

### DIFF
--- a/scripts/cron-restart.sh
+++ b/scripts/cron-restart.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+service cron restart

--- a/scripts/cron-schedule.sh
+++ b/scripts/cron-schedule.sh
@@ -10,5 +10,3 @@ SITE_PUBLIC_DIRECTORY=$2
 cron="* * * * * vagrant /usr/bin/php $SITE_PUBLIC_DIRECTORY/../artisan schedule:run >> /dev/null 2>&1"
 
 echo "$cron" > "/etc/cron.d/$SITE_DOMAIN"
-
-service cron restart

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -184,6 +184,7 @@ class Homestead
         end
 
         if settings.include? 'sites'
+            has_cron = false
             settings["sites"].each do |site|
 
                 # Create SSL certificate
@@ -220,6 +221,7 @@ class Homestead
                         if (site["schedule"])
                             s.path = scriptDir + "/cron-schedule.sh"
                             s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
+                            has_cron = true
                         else
                             s.inline = "rm -f /etc/cron.d/$1"
                             s.args = [site["map"].tr('^A-Za-z0-9', '')]
@@ -232,6 +234,11 @@ class Homestead
                         s.args = [site["map"].tr('^A-Za-z0-9', '')]
                     end
                 end
+            end
+            # Restart cron daemon
+            if has_cron
+                config.vm.provision "shell" do |s|
+                s.path = scriptDir + "/cron-restart.sh"
             end
         end
 


### PR DESCRIPTION
Nov 17 14:02:09 homestead systemd[1]: cron.service: Start request repeated too quickly.

https://laracasts.com/discuss/channels/servers/homestead-create-schedule-fails

This is due to each site configured in the VM restarting the cron service very quickly.
The service does not like this. :) 
I simply added a flag to check if any of the sites have schedule flagged and restart once after the site configurations are done.