### PR TITLE
✨ Add support for 'aspdotnetcore' site type

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -231,7 +231,7 @@ class Homestead
             params += ' )'
           end
           s.path = script_dir + "/serve-#{type}.sh"
-          s.args = [site['map'], site['to'], site['port'] ||= '80', site['ssl'] ||= '443', site['php'] ||= '7.2', params ||= '', site['zray'] ||= 'false']
+          s.args = [site['map'], site['to'], site['port'] ||= '80', site['ssl'] ||= '443', site['php'] ||= '7.2', params ||= '', site['zray'] ||= 'false', site['exec'] ||= 'false']
 
           if site['zray'] == 'true'
             config.vm.provision 'shell' do |s|

--- a/scripts/serve-aspdotnetcore.sh
+++ b/scripts/serve-aspdotnetcore.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+block="map \$http_upgrade \$connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name   $1;
+    location / {
+        proxy_pass         http://localhost:5000;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade \$http_upgrade;
+        proxy_set_header   Connection keep-alive;
+        proxy_set_header   Host \$host;
+        proxy_cache_bypass \$http_upgrade;
+        proxy_set_header   X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto \$scheme;
+    }
+    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate_key /etc/nginx/ssl/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+
+kestrel="[Unit]
+Description=$1
+
+[Service]
+WorkingDirectory=$2
+ExecStart=/usr/bin/dotnet $2/$8
+Restart=always
+# Restart service after 10 seconds if the dotnet service crashes:
+RestartSec=10
+SyslogIdentifier=$1
+User=vagrant
+Environment=ASPNETCORE_ENVIRONMENT=Development
+Environment=DOTNET_PRINT_TELEMETRY_MESSAGE=false
+
+[Install]
+WantedBy=multi-user.target
+"
+
+echo "$kestrel" > "/etc/systemd/system/kestrel-$1.service"
+
+systemctl enable "kestrel-$1.service"


### PR DESCRIPTION
Usage:

In `Homestead.yaml`:

```
folders:
  - map: ~/PhpstormProjects/AspDotNetWeb
    to: /home/vagrant/asp

sites:
  - map: asp.test
    to: /home/vagrant/asp/AspDotNetWeb
    type: "aspdotnetcore"
    exec: AspDotNetWeb.dll
```