### PR TITLE
Update localized Vagrantfile to use same double colon method syntax

### DIFF
--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exist? homesteadYamlPath then
         settings = YAML::load(File.read(homesteadYamlPath))
     elsif File.exist? homesteadJsonPath then
-        settings = JSON.parse(File.read(homesteadJsonPath))
+        settings = JSON::parse(File.read(homesteadJsonPath))
     else
         abort "Homestead settings file not found in " + File.dirname(__FILE__)
     end


### PR DESCRIPTION
This makes it consistent with `Yaml::load` in the line above it and the other Vagrantfile.

https://github.com/laravel/homestead/blob/237387c99ca2b549945ec4aec0d9c101f9ccf3bc/resources/localized/Vagrantfile#L31

https://github.com/laravel/homestead/blob/237387c99ca2b549945ec4aec0d9c101f9ccf3bc/Vagrantfile#L31

