### PR TITLE
Add support for profiling with tideways and xhgui

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -267,7 +267,7 @@ class Homestead
           end
 
           s.path = script_dir + "/serve-#{type}.sh"
-          s.args = [site['map'], site['to'], site['port'] ||= http_port, site['ssl'] ||= https_port, site['php'] ||= '7.3', params ||= '', site['zray'] ||= 'false', site['exec'] ||= 'false', headers ||= '', rewrites ||= '']
+          s.args = [site['map'], site['to'], site['port'] ||= http_port, site['ssl'] ||= https_port, site['php'] ||= '7.3', params ||= '', site['zray'] ||= 'false', site['xhgui'] ||= '', site['exec'] ||= 'false', headers ||= '', rewrites ||= '']
 
           if site['zray'] == 'true'
             config.vm.provision 'shell' do |s|

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -284,6 +284,25 @@ class Homestead
               s.inline = 'rm -rf ' + site['to'].to_s + '/ZendServer'
             end
           end
+
+          if site['xhgui'] == 'true'
+            config.vm.provision 'shell' do |s|
+              s.path = script_dir + '/install-mongo.sh'
+            end
+
+            config.vm.provision 'shell' do |s|
+              s.path = script_dir + '/install-xhgui.sh'
+            end
+
+            config.vm.provision 'shell' do |s|
+              s.inline = 'ln -sf /opt/xhgui/webroot ' + site['to'] + '/xhgui'
+            end
+          else
+            config.vm.provision 'shell' do |s|
+              s.inline = 'rm -rf ' + site['to'].to_s + '/xhgui'
+            end
+          end
+
         end
 
         # Configure The Cron Schedule
@@ -410,7 +429,6 @@ class Homestead
         s.path = script_dir + '/install-influxdb.sh'
       end
     end
-
 
     # Configure All Of The Configured Databases
     if settings.has_key?('databases')

--- a/scripts/install-xhgui.sh
+++ b/scripts/install-xhgui.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+# Check If xhgui Has Been Installed
+
+if [ -f /home/vagrant/.xhgui ]
+then
+    echo "xhgui already installed."
+    exit 0
+fi
+
+touch /home/vagrant/.xhgui
+
+apt install -y php-tideways
+phpenmod -v ALL tideways
+
+git clone https://github.com/perftools/xhgui.git /opt/xhgui
+
+cat <<'EOT' > /opt/xhgui/webroot/.htaccess
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteRule ^ /xhgui/index.php [QSA,L]
+</IfModule>
+EOT
+
+cat <<'EOT' > /opt/xhgui/config/config.php
+<?php
+/**
+ * Configuration for XHGui.
+ */
+return array(
+    // Which backend to use for Xhgui_Saver.
+    // Must be one of 'mongodb', or 'file'.
+    //
+    // Example (save to a temporary file):
+    //
+    //     'save.handler' => 'file',
+    //     # Beware of file locking. You can adujst this file path
+    //     # to reduce locking problems (eg uniqid, time ...)
+    //     'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
+    //
+    'save.handler' => 'mongodb',
+
+    // Database options for MongoDB.
+    //
+    // - db.host: Connection string in the form `mongodb://[ip or host]:[port]`.
+    //
+    // - db.db: The database name.
+    //
+    // - db.options: Additional options for the MongoClient contructor,
+    //               for example 'username', 'password', or 'replicaSet'.
+    //               See <https://secure.php.net/mongoclient_construct#options>.
+    //
+    'db.host' => 'mongodb://127.0.0.1:27017',
+    'db.db' => 'xhprof',
+    'db.options' => array('username' => 'homestead', 'password' => 'secret'),
+
+    // Whether to instrument a user request.
+    //
+    // NOTE: Only applies to using the external/header.php include.
+    //
+    // Must be a function that returns a boolean,
+    // or any non-function value to disable the profiler.
+    //
+    // Default: Profile 1 in 100 requests.
+    //
+    // Example (profile all requests):
+    //
+    //     'profiler.enabled' => function() {
+    //         return true;
+    //     },
+    //
+    'profiler.enable' => function() {
+      // Never profile ourself.
+      if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '/xhgui') === 0) {
+        return false;
+      }
+
+      // Profile if ?xhgui=on, and continue to profile for the next hour.
+      foreach (array('xhgui') as $switch) {
+        if (isset($_GET[$switch]) && $_GET[$switch] == 'on') {
+          setcookie('xhgui', 'on', time() + 3600);
+          return true;
+        }
+      }
+
+      // Profile if we have been set to profiling mode.
+      if (isset($_COOKIE['xhgui']) && $_COOKIE['xhgui'] == 'on') {
+        return true;
+      }
+
+      // Profile the CLI when the XHGUI environment variable is set.
+      if (getenv('XHGUI') == 'on') {
+        return true;
+      }
+    },
+
+    // Transformation for the "simple" variant of the URL.
+    // This is stored as `meta.simple_url` and used for
+    // aggregate data.
+    //
+    // NOTE: Only applies to using the external/header.php include.
+    //
+    // Must be a function that returns a string, or any
+    // non-callable value for the default behaviour.
+    //
+    // Default: Remove numeric values after `=`. For example,
+    // it turns "/foo?page=2" into "/foo?page".
+    'profiler.simple_url' => null,
+
+    // Additional options to be passed to the `_enable()` function
+    // of the profiler extension (xhprof, tideways, etc.).
+    //
+    // NOTE: Only applies to using the external/header.php include.
+    'profiler.options' => array(),
+
+    // Date format used when browsing XHGui pages.
+    //
+    // Must be a format supported by the PHP date() function.
+    // See <https://secure.php.net/date>.
+    'date.format' => 'M jS H:i:s',
+
+    // The number of items to show in "Top lists" with functions
+    // using the most time or memory resources, on XHGui Run pages.
+    'detail.count' => 6,
+
+    // The number of items to show per page, on XHGui list pages.
+    'page.limit' => 25,
+
+    );
+EOT
+
+# Add indexes documented at https://github.com/perftools/xhgui#installation
+mongo --eval "db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } ); \
+db.results.ensureIndex( { 'profile.main().wt' : -1 } ); \
+db.results.ensureIndex( { 'profile.main().mu' : -1 } ); \
+db.results.ensureIndex( { 'profile.main().cpu' : -1 } ); \
+db.results.ensureIndex( { 'meta.url' : 1 } ); \
+db.results.ensureIndex( { 'meta.simple_url' : 1 } ); \
+db.results.ensureIndex( { "meta.request_ts" : 1 }, { expireAfterSeconds : 432000 } )" xhprof
+
+cd /opt/xhgui
+php install.php
+
+for version in 7.1 7.2 7.3
+do
+  cat << 'EOT' > /etc/php/$version/mods-available/xhgui.ini
+; Include xhgui's header for performance profiling.
+auto_prepend_file="/opt/xhgui/external/header.php"
+EOT
+done
+phpenmod -v ALL xhgui
+

