### PR TITLE
Support SMB credentials in Homestead.yaml

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -178,6 +178,8 @@ class Homestead
             mount_opts = folder['mount_options'] ? folder['mount_options'] : ['actimeo=1', 'nolock']
           elsif folder['type'] == 'smb'
             mount_opts = folder['mount_options'] ? folder['mount_options'] : ['vers=3.02', 'mfsymlinks']
+
+            smb_creds = {'smb_host': folder['smb_host'], 'smb_username': folder['smb_username'], 'smb_password': folder['smb_password']}
           end
 
           # For b/w compatibility keep separate 'mount_opts', but merge with options


### PR DESCRIPTION
When using SMB mounts, having to provide the SMB credentials every time the VM boots grows tiresome. This simple change adds the ability to specify those credentials in Homestead.yaml.

It goes without saying that storing these credentials in plaintext poses a security risk, but most developers are using an unprivileged, local account exclusively for this purpose, in which case any associated risk may be acceptable.

I have tested `vagrant up` with and without specifying the credentials and it responds as expected: Vagrant prompts for them if not provided, and it uses them without prompting if they are.

Note that I added support for `smb_host`, too (for details, see: https://www.vagrantup.com/docs/synced-folders/smb.html ).