### PR TITLE
Restart crond service once per provision

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -233,12 +233,11 @@ class Homestead
                     end
                 end
             end
+        end
 
-            if sites.any? { |site| site.has_key?("schedule") }
-                config.vm.provision "shell" do |s|
-                s.name = "Restarting Cron"
-                s.inline = "sudo service cron restart"
-            end
+        config.vm.provision "shell" do |s|
+            s.name = "Restarting Cron"
+            s.inline = "sudo service cron restart"
         end
 
         config.vm.provision "shell" do |s|


### PR DESCRIPTION
As discussed in #730 It will now restart the `crond` service once per provision instead of certain situations involving the `schedule` key in the `sites` settings.