### PR TITLE
Allow numeric ports for proxy sites

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -266,7 +266,7 @@ class Homestead
             end
           else
             config.vm.provision 'shell' do |s|
-              s.inline = 'rm -rf ' + site['to'] + '/ZendServer'
+              s.inline = 'rm -rf ' + site['to'].to_s + '/ZendServer'
             end
           end
         end


### PR DESCRIPTION
Fixes #910 by casting the port to a string and therefore allowing string concatenation in [z-ray cleanup](https://github.com/laravel/homestead/blob/master/scripts/homestead.rb#L269)

This enables

```json
{
  "map": "homestead.test",
  "to": 8080,
  "type": "proxy"
}
```

and keeps:

```json
{
  "map": "homestead.test",
  "to": "8080",
  "type": "proxy"
}
```

It's probable that this will occur in other places, i will look around, but in the meantime, this fixes the most common scenario that is a fresh installation with its defaults.