### PR TITLE
Add Sites from Homestead.yaml to /etc/hosts

### DIFF
--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -82,3 +82,4 @@ block="server {
 
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+echo "127.0.0.1 $1" >> /etc/hosts


### PR DESCRIPTION
While VirtualBox VMs have a means by which to resolve hostnames from the *host* machine's hosts file, the same is not true of other providers, such as Hyper-V (probably due to greater isolation between host and guest).

For example, it's possible to reach (e.g., ping) a hostname defined in the *host* machine's hosts file immediately after provisioning with VirtualBox (on Windows, at least). But with an otherwise identical configuration in Hyper-V, the hostname cannot be resolved.

The primary reason for which I propose this change is that hostname resolution within the VM, for sites defined in `Homestead.yaml`, is required for Dusk testing. Absent the proposed change, Dusk testing does not work on Hyper-V because `homestead.site`, for example, cannot be resolved unless `127.0.0.1 homestead.site` is added to `/etc/hosts`.

Ref: [Laravel Dusk returns empty html document when dumping browser, assertions therefore fail
](https://stackoverflow.com/a/50686795/1772379)