### PR TITLE
Hyper-V : Make xphp alias work with any host IP

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -254,9 +254,11 @@ function xphp() {
     fi
 
     if ! $XDEBUG_ENABLED; then xon; fi
+	
+    HOST_IP=$(last --limit=1 | grep -oP '\d+(\.\d+){3}')
 
     php \
-        -dxdebug.remote_host=192.168.10.1 \
+        -dxdebug.remote_host=${HOST_IP} \
         -dxdebug.remote_autostart=1 \
         "$@"
 


### PR DESCRIPTION
If you're using Hyper-V you can't predict the IP that your host machine will have on the virtual switch, so we can't assume it will be `192.168.10.1` like with other providers.

What this does is get the last connection to the host with `last --limit=1` and extract the IP from the line with grep, then use this as the xdebug.remote_host parameter.
There might be some edge cases where it's not the correct IP, but if you're launching xphp from the command line I think there's a very good chance you're the last person that ssh'ed into the VM. I've been using this for a couple of month in my aliases file and it works fine.