### PR TITLE
Add Object Storage with Minio

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -317,6 +317,13 @@ class Homestead
             end
         end
 
+        # Install Minio If Necessary
+        if settings.has_key?("minio") && settings["minio"]
+            config.vm.provision "shell" do |s|
+                s.path = scriptDir + "/install-minio.sh"
+            end
+        end
+        
         # Install MongoDB If Necessary
         if settings.has_key?("mongodb") && settings["mongodb"]
             config.vm.provision "shell" do |s|

--- a/scripts/install-minio.sh
+++ b/scripts/install-minio.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+if [ -f /home/vagrant/.minio ]
+then
+    echo "Minio already installed."
+    exit 0
+fi
+
+touch /home/vagrant/.minio
+
+curl -O https://dl.minio.io/server/minio/release/linux-amd64/minio
+
+sudo chmod +x minio
+sudo mv minio /usr/local/bin
+sudo useradd -r minio-user -s /sbin/nologin
+sudo mkdir /usr/local/share/minio
+sudo mkdir /etc/minio
+
+cat <<EOT >> /etc/default/minio
+# Local export path.
+MINIO_VOLUMES="/usr/local/share/minio/"
+# Use if you want to run Minio on a custom port.
+MINIO_OPTS="--config-dir /etc/minio --address :9000"
+MINIO_ACCESS_KEY=homestead
+MINIO_SECRET_KEY=secretkey
+
+EOT
+
+sudo chown minio-user:minio-user /usr/local/share/minio
+sudo chown minio-user:minio-user /etc/minio
+
+curl -O https://raw.githubusercontent.com/minio/minio-service/master/linux-systemd/minio.service
+sudo mv minio.service /etc/systemd/system
+sudo systemctl daemon-reload
+sudo systemctl enable minio
+sudo systemctl start minio
+
+sudo ufw allow 9000


### PR DESCRIPTION
This installs s3 object storage through [Minio](https://www.minio.io/).

It listens on port 9000
Access Key is: `homestead`
Secret Key is: `secretkey`

There was one quark to getting this to work:
```
# config/filesystems.php
	's3' => [
		'driver' => 's3',
		'key' => env('AWS_ACCESS_KEY_ID'),
		'secret' => env('AWS_SECRET_ACCESS_KEY'),
		'region' => env('AWS_DEFAULT_REGION'),
		'bucket' => env('AWS_BUCKET'),
		'endpoint' => env('AWS_URL'),
		'use_path_style_endpoint' => true,
	],
```
I needed to set `use_path_style_endpoint` to `true`