### PR TITLE
Add ability to import CA to host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpunit.xml
 /mysql_backup
 /postgres_backup
 /user-customizations.sh
+/.ca

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -548,12 +548,12 @@ class Homestead
       end
 
       config.trigger.after :up do |trigger|
-        trigger.info = "Copying CA files to share..."
+        trigger.info = "Importing CA files..."
         trigger.run = {path: script_dir + "/import-ca.sh"}
       end
 
       config.trigger.after :destroy, :halt do |trigger|
-        trigger.info = "Copying CA files to share..."
+        trigger.info = "Removing CA files..."
         trigger.run = {path: script_dir + "/remove-ca.sh"}
       end
     end

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -540,6 +540,24 @@ class Homestead
       end
     end
 
+    # Import CA cert into host trusted repository if desired
+    if settings.has_key?('import_ca') && settings['import_ca']
+      config.trigger.after :up do |trigger|
+        trigger.info = "Copying CA files to share..."
+        trigger.run_remote = {path: script_dir + "/share-ca.sh"}
+      end
+
+      config.trigger.after :up do |trigger|
+        trigger.info = "Copying CA files to share..."
+        trigger.run = {path: script_dir + "/import-ca.sh"}
+      end
+
+      config.trigger.after :destroy, :halt do |trigger|
+        trigger.info = "Copying CA files to share..."
+        trigger.run = {path: script_dir + "/remove-ca.sh"}
+      end
+    end
+
   end
 
   def self.backup_mysql(database, dir, config)

--- a/scripts/import-ca.sh
+++ b/scripts/import-ca.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+PATH_CA_SHARE="../.ca"
+
+cd $SCRIPTPATH/$PATH_CA_SHARE
+
+for ca in `ls *.crt`
+do
+    if hash trust 2>/dev/null
+    then
+        sudo trust anchor ./$ca
+        echo "Added CA: $ca"
+    fi
+done

--- a/scripts/remove-ca.sh
+++ b/scripts/remove-ca.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+PATH_CA_SHARE="../.ca"
+
+cd $SCRIPTPATH/$PATH_CA_SHARE
+
+for ca in `ls *.crt`
+do
+    if hash trust 2>/dev/null
+    then
+        sudo trust anchor --remove ./$ca
+        echo "Removed CA: $ca"
+    fi
+done

--- a/scripts/share-ca.sh
+++ b/scripts/share-ca.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+
+PATH_SSL="/etc/nginx/ssl"
+PATH_CA_SHARE="/vagrant/.ca"
+
+# Path to the custom Homestead $(hostname) Root CA certificate.
+PATH_ROOT_CNF="${PATH_SSL}/ca.homestead.$(hostname).cnf"
+PATH_ROOT_CRT="${PATH_SSL}/ca.homestead.$(hostname).crt"
+PATH_ROOT_KEY="${PATH_SSL}/ca.homestead.$(hostname).key"
+
+if [ -d "$PATH_SSL" ]
+then
+    if [ ! -d "PATH_CA_SHARE" ]
+    then
+        mkdir $PATH_CA_SHARE 2>/dev/null
+    fi
+    rm -rf "$PATH_CA_SHARE/*"
+
+    cp -p $PATH_ROOT_CRT $PATH_CA_SHARE
+    cp -p $PATH_ROOT_KEY $PATH_CA_SHARE
+    cp -p $PATH_ROOT_CNF $PATH_CA_SHARE
+fi


### PR DESCRIPTION
Add ability to import homestead CA into host trusted repository while homestead is running just by setting `import_ca: true` in your `Homestead.yaml` file

- Currently only working on host systems that use `trust` like Arch Linux

If someone want to adapt it for other systems here is a doc https://github.com/rcrowley/certified/wiki/Trust-your-CA-on-Linux fo other flavors i don't have a system to test it on at the moment.

Note: It will remove it whenever you do `vagrant halt` or `vagrant destroy` so there is little risk of it being exploited especially since the certificate get regenerated whenever the VM gets destroyed.