### PR TITLE
Allow config overrides for per-project installs

### DIFF
--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -9,6 +9,8 @@ confDir = $confDir ||= File.expand_path("vendor/laravel/homestead", File.dirname
 
 homesteadYamlPath = File.expand_path("Homestead.yaml", File.dirname(__FILE__))
 homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
+homesteadOverrideYamlPath = File.expand_path("Homestead.override.yaml", File.dirname(__FILE__))
+homesteadOverrideJsonPath = File.expand_path("Homestead.override.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
 customizationScriptPath = "user-customizations.sh"
 aliasesPath = "aliases"
@@ -31,6 +33,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         settings = JSON.parse(File.read(homesteadJsonPath))
     else
         abort "Homestead settings file not found in #{confDir}"
+    end
+
+    if File.exist? homesteadOverrideYamlPath then
+        settings = settings.merge(YAML::load(File.read(homesteadOverrideYamlPath)))
+    elsif File.exist? homesteadOverrideJsonPath then
+        settings = settings.merge(JSON.parse(File.read(homesteadOverrideJsonPath)))
     end
 
     Homestead.configure(config, settings)


### PR DESCRIPTION
In per-project installs, it's [common for the `Homestead.yaml` to be under version control](https://github.com/search?utf8=%E2%9C%93&q=filename%3AHomestead.yaml+path%3A%2F&type=).

This allows each environment to change some of the settings via a `Homestead.override.yaml` file which can be gitignored.

Reason I wanted this was so I can have 2+ boxes of the same project going at once on my machine, but since each needed a different IP address, I would have had to edit the `Homestead.yaml` and have uncommitted changes.