### PR TITLE
Port 80 in the import links of the GPG keys removed from the scripts

### DIFF
--- a/scripts/install-crystal.sh
+++ b/scripts/install-crystal.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Install Crystal Programming Language Support
-apt-key adv --keyserver hkp://keys.gnupg.net:80 --recv-keys 09617FD37CC06B54
+apt-key adv --keyserver hkp://keys.gnupg.net --recv-keys 09617FD37CC06B54
 echo "deb https://dist.crystal-lang.org/apt crystal main" | tee /etc/apt/sources.list.d/crystal.list
 apt-get update
 apt-get install -y crystal

--- a/scripts/install-maria.sh
+++ b/scripts/install-maria.sh
@@ -31,7 +31,7 @@ rm -rf /etc/mysql
 
 # Add Maria PPA
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xF1656F24C74CD1D8
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xF1656F24C74CD1D8
 sudo add-apt-repository 'deb [arch=amd64,ppc64el] http://ftp.osuosl.org/pub/mariadb/repo/10.4/ubuntu bionic main'
 apt-get update
 

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -11,7 +11,7 @@ fi
 touch /home/vagrant/.mongo
 chown -Rf vagrant:vagrant /home/vagrant/.mongo
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 2>&1
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 2>&1
 echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list
 
 sudo apt-get update


### PR DESCRIPTION
When using Homestead with proxy, port 80 on GPG key bindings causes problems. Details:

* Windows 7 Professional
* Vagrant 2.2.4
* VirtualBox 6.0.6
* Box laravel/homestead 7.2.1
* Homestead in master branch (Latest release v8.4.0)

Vagrant plugins:

```shell
$ vagrant plugin list
vagrant-proxyconf (2.0.1, global)
  - Version Constraint: > 0
```

Logs:

* MariaDB:

```shell
vagrant@homestead:~$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xF1656F24C74CD1D8
Executing: /tmp/apt-key-gpghome.TRZRc3GO4x/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xF1656F24C74CD1D8
gpg: keyserver receive failed: No keyserver available

vagrant@homestead:~$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xF1656F24C74CD1D8
Executing: /tmp/apt-key-gpghome.bpQLD7KW90/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xF1656F24C74CD1D8
gpg: key F1656F24C74CD1D8: 6 signatures not checked due to missing keys
gpg: key F1656F24C74CD1D8: public key "MariaDB Signing Key <signing-key@mariadb.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```

* MongoDB:

```shell
vagrant@homestead:~$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 2>&1
Executing: /tmp/apt-key-gpghome.fp4SRSGqRm/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
gpg: keyserver receive failed: No keyserver available

vagrant@homestead:~$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 9DA31620334BD75D9DCB49F368818C72E52529D4 2>&1
Executing: /tmp/apt-key-gpghome.RGzBmoAM73/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
gpg: key 68818C72E52529D4: public key "MongoDB 4.0 Release Signing Key <packaging@mongodb.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
```