### PR TITLE
Fixed .user.ini subdirectory issue

### DIFF
--- a/scripts/serve-apache.sh
+++ b/scripts/serve-apache.sh
@@ -36,7 +36,7 @@ block="<VirtualHost *:$3>
     <IfModule !mod_fastcgi.c>
         <IfModule mod_proxy_fcgi.c>
             <FilesMatch \".+\.ph(ar|p|tml)$\">
-                SetHandler \"proxy:unix:/var/run/php/php"$5"-fpm.sock|fcgi://localhost/\"
+                SetHandler \"proxy:unix:/var/run/php/php"$5"-fpm.sock|fcgi://localhost\"
             </FilesMatch>
         </IfModule>
     </IfModule>


### PR DESCRIPTION
.user.ini does not work on subdirectories due to the extra leading slash. See related stackoverflow:

https://stackoverflow.com/a/41879334/959060

I've removed the trailing slash.