### PR TITLE
Use Native Pluggable Authentication for MySQL 8

### DIFF
--- a/scripts/install-mysql8.sh
+++ b/scripts/install-mysql8.sh
@@ -45,6 +45,9 @@ debconf-set-selections <<< "mysql-server mysql-server/root_password_again passwo
 # Configure MySQL 8 Remote Access
 echo "bind-address = 0.0.0.0" | tee -a /etc/mysql/conf.d/mysql.cnf
 
+# Use Native Pluggable Authentication
+echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password"
+
 mysql --user="root" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'secret';"
 mysql --user="root" --password="secret" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;"
 mysql --user="root" --password="secret" -e "CREATE USER 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"


### PR DESCRIPTION
MySQL 8 switched to [Caching SHA-2 Pluggable Authentication](https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html) by default. To my knowledge, most clients haven't implemented this yet and as such won't be able to connect to MySQL (error 2054 - The server requested authentication method unknown to the client). 

This directive reverts to [Native Pluggable Authentication](https://dev.mysql.com/doc/refman/8.0/en/native-pluggable-authentication.html) for user creation which was the default in pre-8 MySQL. It should solve lots of issues for folks trying MySQL 8. See also: https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password-compatibility-issues






