### PR TITLE
Add rewrite support to nginx config

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -256,8 +256,18 @@ class Homestead
             end
             headers += ' )'
           end
+          if site.include? 'rewrites'
+            rewrites = '('
+            site['rewrites'].each do |rewrite|
+                rewrites += ' [' + rewrite['map'] + ']=' + "'" + rewrite['to'] + "'"
+            end
+            rewrites += ' )'
+            # Escape variables for bash
+            rewrites.gsub! '$', '\$'
+          end
+
           s.path = script_dir + "/serve-#{type}.sh"
-          s.args = [site['map'], site['to'], site['port'] ||= http_port, site['ssl'] ||= https_port, site['php'] ||= '7.2', params ||= '', site['zray'] ||= 'false', site['exec'] ||= 'false', headers ||= '']
+          s.args = [site['map'], site['to'], site['port'] ||= http_port, site['ssl'] ||= https_port, site['php'] ||= '7.2', params ||= '', site['zray'] ||= 'false', site['exec'] ||= 'false', headers ||= '', rewrites ||= '']
 
           if site['zray'] == 'true'
             config.vm.provision 'shell' do |s|

--- a/scripts/serve-elgg.sh
+++ b/scripts/serve-elgg.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -50,6 +59,8 @@ block="server {
 
     # Max post size
     client_max_body_size 8M;
+
+    $rewritesTXT
 
     location ~ /.well-known {
         allow all;

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
-declare -A headers=$9    # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
@@ -16,6 +17,14 @@ if [ -n "$9" ]; then
    do
       headersTXT="${headersTXT}
       add_header ${element} ${headers[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -37,6 +46,8 @@ block="server {
     index index.html index.htm index.php;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;

--- a/scripts/serve-pimcore.sh
+++ b/scripts/serve-pimcore.sh
@@ -4,6 +4,16 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y php"$5"-bz2
 
+declare -A rewrites=${10}  # Create an associative array
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
+fi
+
 if [ "$7" = "true" ] && [ "$5" = "7.2" ]
 then configureZray="
 location /ZendServer {
@@ -35,6 +45,8 @@ server {
 
     # Pimcore Head-Link Cache-Busting
     rewrite ^/cache-buster-(?:\d+)/(.*) /\$1 last;
+
+    $rewritesTXT
 
     # Stay secure
     #

--- a/scripts/serve-silverstripe.sh
+++ b/scripts/serve-silverstripe.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -30,6 +39,8 @@ block="server {
     if (\$http_x_forwarded_host) {
         return 400;
     }
+
+    $rewritesTXT
 
     location / {
         try_files \$uri /index.php?url=\$uri&\$query_string;

--- a/scripts/serve-spa.sh
+++ b/scripts/serve-spa.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -19,6 +28,8 @@ block="server {
     index index.html;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         try_files \$uri \$uri/ /index.html;

--- a/scripts/serve-statamic.sh
+++ b/scripts/serve-statamic.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -28,6 +37,8 @@ block="server {
     index index.html index.htm index.php;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         rewrite ^/admin.php.*$ /admin.php;

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
     for element in "${!params[@]}"
@@ -8,6 +9,14 @@ if [ -n "$6" ]; then
         paramsTXT="${paramsTXT}
         fastcgi_param ${element} ${params[$element]};"
     done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
 fi
 
 if [ "$7" = "true" ] && [ "$5" = "7.2" ]
@@ -28,6 +37,8 @@ block="server {
     index index.html index.htm index.php app_dev.php;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         try_files \$uri \$uri/ /app_dev.php?\$query_string;

--- a/scripts/serve-symfony4.sh
+++ b/scripts/serve-symfony4.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+declare -A rewrites=${10}  # Create an associative array
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
+fi
+
 if [ "$7" = "true" ] && [ "$5" = "7.2" ]
 then configureZray="
 location /ZendServer {
@@ -18,6 +28,8 @@ block="server {
     index index.html index.htm index.php;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;

--- a/scripts/serve-thinkphp.sh
+++ b/scripts/serve-thinkphp.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -28,6 +37,8 @@ block="server {
     index index.html index.htm index.php;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         if (!-e \$request_filename) {

--- a/scripts/serve-yii.sh
+++ b/scripts/serve-yii.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
    for element in "${!params[@]}"
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
    done
 fi
 
@@ -28,6 +37,8 @@ block="server {
     index index.html index.htm index.php;
 
     charset utf-8;
+
+    $rewritesTXT
 
     location / {
         try_files \$uri \$uri/ /index.php\$is_args\$args;

--- a/scripts/serve-zf.sh
+++ b/scripts/serve-zf.sh
@@ -13,7 +13,8 @@
 #
 # The first two are aliases for the last.
 
-declare -A params=$6     # Create an associative array
+declare -A params=$6       # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
     for element in "${!params[@]}"
@@ -21,6 +22,14 @@ if [ -n "$6" ]; then
         paramsTXT="${paramsTXT}
         fastcgi_param ${element} ${params[$element]};"
     done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
 fi
 
 if [ "$7" = "true" ] && [ "$5" = "7.2" ]
@@ -41,6 +50,8 @@ block="server {
     charset utf-8;
 
     index index.php index.html;
+
+    $rewritesTXT
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;


### PR DESCRIPTION
This PR adds rewrite support to the nginx site config. This makes you redirect/rewrite unfound resources to another destination. 

This is especially usefull for media heavy sites where you don't want all the uploads/media on you local machine. This way you can load then from the production/staging environment.

No apache support needed as this can also be achieved with .htaccess.

### Homestead.yaml syntax

```
sites:
    - map: homestead.test
      to: /home/vagrant/code/public
      rewrites:
        - map: /wp-content/uploads(/.*)
          to: https://my-production-site.com/wp-content/uploads$1
        - map: /storage/images(/.*)
          to: https://my-production-site.com/storage/images$1
```

### Result in nginx config file

```
location ~ /wp-content/uploads(/.*) { if (!-f $request_filename) { return 301 https://my-production-site.com/wp-content/uploads$1; } }
location ~ /storage/images(/.*) { if (!-f $request_filename) { return 301 https://my-production-site.com/storage/images$1; } }
```

Any improvements or comments are very welcome, an alternative way to achieve this without modifying the source when PR is not merged would also be much appreciated.

Thanks
