### PR TITLE
Implement support for Apache Solr Search Database

### DIFF
--- a/scripts/create-solr.sh
+++ b/scripts/create-solr.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sudo su -c "/opt/solr/bin/solr create -c homestead" solr

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -456,6 +456,13 @@ class Homestead
       end
     end
 
+    # Install Solr If Necessary
+    if settings.has_key?('solr') && settings['solr']
+      config.vm.provision 'shell' do |s|
+        s.path = script_dir + '/install-solr.sh'
+      end
+    end
+
     # Install MySQL 8 If Necessary
     if settings.has_key?('mysql8') && settings['mysql8']
         config.vm.provision 'shell' do |s|
@@ -523,6 +530,14 @@ class Homestead
           config.vm.provision 'shell' do |s|
             s.name = 'Creating Mongo Database: ' + db
             s.path = script_dir + '/create-mongo.sh'
+            s.args = [db]
+          end
+        end
+
+        if settings.has_key?('solr') && settings['solr']
+          config.vm.provision 'shell' do |s|
+            s.name = 'Creating Solr Database: ' + db
+            s.path = script_dir + '/create-solr.sh'
             s.args = [db]
           end
         end

--- a/scripts/install-solr.sh
+++ b/scripts/install-solr.sh
@@ -1,0 +1,8 @@
+# Install Java Runtime Enviroment
+sudo apt-get update
+sudo apt-get install default-jre -y
+
+# Install Solr 7.7.1
+wget -q http://archive.apache.org/dist/lucene/solr/7.7.1/solr-7.7.1.tgz
+tar xzf solr-7.7.1.tgz solr-7.7.1/bin/install_solr_service.sh --strip-components=2
+sudo bash ./install_solr_service.sh solr-7.7.1.tgz

--- a/scripts/install-solr.sh
+++ b/scripts/install-solr.sh
@@ -1,6 +1,6 @@
 # Install Java Runtime Enviroment
 sudo apt-get update
-sudo apt-get install default-jre -y
+sudo apt-get install default-jre php-solr -y
 
 # Install Solr 7.7.1
 wget -q http://archive.apache.org/dist/lucene/solr/7.7.1/solr-7.7.1.tgz


### PR DESCRIPTION
To activate Solr just use in Homestead.yaml:

    solr: true

And open the port on: 

    ports:
        - send: 18983
          to: 8983

This installs Solr 7.7.1 per default, current version is 8.1.0 (as of today). I have not much experience with the 8.* branch, so i implemented the latest 7.* version. It also installs a default "homestead" search core.
This is one of my first PR, if you have any improvements or suggestions, let me know.

-Stefan