### PR TITLE
Attempt to restart the web server if it's not started

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -612,6 +612,11 @@ class Homestead
       s.inline = 'sudo service motd-news restart'
     end
 
+    config.vm.provision 'shell', run: "always" do |s|
+        s.name = 'Restart Nginx'
+        s.path = script_dir + '/server-reset.sh'
+    end
+
     if settings.has_key?('backup') && settings['backup'] && (Vagrant::VERSION >= '2.1.0' || Vagrant.has_plugin?('vagrant-triggers'))
       dir_prefix = '/vagrant/'
       settings['databases'].each do |database|

--- a/scripts/server-reset.sh
+++ b/scripts/server-reset.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Check if web server is running and if not restart it.
+# In case some site setting required mount directories to be present and made it unable to start
+
+systemctl is-active --quiet nginx.service
+result=$?
+
+if [ ${result} != "0" ]
+    then
+        systemctl restart nginx.service
+        echo "Server restarted.";
+    else
+        echo "Server running.";
+fi


### PR DESCRIPTION
If a site config relies on vagrant being mounted and it isn't when the server is starting the server won't start.

This is just as small script that attempts to restart the server if it detects it isn't running otherwise it won't do anything.

By the time this is running everything will be mounted.