### PR TITLE
Don’t add bindfs configs if the share type is not NFS

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -167,8 +167,10 @@ class Homestead
                     config.vm.synced_folder folder["map"], folder["to"], type: folder["type"] ||= nil, **options
 
                     # Bindfs support to fix shared folder (NFS) permission issue on Mac
-                    if Vagrant.has_plugin?("vagrant-bindfs")
-                        config.bindfs.bind_folder folder["to"], folder["to"]
+                    if (folder["type"] == "nfs")
+                        if Vagrant.has_plugin?("vagrant-bindfs")
+                            config.bindfs.bind_folder folder["to"], folder["to"]
+                        end
                     end
                 else
                     config.vm.provision "shell" do |s|


### PR DESCRIPTION
You’ll get errors when trying to access these folders otherwise:

```
ls: reading directory '.': Software caused connection abort
ls: cannot open directory '.': Transport endpoint is not connected
```

I installed bindfs because I was going to start using NFS shares but I had turned NFS off temporarily to test something and this happened.
  