### PR TITLE
Correct path for xhgui and mongo scripts

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -334,11 +334,11 @@ class Homestead
 
           if site['xhgui'] == 'true'
             config.vm.provision 'shell' do |s|
-              s.path = script_dir + '/install-mongo.sh'
+              s.path = script_dir + '/features/mongodb.sh'
             end
 
             config.vm.provision 'shell' do |s|
-              s.path = script_dir + '/install-xhgui.sh'
+              s.path = script_dir + '/features/xhgui.sh'
             end
 
             config.vm.provision 'shell' do |s|


### PR DESCRIPTION
This isn't working yet as it looks like there's an error installing php-mongodb:

```
    homestead-d8: Installing shared extensions:     /usr/lib/php/20131226/
    homestead-d8: chmod:
    homestead-d8: cannot access '/usr/lib/php/20160303/mongodb.so'
    homestead-d8: : No such file or directory
    homestead-d8: Reading package lists...
    homestead-d8: Building dependency tree...
    homestead-d8:
    homestead-d8: Reading state information...
    homestead-d8: php7.0-dev is already the newest version (7.0.33-8+ubuntu18.04.1+deb.sury.org+1).
    homestead-d8: 0 upgraded, 0 newly installed, 0 to remove and 12 not upgraded.
    homestead-d8: Configuring for:
    homestead-d8: PHP Api Version:         20151012
    homestead-d8: Zend Module Api No:      20151012
    homestead-d8: Zend Extension Api No:   320151012
    homestead-d8: Installing shared extensions:     /usr/lib/php/20151012/
    homestead-d8: chmod: cannot access '/usr/lib/php/20160303/mongodb.so': No such file or directory
```