### PR TITLE
Fix the issue that Neo4j cannot serve requests immediately after startup

### DIFF
--- a/scripts/install-neo4j.sh
+++ b/scripts/install-neo4j.sh
@@ -14,12 +14,23 @@ apt-get update
 # Install Neo4j Community Edition
 apt-get install -y neo4j=1:3.3.5
 
+# Stop Neo4j for configuration
+systemctl stop neo4j
+
 # Configure Neo4j Remote Access
 sed -i "s/#dbms.connectors.default_listen_address=0.0.0.0/dbms.connectors.default_listen_address=0.0.0.0/" /etc/neo4j/neo4j.conf
 
 # Enable Neo4j as system service
 systemctl enable neo4j
 systemctl start neo4j
+
+# Poll Neo4j
+end="$((SECONDS+60))"
+while true; do
+    nc -w 2 localhost 7687 && break
+    [[ "${SECONDS}" -ge "${end}" ]] && exit 1
+    sleep 1
+done
 
 # Add new Neo4j user
 cypher-shell -u neo4j -p neo4j "CALL dbms.changePassword('secret');"


### PR DESCRIPTION
After starting Neo4j it may take some time before the database is ready to serve requests. The first version install script does not aware this issue.

I fixed this issue by adding a poll script to wait for Neo4j to be available after starting. More details can be found in the [official documentation](https://neo4j.com/docs/operations-manual/3.3/configuration/wait-for-start/).