### PR TITLE
Add support for custom headers in sites

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -230,8 +230,15 @@ class Homestead
             end
             params += ' )'
           end
+          if site.include? 'headers'
+            headers = '('
+            site['headers'].each do |header|
+                headers += ' [' + header['key'] + ']=' + header['value']
+            end
+            headers += ' )'
+          end
           s.path = script_dir + "/serve-#{type}.sh"
-          s.args = [site['map'], site['to'], site['port'] ||= '80', site['ssl'] ||= '443', site['php'] ||= '7.2', params ||= '', site['zray'] ||= 'false', site['exec'] ||= 'false']
+          s.args = [site['map'], site['to'], site['port'] ||= '80', site['ssl'] ||= '443', site['php'] ||= '7.2', params ||= '', site['zray'] ||= 'false', site['exec'] ||= 'false', headers ||= '']
 
           if site['zray'] == 'true'
             config.vm.provision 'shell' do |s|

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
 declare -A params=$6     # Create an associative array
+declare -A headers=$9    # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
    done
 fi
 
@@ -31,6 +40,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
+        $headersTXT
     }
 
     $configureZray


### PR DESCRIPTION
First my use case here was that I had a separate domain for images, so in homestead I set up a separate site to handle images specifically `images.homestead.test` for example. The site I was using was an api/spa setup as well, so the client was separated from the homestead box (a `nuxt` app).

However I also needed to use JavaScript in some cases to convert the images to canvas for cropping, but this will trigger CORS issues. To get around this I needed to add headers to the images to allow it, but passing the images through PHP in order to add the headers is a little overkill so doing it in nginx made sense.

That is what this update brings in, right now its more of a feature request rather then fixing anything. I also have only applied it to the default site type (laravel). It will add headers with some settings in the homestead.yaml like so:

```
sites:
    -
        map: image.homestead.test
        to: /home/vagrant/code/public/storage
        headers: 
            -
                key: "Access-Control-Allow-Origin"
                value: "*"
```

Let me know what you think and I will apply it to the other site types, otherwise I am open to any ideas.