### PR TITLE
Refactoring tests

### DIFF
--- a/tests/InitScriptTest.php
+++ b/tests/InitScriptTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use Tests\Traits\GeneratesTestDirectory;
 use PHPUnit\Framework\TestCase;
+use Tests\Traits\GeneratesTestDirectory;
 
 class InitScriptTest extends TestCase
 {

--- a/tests/InitScriptTest.php
+++ b/tests/InitScriptTest.php
@@ -3,7 +3,7 @@
 namespace Tests;
 
 use Tests\Traits\GeneratesTestDirectory;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class InitScriptTest extends TestCase
 {

--- a/tests/InitScriptTest.php
+++ b/tests/InitScriptTest.php
@@ -33,7 +33,7 @@ class InitScriptTest extends TestCase
     {
         exec('bash init.sh');
 
-        $this->assertTrue(file_exists(self::$testDirectory.'/Homestead.yaml'));
+        $this->assertFileExists(self::$testDirectory.'/Homestead.yaml');
     }
 
     /** @test */
@@ -41,7 +41,7 @@ class InitScriptTest extends TestCase
     {
         exec('bash init.sh json');
 
-        $this->assertTrue(file_exists(self::$testDirectory.'/Homestead.json'));
+        $this->assertFileExists(self::$testDirectory.'/Homestead.json');
     }
 
     /** @test */
@@ -49,7 +49,7 @@ class InitScriptTest extends TestCase
     {
         exec('bash init.sh');
 
-        $this->assertTrue(file_exists(self::$testDirectory.'/after.sh'));
+        $this->assertFileExists(self::$testDirectory.'/after.sh');
     }
 
     /** @test */
@@ -57,6 +57,6 @@ class InitScriptTest extends TestCase
     {
         exec('bash init.sh');
 
-        $this->assertTrue(file_exists(self::$testDirectory.'/aliases'));
+        $this->assertFileExists(self::$testDirectory.'/aliases');
     }
 }

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -5,7 +5,7 @@ namespace Tests;
 use Symfony\Component\Yaml\Yaml;
 use Laravel\Homestead\MakeCommand;
 use Tests\Traits\GeneratesTestDirectory;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Laravel\Homestead\Traits\GeneratesSlugs;
 use Symfony\Component\Console\Tester\CommandTester;
 

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -42,9 +42,9 @@ class MakeCommandTest extends TestCase
 
         $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'Vagrantfile');
 
-        $this->assertEquals(
-            file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Vagrantfile'),
-            file_get_contents(__DIR__.'/../resources/localized/Vagrantfile')
+        $this->assertFileEquals(
+            self::$testDirectory.DIRECTORY_SEPARATOR.'Vagrantfile',
+            __DIR__.'/../resources/localized/Vagrantfile'
         );
     }
 
@@ -74,9 +74,9 @@ class MakeCommandTest extends TestCase
 
         $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases');
 
-        $this->assertEquals(
-            file_get_contents(__DIR__.'/../resources/aliases'),
-            file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases')
+        $this->assertFileEquals(
+            __DIR__.'/../resources/aliases',
+            self::$testDirectory.DIRECTORY_SEPARATOR.'aliases'
         );
     }
 
@@ -91,9 +91,9 @@ class MakeCommandTest extends TestCase
 
         $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases');
 
-        $this->assertEquals(
-            file_get_contents(__DIR__.'/../resources/localized/aliases'),
-            file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'aliases')
+        $this->assertFileEquals(
+            __DIR__.'/../resources/localized/aliases',
+            self::$testDirectory.DIRECTORY_SEPARATOR.'aliases'
         );
     }
 
@@ -137,9 +137,9 @@ class MakeCommandTest extends TestCase
 
         $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh');
 
