### PR TITLE
Enable mod_headers

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -169,6 +169,9 @@ sudo a2enmod rewrite
 # Turn on HTTPS support
 sudo a2enmod ssl
 
+# Turn on headers support
+sudo a2enmod headers
+
 service apache2 restart
 
 if [ $? == 0 ]


### PR DESCRIPTION
Enable mod_headers for sites running on Apache. This allows users to add headers to responses using .htaccess etc.