### PR TITLE
Add header support to missing site types

### DIFF
--- a/scripts/serve-elgg.sh
+++ b/scripts/serve-elgg.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -8,6 +9,14 @@ if [ -n "$6" ]; then
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
    done
 fi
 rewritesTXT=""
@@ -76,6 +85,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ @elgg;
+        $headersTXT
     }
 
     $configureZray

--- a/scripts/serve-pimcore.sh
+++ b/scripts/serve-pimcore.sh
@@ -4,7 +4,16 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y php"$5"-bz2
 
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
 rewritesTXT=""
 if [ -n "${10}" ]; then
    for element in "${!rewrites[@]}"
@@ -80,6 +89,7 @@ server {
         expires 2w;
         access_log off;
         add_header Cache-Control \"public\";
+        $headersTXT
     }
 
     # Assets
@@ -90,6 +100,7 @@ server {
         access_log off;
         log_not_found off;
         add_header Cache-Control \"public\";
+        $headersTXT
     }
 
     # Installer
@@ -102,6 +113,7 @@ server {
         error_page 404 /meta/404;
         add_header \"X-UA-Compatible\" \"IE=edge\";
         try_files \$uri /app.php\$is_args\$args;
+        $headersTXT
     }
 
     # Use this location when the installer has to be run

--- a/scripts/serve-silverstripe.sh
+++ b/scripts/serve-silverstripe.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -8,6 +9,14 @@ if [ -n "$6" ]; then
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
    done
 fi
 rewritesTXT=""
@@ -44,6 +53,7 @@ block="server {
 
     location / {
         try_files \$uri /index.php?url=\$uri&\$query_string;
+        $headersTXT
     }
 
     error_page 404 /assets/error-404.html;
@@ -58,6 +68,7 @@ block="server {
             deny all;
         }
         try_files \$uri /index.php?url=\$uri&\$query_string;
+        $headersTXT
     }
 
     location ~ /framework/.*(main|rpc|tiny_mce_gzip)\.php$ {

--- a/scripts/serve-spa.sh
+++ b/scripts/serve-spa.sh
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+declare -A headers=$9      # Create an associative array
+
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -14,6 +25,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ /index.html;
+        $headersTXT
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }

--- a/scripts/serve-statamic.sh
+++ b/scripts/serve-statamic.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -8,6 +9,14 @@ if [ -n "$6" ]; then
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
    done
 fi
 rewritesTXT=""
@@ -43,6 +52,7 @@ block="server {
     location / {
         rewrite ^/admin.php.*$ /admin.php;
         try_files \$uri \$uri/ /index.php?\$query_string;
+        $headersTXT
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -9,6 +10,14 @@ if [ -n "$6" ]; then
         paramsTXT="${paramsTXT}
         fastcgi_param ${element} ${params[$element]};"
     done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
 fi
 rewritesTXT=""
 if [ -n "${10}" ]; then
@@ -42,6 +51,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ /app_dev.php?\$query_string;
+        $headersTXT
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }

--- a/scripts/serve-symfony4.sh
+++ b/scripts/serve-symfony4.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
 rewritesTXT=""
 if [ -n "${10}" ]; then
    for element in "${!rewrites[@]}"
@@ -33,6 +42,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
+        $headersTXT
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }

--- a/scripts/serve-thinkphp.sh
+++ b/scripts/serve-thinkphp.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -8,6 +9,14 @@ if [ -n "$6" ]; then
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
    done
 fi
 rewritesTXT=""
@@ -45,6 +54,7 @@ block="server {
             rewrite  ^(.*)$  /index.php?s=/\$1  last;
             break;
         }
+        $headersTXT
     }
 
     $configureZray

--- a/scripts/serve-yii.sh
+++ b/scripts/serve-yii.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -8,6 +9,14 @@ if [ -n "$6" ]; then
    do
       paramsTXT="${paramsTXT}
       fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
    done
 fi
 rewritesTXT=""
@@ -42,6 +51,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ /index.php\$is_args\$args;
+        $headersTXT
     }
 
     location ~ ^/assets/.*\.php\$ {

--- a/scripts/serve-zf.sh
+++ b/scripts/serve-zf.sh
@@ -14,6 +14,7 @@
 # The first two are aliases for the last.
 
 declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
 declare -A rewrites=${10}  # Create an associative array
 paramsTXT=""
 if [ -n "$6" ]; then
@@ -22,6 +23,14 @@ if [ -n "$6" ]; then
         paramsTXT="${paramsTXT}
         fastcgi_param ${element} ${params[$element]};"
     done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
 fi
 rewritesTXT=""
 if [ -n "${10}" ]; then
@@ -55,6 +64,7 @@ block="server {
 
     location / {
         try_files \$uri \$uri/ /index.php?\$query_string;
+        $headersTXT
     }
 
     location = /favicon.ico { access_log off; log_not_found off; }


### PR DESCRIPTION
This adds the additional header support to all `serve-` scripts where they were missing