### PR TITLE
Fix mysql8 install script

### DIFF
--- a/scripts/install-mysql8.sh
+++ b/scripts/install-mysql8.sh
@@ -10,6 +10,7 @@ then
 fi
 
 touch /home/vagrant/.mysql8
+chown -Rf vagrant:vagrant /home/vagrant/.mysql8
 
 # Disable Apparmor
 ## See https://github.com/laravel/homestead/issues/629#issue-247524528

--- a/scripts/install-mysql8.sh
+++ b/scripts/install-mysql8.sh
@@ -42,7 +42,7 @@ debconf-set-selections <<< "mysql-server mysql-server/data-dir select ''"
 debconf-set-selections <<< "mysql-server mysql-server/root_password password secret"
 debconf-set-selections <<< "mysql-server mysql-server/root_password_again password secret"
 
-apt-get install -y mysql-server=8.0.15-1ubuntu18.04
+apt-get install -y mysql-server
 
 # Configure MySQL 8 Remote Access
 echo "bind-address = 0.0.0.0" | tee -a /etc/mysql/conf.d/mysql.cnf


### PR DESCRIPTION
Since the official ppa for the mysql 8 is added, the install should not include the specific version, so it will install the latest one.

Closes #1117 