### PR TITLE
Adding mysqldump.sql.gz to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ phpunit.xml
 /Homestead.json
 /after.sh
 /aliases
+/mysqldump.sql.gz


### PR DESCRIPTION
After #542, it's possible to dump MySQL database.
By default dump is saved to `vagrant/mysqldump.sql.gz` and so this file should be ignored IMO