### PR TITLE
Change zsh install script to use .zprofile

### DIFF
--- a/scripts/install-ohmyzsh.sh
+++ b/scripts/install-ohmyzsh.sh
@@ -4,8 +4,9 @@
 
 git clone git://github.com/robbyrussell/oh-my-zsh.git /home/vagrant/.oh-my-zsh
 cp /home/vagrant/.oh-my-zsh/templates/zshrc.zsh-template /home/vagrant/.zshrc
-printf "\nsource ~/.bash_aliases\n" | tee -a /home/vagrant/.zshrc
-printf "\nsource ~/.profile\n" | tee -a /home/vagrant/.zshrc
+printf "\nemulate sh -c 'source ~/.bash_aliases'\n" | tee -a /home/vagrant/.zprofile
+printf "\nemulate sh -c 'source ~/.profile'\n" | tee -a /home/vagrant/.zprofile
 chown -R vagrant:vagrant /home/vagrant/.oh-my-zsh
 chown vagrant:vagrant /home/vagrant/.zshrc
+chown vagrant:vagrant /home/vagrant/.zprofile
 chsh -s /bin/zsh vagrant


### PR DESCRIPTION
Uses `emulate` to avoid conflict during the source of ` ~/.bash_aliases` and `~/.profile` because this files can contains something specific to `bash`

Closes #1131 

Signed-off-by: Ricardo Seriani <ricardo.seriani@gmail.com>