### PR TITLE
Correct the regex used for the fastcgi_split_path_info parameter in the Symfony nginx config.

### DIFF
--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -36,7 +36,7 @@ block="server {
 
     # DEV
     location ~ ^/(app_dev|app_test|config)\.php(/|\$) {
-        fastcgi_split_path_info ^(.+\.php)(/.+)\$;
+        fastcgi_split_path_info ^(.+\.php)(/.*)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
@@ -49,7 +49,7 @@ block="server {
 
     # PROD
     location ~ ^/app\.php(/|$) {
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;


### PR DESCRIPTION
When running Symfony applications in Homestead, we get a 403 error when trying to access the site from `http://my-symfony-app.local/app_dev.php/`, which should be allowed.

This pull request changes the regex used for the fastcgi_split_path_info parameter, to match the regex used in Symfony's [reference documentation](https://symfony.com/doc/3.4/setup/web_server_configuration.html#nginx).

This is my first PR here, so please let me know if I need to provide any more information or have followed the process incorrectly.

Thanks again, we are finding Homestead extremely useful!