### PR TITLE
Fix webdriver installation

### DIFF
--- a/scripts/install-webdriver.sh
+++ b/scripts/install-webdriver.sh
@@ -11,5 +11,6 @@ chown -Rf vagrant:vagrant /home/vagrant/.webdriverutils
 
 # Install The Chrome Web Driver & Dusk Utilities
 
+apt-get update
 apt-get -y install libxpm4 libxrender1 libgtk2.0-0 libnss3 libgconf-2-4 chromium-browser xvfb gtk2-engines-pixbuf \
 xfonts-cyrillic xfonts-100dpi xfonts-75dpi xfonts-base xfonts-scalable imagemagick x11-apps


### PR DESCRIPTION
The `webdriver` feature doesn't work for me. When I add `webdriver: true` to my `Homestead.yaml`, I get 404 errors for multiple packages.

Running `apt-get update` beforehand fixes it.