--- a/scripts/serve-elgg.sh
+++ b/scripts/serve-elgg.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -89,6 +98,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     location ~ \.php$ {

--- a/scripts/serve-laravel.sh
+++ b/scripts/serve-laravel.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -55,6 +64,7 @@ block="server {
     }
 
     $configureZray
+    $configureXhgui
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }

--- a/scripts/serve-pimcore.sh
+++ b/scripts/serve-pimcore.sh
@@ -32,6 +32,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="# mime types are covered in nginx.conf by:
 # http {
 #   include       mime.types;
@@ -56,6 +65,10 @@ server {
     rewrite ^/cache-buster-(?:\d+)/(.*) /\$1 last;
 
     $rewritesTXT
+
+    $configureZray
+
+    $configureXhgui
 
     # Stay secure
     #

--- a/scripts/serve-silverstripe.sh
+++ b/scripts/serve-silverstripe.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -131,6 +140,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     ssl_certificate     /etc/nginx/ssl/$1.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;

--- a/scripts/serve-statamic.sh
+++ b/scripts/serve-statamic.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -86,6 +95,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     ssl_certificate     /etc/nginx/ssl/$1.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;

--- a/scripts/serve-symfony2.sh
+++ b/scripts/serve-symfony2.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -96,6 +105,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     ssl_certificate     /etc/nginx/ssl/$1.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;

--- a/scripts/serve-symfony4.sh
+++ b/scripts/serve-symfony4.sh
@@ -28,6 +28,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -72,6 +81,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     ssl_certificate     /etc/nginx/ssl/$1.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;

--- a/scripts/serve-thinkphp.sh
+++ b/scripts/serve-thinkphp.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -58,6 +67,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }

--- a/scripts/serve-yii.sh
+++ b/scripts/serve-yii.sh
@@ -37,6 +37,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -58,6 +67,8 @@ block="server {
         deny all;
     }
     $configureZray
+
+    $configureXhgui
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt  { access_log off; log_not_found off; }

--- a/scripts/serve-zf.sh
+++ b/scripts/serve-zf.sh
@@ -50,6 +50,15 @@ location /ZendServer {
 else configureZray=""
 fi
 
+if [ "$8" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -94,6 +103,8 @@ block="server {
     }
 
     $configureZray
+
+    $configureXhgui
 
     ssl_certificate     /etc/nginx/ssl/$1.crt;
     ssl_certificate_key /etc/nginx/ssl/$1.key;


### PR DESCRIPTION
Following up from https://github.com/laravel/homestead/issues/1071

To enable profiling:

1. In a site, set `xhgui: 'true'`:

```
sites:
    -
        map: drupal8.test
        to: /home/vagrant/code/web
        type: "apache"
        xhgui: 'true'
```

2. Build or provision the vagrant box.
3. To profile a web request, add `xhgui=on` as a query parameter. A cookie is set so future requests will be profiled (like form submits or ajax requests), and will expire 1 hour after the last request (as profiling is a significant performance hit in itself).
4. To profile a CLI request, set an `XHGUI=on` environment variable with `export` or for a single command with `XHGUI=on php ...`.

TODOs:

- [x] Add support for nginx too.
- [ ] Documentation somewhere?