### PR TITLE
Adding support for graph database Neo4j

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -331,6 +331,13 @@ class Homestead
             end
         end
 
+        # Install Neo4j If Necessary
+        if settings.has_key?("neo4j") && settings["neo4j"]
+            config.vm.provision "shell" do |s|
+                s.path = scriptDir + "/install-neo4j.sh"
+            end
+        end
+
         # Install CouchDB If Necessary
         if settings.has_key?("couchdb") && settings["couchdb"]
             config.vm.provision "shell" do |s|

--- a/scripts/install-neo4j.sh
+++ b/scripts/install-neo4j.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+
+if [ -f /etc/neo4j/neo4j.conf ]
+then
+    echo "Neo4j already installed."
+    exit 0
+fi
+
+wget -O - https://debian.neo4j.org/neotechnology.gpg.key | sudo apt-key add -
+echo 'deb https://debian.neo4j.org/repo stable/' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
+apt-get update
+
+# Install Neo4j Community Edition
+apt-get install -y neo4j=1:3.3.5
+
+# Configure Neo4j Remote Access
+sed -i "s/#dbms.connectors.default_listen_address=0.0.0.0/dbms.connectors.default_listen_address=0.0.0.0/" /etc/neo4j/neo4j.conf
+
+# Enable Neo4j as system service
+systemctl enable neo4j
+systemctl start neo4j
+
+# Add new Neo4j user
+cypher-shell -u neo4j -p neo4j "CALL dbms.changePassword('secret');"
+cypher-shell -u neo4j -p secret "CALL dbms.security.createUser('homestead', 'secret', false);"
+
+# Delete default Neo4j user
+cypher-shell -u homestead -p secret "CALL dbms.security.deleteUser('neo4j');"


### PR DESCRIPTION
This installs graph database [Neo4j](https://neo4j.com/docs/operations-manual/3.3/installation/linux/debian/) through the [official documentation](https://neo4j.com/docs/operations-manual/3.3/installation/linux/debian/).

To enable this, update the `Homestead.yaml` by adding the following line:

> neo4j: true
    
The default ports of Neo4j are 7474, 7473, and 7687. After installation, access Neo4j-browser via `http://<guest-ip>:7474/browser/`. The default username is `homestead`, and password is `secret`.

To make Laravel work with Neo4j, the [
Neo4j Graph Eloquent Driver for Laravel](https://github.com/Vinelab/NeoEloquent) should be integrated into the Laravel project.

I will add relevant documentation to [lavarvel/docs](https://github.com/laravel/docs) through another pull request.

This is my first time to submit a pull request. If there is something wrong, please instruct me what I should do next.