### PR TITLE
Support Symfony 3.x components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - composer install --no-interaction
+  - composer install --no-interaction $PREFER_LOWEST
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - composer install --no-interaction $PREFER_LOWEST
+  - composer update --no-interaction $PREFER_LOWEST
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ before_script:
 script:
   - vendor/bin/phpunit
 
+env:
+  matrix:
+    - PREFER_LOWEST="--prefer-lowest"
+    - PREFER_LOWEST=""
+
 matrix:
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "A virtual machine for web artisans.",
     "require": {
         "php": "^7.1",
-        "symfony/console": "~4.0",
-        "symfony/process": "~4.0",
-        "symfony/yaml": "~4.0"
+        "symfony/console": "~3.0||~4.0",
+        "symfony/process": "~3.0||~4.0",
+        "symfony/yaml": "~3.0||~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae1a58f62b863ec65b43ee360da3758f",
+    "content-hash": "f06e47b39e9337c02c5a9caecbf9be94",
     "packages": [
         {
             "name": "symfony/console",
@@ -188,7 +188,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
+                    "email": "backendtea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1179,6 +1179,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {


### PR DESCRIPTION
I'd like to use Homestead within a Drupal 8 project, but Drupal does not yet support Symfony 4 components. Judging from https://github.com/laravel/homestead/pull/1030 it looks like nothing here actually depends on new 4.x APIs. Note I haven't done any tests beyond phpunit.