### PR TITLE
Update install-mysql8.sh to use latest deb package

### DIFF
--- a/scripts/install-mysql8.sh
+++ b/scripts/install-mysql8.sh
@@ -29,10 +29,10 @@ rm -rf /var/log/mysql
 rm -rf /etc/mysql
 
 # Add MySQL PPA
-wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
-dpkg -i mysql-apt-config_0.8.10-1_all.deb
+wget -c https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
+dpkg -i mysql-apt-config_0.8.12-1_all.deb
 sed -i 's/mysql-5.7/mysql-8.0/g' /etc/apt/sources.list.d/mysql.list
-rm -rf mysql-apt-config_0.8.10-1_all.deb
+rm -rf mysql-apt-config_0.8.12-1_all.deb
 apt-get update
 apt-get install -y mysql-server
 


### PR DESCRIPTION
Resolves apt key signing error which was preventing mysql 8 install.