### PR TITLE
Support for i386 architecture removed from the MariaDB installation

### DIFF
--- a/scripts/install-maria.sh
+++ b/scripts/install-maria.sh
@@ -31,7 +31,7 @@ rm -rf /etc/mysql
 # Add Maria PPA
 
 sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-sudo add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.3/ubuntu bionic main'
+sudo add-apt-repository 'deb [arch=amd64,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.3/ubuntu bionic main'
 apt-get update
 
 # Set The Automated Root Password


### PR DESCRIPTION
The MariaDB repository does not support i386 architecture, when the `sudo apt update` command is used, the error is reported:

```
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'http://ftp.osuosl.org/pub/mariadb/repo/10.3/ubuntu bionic InRelease' doesn't support architecture 'i386'
```