### PR TITLE
SSL certificates are now signed with a custom root certificate.

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -3,47 +3,120 @@
 mkdir /etc/nginx/ssl 2>/dev/null
 
 PATH_SSL="/etc/nginx/ssl"
+
+# Path to the custom Homestead Root CA certificate.
+PATH_ROOT_CNF="${PATH_SSL}/ca.homestead.cnf"
+PATH_ROOT_CRT="${PATH_SSL}/ca.homestead.crt"
+PATH_ROOT_KEY="${PATH_SSL}/ca.homestead.key"
+
+# Path to the custom site certificate.
 PATH_CNF="${PATH_SSL}/${1}.cnf"
-PATH_KEY="${PATH_SSL}/${1}.key"
 PATH_CRT="${PATH_SSL}/${1}.crt"
+PATH_CSR="${PATH_SSL}/${1}.csr"
+PATH_KEY="${PATH_SSL}/${1}.key"
+
+BASE_CNF="
+    [ ca ]
+    default_ca = ca_homestead
+
+    [ ca_homestead ]
+    dir           = $PATH_SSL
+    certs         = $PATH_SSL
+    new_certs_dir = $PATH_SSL
+
+    private_key   = $PATH_ROOT_KEY
+    certificate   = $PATH_ROOT_CRT
+
+    default_md    = sha256
+
+    name_opt      = ca_default
+    cert_opt      = ca_default
+    default_days  = 365
+    preserve      = no
+    policy        = policy_loose
+
+    [ policy_loose ]
+    countryName             = optional
+    stateOrProvinceName     = optional
+    localityName            = optional
+    organizationName        = optional
+    organizationalUnitName  = optional
+    commonName              = supplied
+    emailAddress            = optional
+
+    [ req ]
+    prompt              = no
+    encrypt_key         = no
+    default_bits        = 2048
+    distinguished_name  = req_distinguished_name
+    string_mask         = utf8only
+    default_md          = sha256
+    x509_extensions     = v3_ca
+
+    [ v3_ca ]
+    authorityKeyIdentifier = keyid,issuer
+    basicConstraints       = critical, CA:true, pathlen:0
+    keyUsage               = critical, digitalSignature, keyCertSign
+    subjectKeyIdentifier   = hash
+
+    [ server_cert ]
+    authorityKeyIdentifier = keyid,issuer:always
+    basicConstraints       = CA:FALSE
+    extendedKeyUsage       = serverAuth
+    keyUsage               = critical, digitalSignature, keyEncipherment
+    subjectAltName         = @alternate_names
+    subjectKeyIdentifier   = hash
+"
+
+# Only generate the root certificate when there isn't one already there.
+if [ ! -f $PATH_ROOT_CNF ] || [ ! -f $PATH_ROOT_KEY ] || [ ! -f $PATH_ROOT_CRT ]
+then
+    # Generate an OpenSSL configuration file specifically for this certificate.
+    cnf="
+        ${BASE_CNF}
+        [ req_distinguished_name ]
+        O  = Vagrant
+        C  = UN
+        CN = Homestead Root CA
+    "
+    echo "$cnf" > $PATH_ROOT_CNF
+
+    # Finally, generate the private key and certificate.
+    openssl genrsa -out "$PATH_ROOT_KEY" 4096 2>/dev/null
+    openssl req -config "$PATH_ROOT_CNF" \
+        -key "$PATH_ROOT_KEY" \
+        -x509 -new -extensions v3_ca -days 3650 -sha256 \
+        -out "$PATH_ROOT_CRT" 2>/dev/null
+fi
 
 # Only generate a certificate if there isn't one already there.
 if [ ! -f $PATH_CNF ] || [ ! -f $PATH_KEY ] || [ ! -f $PATH_CRT ]
 then
-
     # Uncomment the global 'copy_extentions' OpenSSL option to ensure the SANs are copied into the certificate.
     sed -i '/copy_extensions\ =\ copy/s/^#\ //g' /etc/ssl/openssl.cnf
 
     # Generate an OpenSSL configuration file specifically for this certificate.
-    block="
-        [ req ]
-        prompt = no
-        default_bits = 2048
-        default_keyfile = $PATH_KEY
-        encrypt_key = no
-        default_md = sha256
-        distinguished_name = req_distinguished_name
-        x509_extensions = v3_ca
-
+    cnf="
+        ${BASE_CNF}
         [ req_distinguished_name ]
-        O=Vagrant
-        C=UN
-        CN=$1
-
-        [ v3_ca ]
-        basicConstraints=CA:FALSE
-        subjectKeyIdentifier=hash
-        authorityKeyIdentifier=keyid,issuer
-        keyUsage = nonRepudiation, digitalSignature, keyEncipherment
-        subjectAltName = @alternate_names
+        O  = Vagrant
+        C  = UN
+        CN = $1
 
         [ alternate_names ]
         DNS.1 = $1
         DNS.2 = *.$1
     "
-    echo "$block" > $PATH_CNF
+    echo "$cnf" > $PATH_CNF
 
-    # Finally, generate the private key and certificate.
+    # Finally, generate the private key and certificate signed with the Homestead Root CA.
     openssl genrsa -out "$PATH_KEY" 2048 2>/dev/null
-    openssl req -new -x509 -config "$PATH_CNF" -out "$PATH_CRT" -days 365 2>/dev/null
+    openssl req -config "$PATH_CNF" \
+        -key "$PATH_KEY" \
+        -new -sha256 -out "$PATH_CSR" 2>/dev/null
+    openssl x509 -req -extfile "$PATH_CNF" \
+        -extensions server_cert -days 365 \
+        -in "$PATH_CSR" \
+        -CA "$PATH_ROOT_CRT" -CAkey "$PATH_ROOT_KEY" -CAcreateserial \
+        -out "$PATH_CRT" 2>/dev/null
 fi


### PR DESCRIPTION
This slightly changes the process of signing certificates. Instead of creating a self signed certificate for every site you've defined in your homestead box, these certificate will now be signed with a custom Root certificate instead.

This is super helpful when you want to add those certificates to your trust store, instead of adding every certificate manually and trusting them you now only need to add the Root CRT to the trust store and everything signed with it will be automatically trusted.

<img width="761" alt="screen shot 2017-12-21 at 16 16 20" src="https://user-images.githubusercontent.com/2406615/34295718-15a8bd90-e70f-11e7-8a0a-a3727bd57e0c.png">

**Small side note:** Just like the current implementation, SSL certificates wont be replaced when they're already have been created. If you want to create a new SSL certificate for your site signed with the Root certificate, simply remove the `name.of.your.site.*` files from the `/etc/nginx/ssl` directory in your homestead box and 're-provision' your sites. This will automatically create new certificates.