### PR TITLE
Add support for the friendly URLs in the MODX Content Management System

### DIFF
--- a/scripts/serve-modx.sh
+++ b/scripts/serve-modx.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+declare -A params=$6       # Create an associative array
+declare -A headers=$9      # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
+paramsTXT=""
+if [ -n "$6" ]; then
+   for element in "${!params[@]}"
+   do
+      paramsTXT="${paramsTXT}
+      fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "$9" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
+fi
+
+if [ "$7" = "true" ] && [ "$5" = "7.2" ]
+then configureZray="
+location /ZendServer {
+        try_files \$uri \$uri/ /ZendServer/index.php?\$args;
+}
+"
+else configureZray=""
+fi
+
+block="server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name .$1;
+    root \"$2\";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    $rewritesTXT
+
+    location / {
+        if (!-e \$request_filename) {
+            rewrite ^/(.*)\$ /index.php?q=\$1 last;
+        }
+        $headersTXT
+    }
+
+    $configureZray
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/$1-error.log error;
+
+    sendfile off;
+
+    client_max_body_size 100m;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        $paramsTXT
+
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate_key /etc/nginx/ssl/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
+#echo "127.0.0.1 $1" >> /etc/hosts


### PR DESCRIPTION
MODX is supported out of the box by the default-homestead-config (laravel), but with Friendly URL's enabled, it won't. This serve-modx.sh is tested with several MODX-powered website:
- Normal 1-context sites
- Resources with multiple folders
- Multi-context instances