### PR TITLE
hyperv : use linked_clone instead of deprecated differencing_disk option

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -66,7 +66,7 @@ class Homestead
       h.vmname = settings['names'] ||= 'homestead-7'
       h.cpus = settings['cpus'] ||= 1
       h.memory = settings['memory'] ||= 2048
-      h.differencing_disk = true
+      h.linked_clone = true
 
       if Vagrant.has_plugin?('vagrant-hostmanager')
         override.hostmanager.ignore_private_ip = true


### PR DESCRIPTION
Vagrant would throw a lot of warnings because differencing_disk is a deprecated option. According to the docs linked_clone is the correct way now and does exactly the same thing : https://www.vagrantup.com/docs/hyperv/configuration.html