### PR TITLE
Proposal: user-specific after.sh files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ phpunit.xml
 /Homestead.yaml
 /Homestead.json
 /after.sh
+/after.local.sh
 /aliases
 /mysqldump.sql.gz
 /mysql_backup

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ phpunit.xml
 /Homestead.yaml
 /Homestead.json
 /after.sh
-/after.local.sh
 /aliases
 /mysqldump.sql.gz
 /mysql_backup
 /postgres_backup
+/user-customizations.sh

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ confDir = $confDir ||= File.expand_path(File.dirname(__FILE__))
 homesteadYamlPath = confDir + "/Homestead.yaml"
 homesteadJsonPath = confDir + "/Homestead.json"
 afterScriptPath = confDir + "/after.sh"
+afterLocalScriptPath = confDir + "/after.local.sh"
 aliasesPath = confDir + "/aliases"
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
@@ -36,6 +37,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if File.exist? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+    end
+
+    if File.exist? afterLocalScriptPath then
+        config.vm.provision "shell", path: afterLocalScriptPath, privileged: false, keep_color: true
     end
 
     if Vagrant.has_plugin?('vagrant-hostsupdater')

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ confDir = $confDir ||= File.expand_path(File.dirname(__FILE__))
 homesteadYamlPath = confDir + "/Homestead.yaml"
 homesteadJsonPath = confDir + "/Homestead.json"
 afterScriptPath = confDir + "/after.sh"
-afterLocalScriptPath = confDir + "/after.local.sh"
+customizationScriptPath = confDir + "/user-customizations.sh"
 aliasesPath = confDir + "/aliases"
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
@@ -39,8 +39,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
 
-    if File.exist? afterLocalScriptPath then
-        config.vm.provision "shell", path: afterLocalScriptPath, privileged: false, keep_color: true
+    if File.exist? customizationScriptPath then
+        config.vm.provision "shell", path: customizationScriptPath, privileged: false, keep_color: true
     end
 
     if Vagrant.has_plugin?('vagrant-hostsupdater')

--- a/resources/after.sh
+++ b/resources/after.sh
@@ -3,3 +3,7 @@
 # If you would like to do some extra provisioning you may
 # add any commands you wish to this file and they will
 # be run after the Homestead machine is provisioned.
+#
+# If you have user-specific configurations you would like
+# to apply, you may also create after.local.sh, which will
+# be run after this script.

--- a/resources/after.sh
+++ b/resources/after.sh
@@ -5,5 +5,5 @@
 # be run after the Homestead machine is provisioned.
 #
 # If you have user-specific configurations you would like
-# to apply, you may also create after.local.sh, which will
-# be run after this script.
+# to apply, you may also create user-customizations.sh,
+# which will be run after this script.

--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -10,7 +10,7 @@ confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname
 homesteadYamlPath = File.expand_path("Homestead.yaml", File.dirname(__FILE__))
 homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
-afterLocalScriptPath = "after.local.sh"
+customizationScriptPath = "user-customizations.sh"
 aliasesPath = "aliases"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
@@ -39,8 +39,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
 
-    if File.exist? afterLocalScriptPath then
-        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+    if File.exist? customizationScriptPath then
+        config.vm.provision "shell", path: customizationScriptPath, privileged: false, keep_color: true
     end
 
     if defined? VagrantPlugins::HostsUpdater

--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -10,6 +10,7 @@ confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname
 homesteadYamlPath = File.expand_path("Homestead.yaml", File.dirname(__FILE__))
 homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
+afterLocalScriptPath = "after.local.sh"
 aliasesPath = "aliases"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
@@ -35,6 +36,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exist? afterScriptPath then
+        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+    end
+
+    if File.exist? afterLocalScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
     end
 


### PR DESCRIPTION
I'm a huge fan of the `after.sh` convention, which really lets me streamline the setup of an application (I tend to use per-project Homestead installations); picking up one of my Laravel apps usually looks like:

1. Clone the git repo
2. Install Composer dependencies
3. `$ vendor/bin/homestead make`
4. `$ vagrant up` (with `after.sh` handling migrations, seeding, etc.)
5. `$ vagrant ssh`

— then start building awesome stuff!

The `after.sh` script is great to ensure that new VMs automatically get system requirements and let me save developers a step in running migrations/seeders. Of course, developers are an opinionated bunch, so I find myself running this anytime I rebuild the VM:

```sh
# Replace nano with a much better editor 💥
$ sudo update-alternatives --set editor /usr/bin/vim.basic
```

For developers more dependent on their own, more-unique aliases, it's nice to have a way to set user-specific settings automatically in a script that's not tracked under version control.

This PR introduces just that, in the form of an `after.local.sh` file: when present, the `after.local.sh` file will be executed immediately following the `after.sh` file (though the two are not tied to one another). Nothing is generated automatically, but developers who want to be able to fully customize the VM without losing their work with each rebuild, `after.local.sh` is 👌 

## Alternate approach

If the maintainers/community find that this doesn't add enough value, I'll also leave the less-canonical implementation for teams that would benefit from this concept:

```sh
# after.sh

# Load developer-specific after.sh commands.
if [ -e after.local.sh ]; then
    ./after.local.sh
fi
```