### PR TITLE
Cron Schedule :: change sites does not remove old

### DIFF
--- a/scripts/cron-schedule.sh
+++ b/scripts/cron-schedule.sh
@@ -9,4 +9,4 @@ SITE_PUBLIC_DIRECTORY=$2
 
 cron="* * * * * vagrant /usr/bin/php $SITE_PUBLIC_DIRECTORY/../artisan schedule:run >> /dev/null 2>&1"
 
-echo "$cron" > "/etc/cron.d/$SITE_DOMAIN"
+echo "$cron" > "/etc/cron.d/homestead-schedule-$SITE_DOMAIN"

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -212,6 +212,10 @@ class Homestead
                     s.args = [site["map"], site["to"], site["port"] ||= "80", site["ssl"] ||= "443", site["php"] ||= "7.2", params ||= ""]
                 end
 
+                # Remove all existing Cron Schedules
+                config.vm.provision "shell" do |s|
+                    s.inline = "rm -f /etc/cron.d/*"
+		        end
                 # Configure The Cron Schedule
                 if (site.has_key?("schedule"))
                     config.vm.provision "shell" do |s|
@@ -220,9 +224,6 @@ class Homestead
                         if (site["schedule"])
                             s.path = scriptDir + "/cron-schedule.sh"
                             s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
-                        else
-                            s.inline = "rm -f /etc/cron.d/$1"
-                            s.args = [site["map"].tr('^A-Za-z0-9', '')]
                         end
                     end
                 else

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -222,8 +222,12 @@ class Homestead
                         s.name = "Creating Schedule"
 
                         if (site["schedule"])
+                            # create new cron with prefixed site_domain.
                             s.path = scriptDir + "/cron-schedule.sh"
                             s.args = [site["map"].tr('^A-Za-z0-9', ''), site["to"]]
+                            # remove old, non-prefixed crons
+                            s.inline = "rm -f /etc/cron.d/$1"
+                            s.args = [site["map"].tr('^A-Za-z0-9', '')]
                         end
                     end
                 else

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -214,8 +214,8 @@ class Homestead
 
                 # Remove all existing Cron Schedules
                 config.vm.provision "shell" do |s|
-                    s.inline = "rm -f /etc/cron.d/*"
-		        end
+                    s.inline = "rm -f /etc/cron.d/homestead-schedule-*"
+		end
                 # Configure The Cron Schedule
                 if (site.has_key?("schedule"))
                     config.vm.provision "shell" do |s|


### PR DESCRIPTION
# This will remove all cron.d files (prefixed now) instead of per site.
This is useful for when you reprovision a box with adding some sites and removing others...

Recent Example:  `app.dev` becomes `app.test`

## Possible issues 
 1 - do not remove all
removing ALL cron.d entries if you have custom things in cron.d
## Solution: 
also have the cron-schedule.sh script prefix homestead schedules with something like "homestead-"
Then have `s.inline = "rm -f /etc/cron.d/horizon-*"`

 2 - old crons
anyone reprovisioning with this change, will have duplicate cron.d files
 - `{site_domain}`
 - `horizon-schedule-{site_domain}`
This will not clean up existing boxes now, but it will for future boxes and releases.  I have an idea for this....
