### PR TITLE
Add mysql upgrade for mariadb

### DIFF
--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -64,7 +64,7 @@ mysql --user="root" -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secre
 mysql --user="root" -e "FLUSH PRIVILEGES;"
 service mysql restart
 
-mysql_upgrade --user="root" --password="secret" --verbose --force
+mysql_upgrade --user="root" --verbose --force
 service mysql restart
 
 unset MYSQL_PWD

--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -58,7 +58,7 @@ export MYSQL_PWD=secret
 mysql --user="root" -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 service mysql restart
 
-mysql --user="root" -e "CREATE USER 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
+mysql --user="root" -e "CREATE USER IF NOT EXISTS 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
 mysql --user="root" -e "GRANT ALL ON *.* TO 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 mysql --user="root" -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 mysql --user="root" -e "FLUSH PRIVILEGES;"

--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -53,13 +53,15 @@ bind-address = 0.0.0.0
 ignore-db-dir = lost+found
 EOF
 
-sed -i '/^bind-address/s/bind-address.*=.*/bind-address = 0.0.0.0/' /etc/mysql/my.cnf
+export MYSQL_PWD=secret
 
-mysql --user="root" --password="secret" -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+mysql --user="root" -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 service mysql restart
 
-mysql --user="root" --password="secret" -e "CREATE USER 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
-mysql --user="root" --password="secret" -e "GRANT ALL ON *.* TO 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -e "FLUSH PRIVILEGES;"
+mysql --user="root" -e "CREATE USER 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
+mysql --user="root" -e "GRANT ALL ON *.* TO 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+mysql --user="root" -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+mysql --user="root" -e "FLUSH PRIVILEGES;"
 service mysql restart
+
+unset MYSQL_PWD

--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -64,4 +64,7 @@ mysql --user="root" -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secre
 mysql --user="root" -e "FLUSH PRIVILEGES;"
 service mysql restart
 
+mysql_upgrade --user="root" --password="secret" --verbose --force
+service mysql restart
+
 unset MYSQL_PWD

--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -46,7 +46,12 @@ debconf-set-selections <<< "mariadb-server mysql-server/root_password_again pass
 
 apt-get install -y mariadb-server
 
-# Configure Maria Remote Access
+# Configure Maria Remote Access and ignore db dirs
+cat > /etc/mysql/conf.d/mysql.cnf << EOF
+[mysqld]
+bind-address = 0.0.0.0
+ignore-db-dir = lost+found
+EOF
 
 sed -i '/^bind-address/s/bind-address.*=.*/bind-address = 0.0.0.0/' /etc/mysql/my.cnf
 


### PR DESCRIPTION
I added `mysql_upgrade` (#1228)
Fix problem with `lost+found` tables https://gist.github.com/pOmelchenko/e376dc1e99060b2b49281567a13f61ed#file-mysql_upgrade_log-L61-L62
and move password from command parameters to variable