-        $this->assertEquals(
-            file_get_contents(__DIR__.'/../resources/after.sh'),
-            file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh')
+        $this->assertFileEquals(
+            __DIR__.'/../resources/after.sh',
+            self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh'
         );
     }
 

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -396,9 +396,11 @@ class MakeCommandTest extends TestCase
 
         $settings = Yaml::parse(file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.yaml'));
 
-        $this->assertEquals('test_name', $settings['name']);
-        $this->assertEquals('test_hostname', $settings['hostname']);
-        $this->assertEquals('127.0.0.1', $settings['ip']);
+        $this->assertArraySubset([
+            'name' => 'test_name',
+            'hostname' => 'test_hostname',
+            'ip' => '127.0.0.1',
+        ], $settings);
     }
 
     /** @test */
@@ -417,9 +419,11 @@ class MakeCommandTest extends TestCase
 
         $settings = json_decode(file_get_contents(self::$testDirectory.DIRECTORY_SEPARATOR.'Homestead.json'), true);
 
-        $this->assertEquals('test_name', $settings['name']);
-        $this->assertEquals('test_hostname', $settings['hostname']);
-        $this->assertEquals('127.0.0.1', $settings['ip']);
+        $this->assertArraySubset([
+            'name' => 'test_name',
+            'hostname' => 'test_hostname',
+            'ip' => '127.0.0.1',
+        ], $settings);
     }
 
     /** @test */

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 use Laravel\Homestead\MakeCommand;
 use Tests\Traits\GeneratesTestDirectory;
-use PHPUnit\Framework\TestCase;
 use Laravel\Homestead\Traits\GeneratesSlugs;
 use Symfony\Component\Console\Tester\CommandTester;
 

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Settings;
 
-use Tests\Traits\GeneratesTestDirectory;
 use PHPUnit\Framework\TestCase;
+use Tests\Traits\GeneratesTestDirectory;
 use Laravel\Homestead\Settings\JsonSettings;
 
 class JsonSettingsTest extends TestCase

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Settings;
 
 use Tests\Traits\GeneratesTestDirectory;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Laravel\Homestead\Settings\JsonSettings;
 
 class JsonSettingsTest extends TestCase

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -33,7 +33,7 @@ class JsonSettingsTest extends TestCase
 
         $settings->save($filename);
 
-        $this->assertTrue(file_exists($filename));
+        $this->assertFileExists($filename);
         $attributes = json_decode(file_get_contents($filename), true);
         $this->assertEquals('192.168.10.10', $attributes['ip']);
         $this->assertEquals('2048', $attributes['memory']);

--- a/tests/Settings/JsonSettingsTest.php
+++ b/tests/Settings/JsonSettingsTest.php
@@ -15,10 +15,11 @@ class JsonSettingsTest extends TestCase
     {
         $settings = JsonSettings::fromFile(__DIR__.'/../../resources/Homestead.json');
 
-        $attributes = $settings->toArray();
-        $this->assertEquals('192.168.10.10', $attributes['ip']);
-        $this->assertEquals('2048', $attributes['memory']);
-        $this->assertEquals(1, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '192.168.10.10',
+            'memory' => '2048',
+            'cpus' => '1',
+        ], $settings->toArray());
     }
 
     /** @test */
@@ -35,9 +36,11 @@ class JsonSettingsTest extends TestCase
 
         $this->assertFileExists($filename);
         $attributes = json_decode(file_get_contents($filename), true);
-        $this->assertEquals('192.168.10.10', $attributes['ip']);
-        $this->assertEquals('2048', $attributes['memory']);
-        $this->assertEquals(1, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '192.168.10.10',
+            'memory' => '2048',
+            'cpus' => '1',
+        ], $settings->toArray());
     }
 
     /** @test */
@@ -55,10 +58,11 @@ class JsonSettingsTest extends TestCase
             'cpus' => 2,
         ]);
 
-        $attributes = $settings->toArray();
-        $this->assertEquals('127.0.0.1', $attributes['ip']);
-        $this->assertEquals('4096', $attributes['memory']);
-        $this->assertEquals(2, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '127.0.0.1',
+            'memory' => '4096',
+            'cpus' => '2',
+        ], $settings->toArray());
     }
 
     /** @test */
@@ -76,10 +80,11 @@ class JsonSettingsTest extends TestCase
             'cpus' => null,
         ]);
 
