### PR TITLE
Enable symlinks on shared folders with VirtualBox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,4 +45,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.hostmanager.manage_host = true
         config.hostmanager.aliases = settings['sites'].map { |site| site['map'] }
     end
+
+    config.vm.provider "virtualbox" do |v|
+        v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+    end
 end


### PR DESCRIPTION
See https://stackoverflow.com/questions/24200333/symbolic-links-and-synced-folders-in-vagrant

Tried and tested on Win 10 Pro. Without this 'fix', npm install fails for a variety of projects due to not being able to create symlinks