### PR TITLE
mongodb extension to 1.4.0

### DIFF
--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -23,7 +23,7 @@ sudo systemctl enable mongod
 sudo systemctl start mongod
 
 sudo rm -rf /tmp/mongo-php-driver /usr/src/mongo-php-driver
-git clone -c advice.detachedHead=false -q -b '1.3.3' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
+git clone -c advice.detachedHead=false -q -b '1.4.0' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
 sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver
 cd /usr/src/mongo-php-driver
 git submodule -q update --init


### PR DESCRIPTION
mongodb extension to 1.4.0 required with library version 1.3.0 
https://github.com/mongodb/mongo-php-library/pull/498#issuecomment-366987657

could possibly be updated to 1.4.2... but tested and working with 1.4.0