### PR TITLE
Switch php tools' versions also while switching

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -40,18 +40,26 @@ function dusk() {
 
 function php56() {
     sudo update-alternatives --set php /usr/bin/php5.6
+    sudo update-alternatives --set php-config /usr/bin/php-config5.6
+    sudo update-alternatives --set phpize /usr/bin/phpize5.6
 }
 
 function php70() {
     sudo update-alternatives --set php /usr/bin/php7.0
+    sudo update-alternatives --set php-config /usr/bin/php-config7.0
+    sudo update-alternatives --set phpize /usr/bin/phpize7.0
 }
 
 function php71() {
     sudo update-alternatives --set php /usr/bin/php7.1
+    sudo update-alternatives --set php-config /usr/bin/php-config7.1
+    sudo update-alternatives --set phpize /usr/bin/phpize7.1
 }
 
 function php72() {
     sudo update-alternatives --set php /usr/bin/php7.2
+    sudo update-alternatives --set php-config /usr/bin/php-config7.2
+    sudo update-alternatives --set phpize /usr/bin/phpize7.2
 }
 
 function serve-apache() {


### PR DESCRIPTION
Switch aliases currently only change the php binary's version. Tools also need to be switched to work as expected with the selected php version.