### PR TITLE
Merge SMB creds from Homestead.yaml into config

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -183,7 +183,7 @@ class Homestead
           end
 
           # For b/w compatibility keep separate 'mount_opts', but merge with options
-          options = (folder['options'] || {}).merge({ mount_options: mount_opts })
+          options = (folder['options'] || {}).merge({ mount_options: mount_opts }).merge(smb_creds || {})
 
           # Double-splat (**) operator only works with symbol keys, so convert
           options.keys.each{|k| options[k.to_sym] = options.delete(k) }


### PR DESCRIPTION
While SMB credentials were being parsed, they weren't being merged into the effective configuration; this change implements the intended behavior.

@svpernova09 This was simply an oversight on my part; I had a bunch of WIP code all over the place and had meant to include this in my previous PR. Thanks!