### PR TITLE
Fix error message for missing Homestead settings

### DIFF
--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     elsif File.exist? homesteadJsonPath then
         settings = JSON.parse(File.read(homesteadJsonPath))
     else
-        abort "Homestead settings file not found in #{confDir}"
+        abort "Homestead settings file not found in " + File.dirname(__FILE__)
     end
 
     Homestead.configure(config, settings)


### PR DESCRIPTION
For localized Homestead installs, the path to the `Homestead.yaml/.json` is expected to be the same as the `Vagrantfile`, as seen in `homesteadYamlPath` and `homesteadJsonPath`. This fixes the error message.