### PR TITLE
Add verify_host_key config

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -10,7 +10,7 @@ class Homestead
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
       
-    # Configure Verfiy Host Key
+    # Configure Verify Host Key
     config.ssh.verify_host_key = :never
 
     # Configure The Box

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -9,6 +9,9 @@ class Homestead
 
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
+      
+    # Configure Verfiy Host Key
+    config.ssh.verify_host_key = :never
 
     # Configure The Box
     config.vm.define settings['name'] ||= 'homestead-7'

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -11,7 +11,13 @@ class Homestead
     config.ssh.forward_agent = true
       
     # Configure Verify Host Key
-    config.ssh.verify_host_key = :never
+    config.ssh.verify_host_key = true
+
+    if config.ssh.verify_host_key == nil
+      config.ssh.verify_host_key = true
+    else
+      config.ssh.verify_host_key = :never
+    end
 
     # Configure The Box
     config.vm.define settings['name'] ||= 'homestead-7'

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -10,7 +10,7 @@ class Homestead
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
     
-   # Configure Verify Host Key
+    # Configure Verify Host Key
     if settings.has_key?('verify_host_key')
       config.ssh.verify_host_key = settings['verify_host_key']
     end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -9,20 +9,14 @@ class Homestead
 
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
+    
     # Configure Verify Host Key
     if settings.has_key?('verify_host_key')
       config.ssh.verify_host_key = settings['verify_host_key']
     else
-      config.ssh.verify_host_key = true
-    end
-    # Configure Verify Host Key
-    config.ssh.verify_host_key = true
-
-    if config.ssh.verify_host_key == nil
-      config.ssh.verify_host_key = true
-    else
-      config.ssh.verify_host_key = :never
-    end
+      config.ssh.verify_host_key = true || :accept_new_or_local_tunnel
+    end    
+    config.ssh.verify_host_key = :accept_new_or_local_tunnel
 
     # Configure The Box
     config.vm.define settings['name'] ||= 'homestead-7'

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -10,13 +10,10 @@ class Homestead
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
     
-    # Configure Verify Host Key
+   # Configure Verify Host Key
     if settings.has_key?('verify_host_key')
       config.ssh.verify_host_key = settings['verify_host_key']
-    else
-      config.ssh.verify_host_key = true || :accept_new_or_local_tunnel
-    end    
-    config.ssh.verify_host_key = :accept_new_or_local_tunnel
+    end
 
     # Configure The Box
     config.vm.define settings['name'] ||= 'homestead-7'

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -9,7 +9,12 @@ class Homestead
 
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
-      
+    # Configure Verify Host Key
+    if settings.has_key?('verify_host_key')
+      config.ssh.verify_host_key = settings['verify_host_key']
+    else
+      config.ssh.verify_host_key = true
+    end
     # Configure Verify Host Key
     config.ssh.verify_host_key = true
 


### PR DESCRIPTION
The following deprecation error message may appear in some Vagrant installs:
```
verify_host_key: false is deprecated, use :never
```
Adding a config for verify_host_key addresses this issue.