### PR TITLE
Fix mysql 8 authentication plugin

### DIFF
--- a/scripts/install-mysql8.sh
+++ b/scripts/install-mysql8.sh
@@ -46,7 +46,8 @@ debconf-set-selections <<< "mysql-server mysql-server/root_password_again passwo
 echo "bind-address = 0.0.0.0" | tee -a /etc/mysql/conf.d/mysql.cnf
 
 # Use Native Pluggable Authentication
-echo -e "[mysqld]\ndefault_authentication_plugin=mysql_native_password"
+echo -e "[mysqld]\ndefault_authentication_plugin = mysql_native_password" | tee -a /etc/mysql/conf.d/mysql.cnf
+service mysql restart
 
 mysql --user="root" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'secret';"
 mysql --user="root" --password="secret" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;"


### PR DESCRIPTION
The previous implementation was just echoing the string to stdout, this ensures that it reaches `/etc/mysql/conf.d/mysql.cnf`

Also while testing this i found that this requires a restart before creating the users.