### PR TITLE
Fix nginx unable to start on VM restart

### DIFF
--- a/scripts/serve-cakephp3.sh
+++ b/scripts/serve-cakephp3.sh
@@ -105,6 +105,21 @@ server {
 }
 "
 
+# Restart nginx if it started before vagrant path was mounted
+# (happens after stopping and restarting the VM)
+timer="[Unit]
+Description=Nginx delay
+
+[Timer]
+OnStartupSec=40sec
+
+[Install]
+WantedBy=timers.target
+"
+
+echo "$timer" > "/lib/systemd/system/nginx.timer"
+systemctl enable nginx.timer
+
 echo "$block" > "/etc/nginx/sites-available/$1"
 ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"
 #echo "127.0.0.1 $1" >> /etc/hosts


### PR DESCRIPTION
Because this config relies on the site path `/vagrant` already being mounted when nginx start it will fail when restarting the VM since the server will attempt to start way sooner.

This will just restart it 40 seconds later.

Ideally i would like to start nginx after `vagrant.mount` but haven't found anything that works yet.