### PR TITLE
Add possibility to dynamically set folders->map (host path)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ homesteadJsonPath = confDir + "/Homestead.json"
 afterScriptPath = confDir + "/after.sh"
 customizationScriptPath = confDir + "/user-customizations.sh"
 aliasesPath = confDir + "/aliases"
+hostPath = '~/code'
 
 require File.expand_path(File.dirname(__FILE__) + '/scripts/homestead.rb')
 
@@ -26,9 +27,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if File.exist? homesteadYamlPath then
-        settings = YAML::load(File.read(homesteadYamlPath))
+        settings = YAML::load(File.read(homesteadYamlPath) % { HOST_PATH: hostPath })
     elsif File.exist? homesteadJsonPath then
-        settings = JSON::parse(File.read(homesteadJsonPath))
+        settings = JSON::parse(File.read(homesteadJsonPath) % { HOST_PATH: hostPath })
     else
         abort "Homestead settings file not found in #{confDir}"
     end
@@ -36,11 +37,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exist? afterScriptPath then
-        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+        config.vm.provision "shell", path: afterScriptPath, privileged: true, keep_color: true, env: { HOST_PATH: hostPath }
     end
 
     if File.exist? customizationScriptPath then
-        config.vm.provision "shell", path: customizationScriptPath, privileged: false, keep_color: true
+        config.vm.provision "shell", path: customizationScriptPath, privileged: true, keep_color: true, env: { HOST_PATH: hostPath }
     end
 
     if Vagrant.has_plugin?('vagrant-hostsupdater')

--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -9,7 +9,7 @@
     ],
     "folders": [
         {
-            "map": "~/code",
+            "map": "%{HOST_PATH}",
             "to": "/home/vagrant/code"
         }
     ],

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -10,7 +10,7 @@ keys:
     - ~/.ssh/id_rsa
 
 folders:
-    - map: ~/code
+    - map: %{HOST_PATH}
       to: /home/vagrant/code
 
 sites:

--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -12,10 +12,11 @@ homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
 customizationScriptPath = "user-customizations.sh"
 aliasesPath = "aliases"
+hostPath = __dir__
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
 
-Vagrant.require_version '>= 1.9.0'
+Vagrant.require_version '>= 2.1.0'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exist? aliasesPath then
@@ -26,9 +27,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if File.exist? homesteadYamlPath then
-        settings = YAML::load(File.read(homesteadYamlPath))
+        settings = YAML::load(File.read(homesteadYamlPath) % { HOST_PATH: hostPath })
     elsif File.exist? homesteadJsonPath then
-        settings = JSON::parse(File.read(homesteadJsonPath))
+        settings = JSON::parse(File.read(homesteadJsonPath) % { HOST_PATH: hostPath })
     else
         abort "Homestead settings file not found in " + File.dirname(__FILE__)
     end
@@ -36,11 +37,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     Homestead.configure(config, settings)
 
     if File.exist? afterScriptPath then
-        config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true
+        config.vm.provision "shell", path: afterScriptPath, privileged: true, keep_color: true, env: { HOST_PATH: hostPath }
     end
 
     if File.exist? customizationScriptPath then
-        config.vm.provision "shell", path: customizationScriptPath, privileged: false, keep_color: true
+        config.vm.provision "shell", path: customizationScriptPath, privileged: true, keep_color: true, env: { HOST_PATH: hostPath }
     end
 
     if defined? VagrantPlugins::HostsUpdater


### PR DESCRIPTION
Add possibility to dynamically set `folders -> map` (host path) in Homestead.yaml and Homestead.json files, when Homestead installed per project. Also `HOST_PATH` variable is passed to `after.sh` and `user-customizations.sh` allowing to perform more advanced setup.

This will allow easier default configuration, and more advanced things like:
put these lines in `after.sh`
```
phpenmod -s ALL xdebug
XDEBUG_INI=/etc/php/7.2/mods-available/xdebug.ini
XDEBUG_INI_ORIG=${XDEBUG_INI}.orig
test -f ${XDEBUG_INI_ORIG} || cp ${XDEBUG_INI} ${XDEBUG_INI_ORIG}
echo "xdebug.file_link_format = \"phpstorm://open?file=%f&line=%l&/home/vagrant/code>${HOST_PATH}\"" >> ${XDEBUG_INI}
echo "xdebug.remote_autostart = 1" >> ${XDEBUG_INI}

service php7.2-fpm restart
```
after that, all links generated by XDebug will be able to open PHPStorm with target file and target line.