### PR TITLE
Prevent duplicate Mutex posixsem entries

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -173,7 +173,10 @@ sudo a2enmod ssl
 sudo a2enmod headers
 
 # Add Mutex to config to prevent auto restart issues
-echo 'Mutex posixsem' | sudo tee -a /etc/apache2/apache2.conf
+if [ -z "$(grep '^Mutex posixsem$' /etc/apache2/apache2.conf)" ]
+then
+    echo 'Mutex posixsem' | sudo tee -a /etc/apache2/apache2.conf
+fi
 
 service apache2 restart
 


### PR DESCRIPTION
@svpernova09 

I've noticed that the echo mutex fix appends that line to /etc/apache2/apache2.conf for each site registered on each provision. Not a huge problem, but perhaps we should grep for its presence first?