### PR TITLE
missing end after cron-restart.sh fires

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -238,7 +238,8 @@ class Homestead
             # Restart cron daemon
             if has_cron
                 config.vm.provision "shell" do |s|
-                s.path = scriptDir + "/cron-restart.sh"
+                    s.path = scriptDir + "/cron-restart.sh"
+                end
             end
         end
 


### PR DESCRIPTION
getting error "homestead.rb:377: syntax error, unexpected end-of-input, expecting keyword_end" after `vagrant provision`