### PR TITLE
Don't ask for confirmation when installing php-dev packages.

### DIFF
--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -28,7 +28,7 @@ sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver
 cd /usr/src/mongo-php-driver
 git submodule -q update --init
 
-sudo apt-get install php5.6-dev
+sudo DEBIAN_FRONTEND=noninteractive apt-get install php5.6-dev -yq
 phpize5.6
 ./configure --with-php-config=/usr/bin/php-config5.6 > /dev/null
 make clean > /dev/null
@@ -40,7 +40,7 @@ sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/cli/conf.d/20-mong
 sudo ln -s /etc/php/5.6/mods-available/mongo.ini /etc/php/5.6/fpm/conf.d/20-mongo.ini
 sudo service php5.6-fpm restart
 
-sudo apt-get install php7.0-dev
+sudo DEBIAN_FRONTEND=noninteractive apt-get install php7.0-dev -yq
 phpize7.0
 ./configure --with-php-config=/usr/bin/php-config7.0 > /dev/null
 make clean > /dev/null
@@ -52,7 +52,7 @@ sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/cli/conf.d/20-mong
 sudo ln -s /etc/php/7.0/mods-available/mongo.ini /etc/php/7.0/fpm/conf.d/20-mongo.ini
 sudo service php7.0-fpm restart
 
-sudo apt-get install php7.1-dev
+sudo DEBIAN_FRONTEND=noninteractive apt-get install php7.1-dev -yq
 phpize7.1
 ./configure --with-php-config=/usr/bin/php-config7.1 > /dev/null
 make clean > /dev/null


### PR DESCRIPTION
I ran into the same issue described in #872 but when re-provisioning from `master`, the apt-get now gets stuck waiting for user confirmation and never completes. For example:

```
    homestead-7: The following NEW packages will be installed:
    homestead-7:   php7.1-dev
    homestead-7: The following packages will be upgraded:
    homestead-7:   php7.1-bcmath php7.1-cli php7.1-common php7.1-curl php7.1-fpm php7.1-gd
    homestead-7:   php7.1-imap php7.1-intl php7.1-json php7.1-mbstring php7.1-mysql
    homestead-7:   php7.1-opcache php7.1-pgsql php7.1-readline php7.1-soap php7.1-sqlite3
    homestead-7:   php7.1-xml php7.1-zip
    homestead-7: 18 upgraded, 1 newly installed, 0 to remove and 50 not upgraded.
    homestead-7: Need to get 5,444 kB of archives.
    homestead-7: After this operation, 5,297 kB of additional disk space will be used.
    homestead-7: Do you want to continue?
    homestead-7:  [Y/n]
    homestead-7: Abort.
```

This pull request updates those apt-get installs to run non-interactively.