### PR TITLE
Hyper-V provider

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -165,6 +165,10 @@ class Homestead
         if File.exist? File.expand_path(folder['map'])
           mount_opts = []
 
+          if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'hyperv'
+            folder['type'] = 'smb'
+          end
+
           if folder['type'] == 'nfs'
             mount_opts = folder['mount_options'] ? folder['mount_options'] : ['actimeo=1', 'nolock']
           elsif folder['type'] == 'smb'

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -61,6 +61,18 @@ class Homestead
       end
     end
 
+    # Configure A Few Hyper-V Settings
+    config.vm.provider "hyperv" do |h, override|
+      h.vmname = settings['names'] ||= 'homestead-7'
+      h.cpus = settings['cpus'] ||= 1
+      h.memory = settings['memory'] ||= 2048
+      h.differencing_disk = true
+
+      if Vagrant.has_plugin?('vagrant-hostmanager')
+        override.hostmanager.ignore_private_ip = true
+      end
+    end
+
     # Configure A Few Parallels Settings
     config.vm.provider 'parallels' do |v|
       v.name = settings['name'] ||= 'homestead-7'


### PR DESCRIPTION
Homestead does provide Hyper-V boxes, but the default configuration does not give a better experiencie for the Vagrant + Hyper-V. So I fixed few things,,,

### What this PR provides:

It configures the name, CPU and memory of the Hyper-V VM. It also tells Hyper-V to use a [differencing disk](https://technet.microsoft.com/en-us/library/cc720381(v=ws.10).aspx) instead of literally cloning the box image.

The last part will tell Vagrant Hostmanager to use the SSH IP instead of using the private network IP, since we all know [Hyper-V is a c**t to networking](https://www.vagrantup.com/docs/hyperv/limitations.html#limited-networking). I recommend that if we're to document Hyper-V usage in the docs, that we HIGHLY suggest the use of Vagrant Hostmanager since it'll automatically update any IP references in the host files and remove some pain of the Vagrant limitations, and at this time Vagrant Hostupdater doesn't do anything (since it doesn't offer an option to use the SSH IP instead of the network one).

I also enforced the "smb" type for shared folders. This may be a breaking change, but "SMB" is by far the synced folder type to use with Hyper-V.

### Hyper-V rant

HYPER-V DOES NOT PROVIDE A SOLID DEVELOPER EXPERIENCE WITH VAGRANT. And so far, the main issues that I've seen from people using Hyper-V are Synced Folders and Networking.

Synced Folders is resolved best by using SMB, and the default box already have cifs-utils from laravel/settler#109, but it must be added to the documentation that both Homestead and any other folder you want to share MUST NOT be under a directory path that contains spaces (`C:\Program Files`, `C:\Users\Taylor Otwell`), otherwise the synced folders will not be mounted (the SMB script will crash).

The Networking is the trick one. You'll not configure anything from Vagrant, it is unable to manage, all the configurations will be done to the OS and Hyper-V Manager. The most common solution is:

1. Create a Internal Virtual Switch via the Hyper-V Manager
2. In the Control Panel, share the network adapter that provides your PC Internet and networking with the network adapter associated with the Virtual Switch you created. Also, uninstall IPv6 from the network adapter associated with the Virtual Switch (This solves both VM not having internet access and some issues like SSH host being IPv6 instead of IPv4 and crashing the SMB share)
  
  > The step 2 can be skipped if you decide to use a External Virtual Switch.

3. If Docker for Windows is installed and running, quit it. This can also be done as a troubleshoot step, because it's commonly associated will Vagrant guessing the MobyLinuxVM IP instead of the Homestead one.

4. If you did step 2, you probably will be offline when you shutdown and power on your PC. It can be fixed by removing the Internet Sharing in the network adapted.

Most Hyper-V issues are related to Networking, since if Vagrant can't guess how to connect to the VM properly and the VM doesn't connect to the internet, both synced folders and some providers will crash.

I hope this help in some way.