### PR TITLE
Remove params support from spa site type

### DIFF
--- a/scripts/serve-spa.sh
+++ b/scripts/serve-spa.sh
@@ -1,15 +1,5 @@
 #!/usr/bin/env bash
 
-declare -A params=$6     # Create an associative array
-paramsTXT=""
-if [ -n "$6" ]; then
-   for element in "${!params[@]}"
-   do
-      paramsTXT="${paramsTXT}
-      fastcgi_param ${element} ${params[$element]};"
-   done
-fi
-
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -37,8 +27,6 @@ block="server {
     location ~ /\.ht {
         deny all;
     }
-
-    $paramsTXT
 
     ssl_certificate     /etc/nginx/ssl/$1.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;


### PR DESCRIPTION
Fastcgi params are only supported in PHP location blocks. spa site type does not use PHP