### PR TITLE
Certificate generation fix

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -115,7 +115,7 @@ then
         -key "$PATH_KEY" \
         -new -sha256 -out "$PATH_CSR" 2>/dev/null
     openssl x509 -req -extfile "$PATH_CNF" \
-        -extensions server_cert -days 365 \
+        -extensions server_cert -days 365 -sha256 \
         -in "$PATH_CSR" \
         -CA "$PATH_ROOT_CRT" -CAkey "$PATH_ROOT_KEY" -CAcreateserial \
         -out "$PATH_CRT" 2>/dev/null


### PR DESCRIPTION
Certificate for a website was generated as SHA-1 instead of SHA-256. This fix ensure, that correct certificate is generated every time.