### PR TITLE
Updated Vagrantfile for localized use

### DIFF
--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -15,7 +15,7 @@ aliasesPath = "aliases"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
 
-Vagrant.require_version '>= 2.1.0'
+Vagrant.require_version '>= 1.9.0'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exist? aliasesPath then

--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -15,7 +15,7 @@ aliasesPath = "aliases"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
 
-Vagrant.require_version '>= 1.9.0'
+Vagrant.require_version '>= 2.1.0'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exist? aliasesPath then
@@ -43,7 +43,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.provision "shell", path: customizationScriptPath, privileged: false, keep_color: true
     end
 
-    if defined? VagrantPlugins::HostsUpdater
+    if Vagrant.has_plugin?('vagrant-hostsupdater')
         config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
+    elsif Vagrant.has_plugin?('vagrant-hostmanager')
+        config.hostmanager.enabled = true
+        config.hostmanager.manage_host = true
+        config.hostmanager.aliases = settings['sites'].map { |site| site['map'] }
     end
 end


### PR DESCRIPTION
Shamelessly nicked from the main Vagrantfile, now also supports the vagrant-hostmanager plugin.
Required Vagrant version has increased too.