### PR TITLE
Define types for "apigility", "expressive", and "zf" applications

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -205,7 +205,12 @@ class Homestead
 
                 type = site["type"] ||= "laravel"
 
-                if (type == "symfony")
+                case type
+                when "apigility"
+                    type = "zf"
+                when "expressive"
+                    type = "zf"
+                when "symfony"
                     type = "symfony2"
                 end
 

--- a/scripts/serve-zf.sh
+++ b/scripts/serve-zf.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Script for setting up the web server for any of the following applications:
+#
+# - Apigility
+# - Expressive
+# - zend-mvc
+#
+# Type declaration in Homestead.yaml should be one of:
+#
+# - apigility
+# - expressive
+# - zf
+#
+# The first two are aliases for the last.
+
+declare -A params=$6     # Create an associative array
+paramsTXT=""
+if [ -n "$6" ]; then
+    for element in "${!params[@]}"
+    do
+        paramsTXT="${paramsTXT}
+        fastcgi_param ${element} ${params[$element]};"
+    done
+fi
+
+if [ "$7" = "true" ] && [ "$5" = "7.2" ]
+then configureZray="
+location /ZendServer {
+        try_files \$uri \$uri/ /ZendServer/index.php?\$args;
+}
+"
+else configureZray=""
+fi
+
+block="server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name $1;
+    root \"$2\";
+
+    charset utf-8;
+
+    index index.php index.html;
+
+    location / {
+        try_files \$uri \$uri/ /index.php?\$query_string;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/$1-ssl-error.log error;
+
+    sendfile off;
+
+    client_max_body_size 100m;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.*)\$;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME \$document_root/\$fastcgi_script_name;
+        $paramsTXT
+
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    $configureZray
+
+    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate_key /etc/nginx/ssl/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"


### PR DESCRIPTION
Adds the script `serve-zf.sh`, which sets up an nginx host for use with any of Apigility, Expressive, or zend-mvc applications, as they all use the same setup.

In each case, developers should do the following in `Homestead.yaml`:

- create a `folders` mapping that maps the application root directory to a directory in the vagrant box.
- add a site that
  - defines a "to" setting that appends "/public" to the "to" mapping from the above step.
  - uses a "type" of either:
    - "apigility"
    - "expressive"
    - "zf"

The patch updates `scripts/homestead.rb` to add a `case` statement that redefines the `type` if either `apigility`, `expressive`, or `symfony` are detected. In the first two instances, they map to `zf`; the last maps to `symfony2` (which it did previously via a conditional).