### PR TITLE
Add support for database backup before destroying vm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ phpunit.xml
 /after.sh
 /aliases
 /mysqldump.sql.gz
+/mysql_backup
+/postgres_backup


### PR DESCRIPTION
Usage:

```
backup: true
```

All databases listed in `databases` will be back up.

Backup files will be placed in `${Homestead}/${db_type}_backup/${db_name}-${timestamp}.sql`

`vagrant-triggers` plugin is required if vagrant version < 2.1.0