### PR TITLE
Branch 'release' reflect 'master' about 'features' key in Homestead.{yaml,json}

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -20,6 +20,11 @@ sites:
 databases:
     - homestead
 
+features:
+    - mariadb: false
+    - ohmyzsh: false
+    - webdriver: false
+
 # ports:
 #     - send: 50000
 #       to: 5000

--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -21,5 +21,10 @@
     ],
     "databases": [
         "homestead"
-    ]
+    ],
+    "features": {
+        "mariadb": "false",
+        "ohmyzsh": "false",
+        "webdriver": "false"
+    }
 }

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -20,6 +20,11 @@ sites:
 databases:
     - homestead
 
+features:
+    - mariadb: false
+    - ohmyzsh: false
+    - webdriver: false
+
 # ports:
 #     - send: 50000
 #       to: 5000


### PR DESCRIPTION
New versions of Homestead look into Homestead.{yaml,json} file for 'features' key in order to install any optional software in a 'pre-configured way'.

The official Laravel Homestead documentation points to 'release' branch, which can induce confusing due to the provision doesn't work.

I kept the same examples as in the 'master' branch, already ok (#1220).