### PR TITLE
Remove automatic www prefix in /etc/hosts entries

### DIFF
--- a/scripts/hosts-add.sh
+++ b/scripts/hosts-add.sh
@@ -12,7 +12,7 @@ then
             echo "$HOSTNAME already exists:";
             echo $(grep [^\.]$HOSTNAME /etc/hosts);
         else
-            sudo sed -i "/#### HOMESTEAD-SITES-BEGIN/c\#### HOMESTEAD-SITES-BEGIN\\n$IP\t$HOSTNAME\twww.$HOSTNAME" /etc/hosts
+            sudo sed -i "/#### HOMESTEAD-SITES-BEGIN/c\#### HOMESTEAD-SITES-BEGIN\\n$IP\t$HOSTNAME" /etc/hosts
 
             if ! [ -n "$(grep [^\.]$HOSTNAME /etc/hosts)" ]
                 then

--- a/scripts/serve-modx.sh
+++ b/scripts/serve-modx.sh
@@ -95,4 +95,5 @@ block="server {
 
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
-#echo "127.0.0.1 $1" >> /etc/hosts
+
+sudo /vagrant/scripts/hosts-add.sh '127.0.0.1' "$1"


### PR DESCRIPTION
Also, replace last line in serve-modx.sh to match that in serve-laravel.

This is a follow-up to the as yet unresolved comments in #1129 .

Are there any other scripts in `scripts/serve-*` that need this change? Upon cursory analysis, I could find only one, `serve-modx.sh`.