-        $attributes = $settings->toArray();
-        $this->assertEquals('192.168.10.10', $attributes['ip']);
-        $this->assertEquals('2048', $attributes['memory']);
-        $this->assertEquals(1, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '192.168.10.10',
+            'memory' => '2048',
+            'cpus' => '1',
+        ], $settings->toArray());
     }
 
     /** @test */

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -2,9 +2,9 @@
 
 namespace Tests\Settings;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 use Tests\Traits\GeneratesTestDirectory;
-use PHPUnit\Framework\TestCase;
 use Laravel\Homestead\Settings\YamlSettings;
 
 class YamlSettingsTest extends TestCase

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -34,7 +34,7 @@ class YamlSettingsTest extends TestCase
 
         $settings->save($filename);
 
-        $this->assertTrue(file_exists($filename));
+        $this->assertFileExists($filename);
         $attributes = Yaml::parse(file_get_contents($filename));
         $this->assertEquals('192.168.10.10', $attributes['ip']);
         $this->assertEquals('2048', $attributes['memory']);

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -16,10 +16,11 @@ class YamlSettingsTest extends TestCase
     {
         $settings = YamlSettings::fromFile(__DIR__.'/../../resources/Homestead.yaml');
 
-        $attributes = $settings->toArray();
-        $this->assertEquals('192.168.10.10', $attributes['ip']);
-        $this->assertEquals('2048', $attributes['memory']);
-        $this->assertEquals(1, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '192.168.10.10',
+            'memory' => '2048',
+            'cpus' => '1',
+        ], $settings->toArray());
     }
 
     /** @test */
@@ -35,10 +36,11 @@ class YamlSettingsTest extends TestCase
         $settings->save($filename);
 
         $this->assertFileExists($filename);
-        $attributes = Yaml::parse(file_get_contents($filename));
-        $this->assertEquals('192.168.10.10', $attributes['ip']);
-        $this->assertEquals('2048', $attributes['memory']);
-        $this->assertEquals(1, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '192.168.10.10',
+            'memory' => '2048',
+            'cpus' => '1',
+        ], Yaml::parse(file_get_contents($filename)));
     }
 
     /** @test */
@@ -56,10 +58,11 @@ class YamlSettingsTest extends TestCase
             'cpus' => 2,
         ]);
 
-        $attributes = $settings->toArray();
-        $this->assertEquals('127.0.0.1', $attributes['ip']);
-        $this->assertEquals('4096', $attributes['memory']);
-        $this->assertEquals(2, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '127.0.0.1',
+            'memory' => '4096',
+            'cpus' => '2',
+        ], $settings->toArray());
     }
 
     /** @test */
@@ -77,10 +80,11 @@ class YamlSettingsTest extends TestCase
             'cpus' => null,
         ]);
 
-        $attributes = $settings->toArray();
-        $this->assertEquals('192.168.10.10', $attributes['ip']);
-        $this->assertEquals('2048', $attributes['memory']);
-        $this->assertEquals(1, $attributes['cpus']);
+        $this->assertArraySubset([
+            'ip' => '192.168.10.10',
+            'memory' => '2048',
+            'cpus' => '1',
+        ], $settings->toArray());
     }
 
     /** @test */

--- a/tests/Settings/YamlSettingsTest.php
+++ b/tests/Settings/YamlSettingsTest.php
@@ -4,7 +4,7 @@ namespace Tests\Settings;
 
 use Symfony\Component\Yaml\Yaml;
 use Tests\Traits\GeneratesTestDirectory;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Laravel\Homestead\Settings\YamlSettings;
 
 class YamlSettingsTest extends TestCase


### PR DESCRIPTION
I've refactored some tests, using:

- [`assertFileEixsts`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileEquals) instead of `assertTrue(file_exists())`;
- [`assertArraySubset`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertArraySubset) when comparing `arrays`;
- [`assertFileEquals`](https://phpunit.de/manual/current/pt_br/appendixes.assertions.html#appendixes.assertions.assertFileEquals) when comparing files.

I've also removed unnecessary aliases for `PHPUnit\Framework\TestCase`;