### PR TITLE
Add missing ssl_certificate to elgg site type

### DIFF
--- a/scripts/serve-elgg.sh
+++ b/scripts/serve-elgg.sh
@@ -86,6 +86,9 @@ block="server {
         fastcgi_param SCRIPT_NAME     /index.php;
         fastcgi_param QUERY_STRING    __elgg_uri=\$uri&\$args;
     }
+
+    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate_key /etc/nginx/ssl/$1.key;
 }
 "
 


### PR DESCRIPTION
Fixes error in nginx:

```
nginx: [emerg] no "ssl_certificate" is defined for the "listen ... ssl" directive in /etc/nginx/sites-enabled/homestead-elgg.test:1
nginx: configuration file /etc/nginx/nginx.conf test failed
```

