### PR TITLE
Fix install-mongo.sh

### DIFF
--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -28,6 +28,7 @@ sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver
 cd /usr/src/mongo-php-driver
 git submodule -q update --init
 
+sudo apt-get install php5.6-dev
 phpize5.6
 ./configure --with-php-config=/usr/bin/php-config5.6 > /dev/null
 make clean > /dev/null
@@ -39,6 +40,7 @@ sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/cli/conf.d/20-mong
 sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/fpm/conf.d/20-mongo.ini
 sudo service php5.6-fpm restart
 
+sudo apt-get install php7.0-dev
 phpize7.0
 ./configure --with-php-config=/usr/bin/php-config7.0 > /dev/null
 make clean > /dev/null
@@ -50,6 +52,7 @@ sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/cli/conf.d/20-mong
 sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/fpm/conf.d/20-mongo.ini
 sudo service php7.0-fpm restart
 
+sudo apt-get install php7.1-dev
 phpize7.1
 ./configure --with-php-config=/usr/bin/php-config7.1 > /dev/null
 make clean > /dev/null


### PR DESCRIPTION
Add the proper installations of PHP dev installs to the Mongo DB script so that we can use PHPize to properly install the modules.

This isn't documented, but you can add `mongodb:true` to the top-level of your `Homestead.yaml` to install mongodb. It was broken. This PR fixes it.