### PR TITLE
Refactor cron provisioning

### DIFF
--- a/scripts/cron-restart.sh
+++ b/scripts/cron-restart.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-service cron restart

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -184,7 +184,6 @@ class Homestead
         end
 
         if settings.include? 'sites'
-            has_cron = false
             settings["sites"].each do |site|
 
                 # Create SSL certificate
@@ -221,7 +220,6 @@ class Homestead
                         if (site["schedule"])
                             s.path = scriptDir + "/cron-schedule.sh"
                             s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
-                            has_cron = true
                         else
                             s.inline = "rm -f /etc/cron.d/$1"
                             s.args = [site["map"].tr('^A-Za-z0-9', '')]
@@ -235,10 +233,11 @@ class Homestead
                     end
                 end
             end
-            # Restart cron daemon
-            if has_cron
+
+            if sites.any? { |site| site.has_key?("schedule") }
                 config.vm.provision "shell" do |s|
-                s.path = scriptDir + "/cron-restart.sh"
+                s.name = "Restarting Cron"
+                s.inline = "sudo service cron restart"
             end
         end
 


### PR DESCRIPTION
Removes the flag to check if a site has schedule to trigger the service restart. Now it makes the check directly and its more expressive.

Also, it inlines the script to restart the service.

@svpernova09 there is something that bugs me, here is my scenario:

- A site has schedule and homestead is provisioned.
- A site removes the schedule and homestead is provisioned again.

With the current implementation, homestead will not restart the cron service when the schedule has been removed. It should?

If the answer is yes, then we should restart every time, it will be very cheap because it will happen only once per provisioning. We already have precedent for this with the nginx and php-fpm services that are restarted no matter what in each provisioning cycle.

If the answer is no, then no further action is required.