### PR TITLE
Fix CPU soft lockup when audio is enabled

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -35,6 +35,7 @@ class Homestead
       vb.name = settings['name'] ||= 'homestead-7'
       vb.customize ['modifyvm', :id, '--memory', settings['memory'] ||= '2048']
       vb.customize ['modifyvm', :id, '--cpus', settings['cpus'] ||= '1']
+      vb.customize ['modifyvm', :id, '--audio', 'none']
       vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
       vb.customize ['modifyvm', :id, '--natdnshostresolver1', settings['natdnshostresolver'] ||= 'on']
       vb.customize ['modifyvm', :id, '--ostype', 'Ubuntu_64']


### PR DESCRIPTION
For some weird reason on my laptop I am getting CPU "soft lockup" errors during boot and boot time becomes extremely long.

Once I disabled audio homestead booted up really fast.

I can't explain why this is happening, but I'm sure no one needs the audio enabled either way right? =)