### PR TITLE
mongodb v4.0.x / bionic instead of xenial

### DIFF
--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -10,9 +10,8 @@ fi
 
 touch /home/vagrant/.mongo
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 2>&1
-
-echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 2>&1
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
 
 sudo apt-get update
 


### PR DESCRIPTION
Homestead uses Ubuntu bionic release, this script contains obsolete reference to xenial release of mongodb source
Changes for proper mongodb source and version 4.0.x