### PR TITLE
allow server with no sites config. (redis, elastic...)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,12 +37,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exist? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
-
-    if Vagrant.has_plugin?('vagrant-hostsupdater')
-        config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
-    elsif Vagrant.has_plugin?('vagrant-hostmanager')
-        config.hostmanager.enabled = true
-        config.hostmanager.manage_host = true
-        config.hostmanager.aliases = settings['sites'].map { |site| site['map'] }
-    end
 end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -243,6 +243,14 @@ class Homestead
                     end
                 end
             end
+
+            if Vagrant.has_plugin?('vagrant-hostsupdater')
+                config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
+            elsif Vagrant.has_plugin?('vagrant-hostmanager')
+                config.hostmanager.enabled = true
+                config.hostmanager.manage_host = true
+                config.hostmanager.aliases = settings['sites'].map { |site| site['map'] }
+            end
         end
 
         # Configure All Of The Server Environment Variables


### PR DESCRIPTION
Current Vagrantfile fails if you do not have sites configures. this update moves it into the sites area of the homestead.rb, confirming that sites exist first.  

This is useful for creating additional redis, elastic, database servers to mimic a larger environment.