### PR TITLE
Enable cable connection on the booted vm 

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -35,6 +35,7 @@ class Homestead
             vb.customize ["modifyvm", :id, "--memory", settings["memory"] ||= "2048"]
             vb.customize ["modifyvm", :id, "--cpus", settings["cpus"] ||= "1"]
             vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+            vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
             vb.customize ["modifyvm", :id, "--natdnshostresolver1", settings["natdnshostresolver"] ||= "on"]
             vb.customize ["modifyvm", :id, "--ostype", "Ubuntu_64"]
             if settings.has_key?("gui") && settings["gui"]


### PR DESCRIPTION
A lot of people had a timeout error when booting the vm , because failure of raising the network interfaces.
`A start job is running for raise network interfaces`

![](https://i.stack.imgur.com/gMkdg.png)

fixing it is to enable cable connection in the vm.
