### PR TITLE
Fixed warnings with password on the command line

### DIFF
--- a/scripts/features/mysql8.sh
+++ b/scripts/features/mysql8.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-export DEBIAN_FRONTEND=noninteractive
 # Check If MySQL 8 Has Been Installed
-
-if [ -f /home/vagrant/.homestead-features/mysql8 ]
-then
+if [[ -f /home/vagrant/.homestead-features/mysql8 ]]; then
     echo "MySQL 8 already installed."
     exit 0
 fi
+
+export DEBIAN_FRONTEND=noninteractive
 
 touch /home/vagrant/.homestead-features/mysql8
 chown -Rf vagrant:vagrant /home/vagrant/.homestead-features

--- a/scripts/features/mysql8.sh
+++ b/scripts/features/mysql8.sh
@@ -42,11 +42,13 @@ debconf-set-selections <<< "mysql-server mysql-server/root_password_again passwo
 
 apt-get install -y mysql-server
 
-# Configure MySQL 8 Remote Access
-echo "bind-address = 0.0.0.0" | tee -a /etc/mysql/conf.d/mysql.cnf
+# Configure MySQL 8 Remote Access and Native Pluggable Authentication
+cat > /etc/mysql/conf.d/mysqld.cnf << EOF
+[mysqld]
+bind-address = 0.0.0.0
+default_authentication_plugin = mysql_native_password
+EOF
 
-# Use Native Pluggable Authentication
-echo -e "[mysqld]\ndefault_authentication_plugin = mysql_native_password" | tee -a /etc/mysql/conf.d/mysql.cnf
 service mysql restart
 
 mysql --user="root" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'secret';"

--- a/scripts/features/mysql8.sh
+++ b/scripts/features/mysql8.sh
@@ -18,7 +18,6 @@ service apparmor teardown
 update-rc.d -f apparmor remove
 
 # Remove MySQL
-
 apt-get remove -y --purge mysql-server mysql-client mysql-common
 apt-get autoremove -y
 apt-get autoclean
@@ -40,6 +39,7 @@ debconf-set-selections <<< "mysql-server mysql-server/data-dir select ''"
 debconf-set-selections <<< "mysql-server mysql-server/root_password password secret"
 debconf-set-selections <<< "mysql-server mysql-server/root_password_again password secret"
 
+# Install MySQL 8
 apt-get install -y mysql-server
 
 # Configure MySQL 8 Remote Access and Native Pluggable Authentication

--- a/scripts/features/mysql8.sh
+++ b/scripts/features/mysql8.sh
@@ -61,3 +61,6 @@ mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'0.0.0.0' WIT
 mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'%' WITH GRANT OPTION;"
 mysql --user="root" -e "FLUSH PRIVILEGES;"
 service mysql restart
+
+unset MYSQL_PWD
+unset DEBIAN_FRONTEND

--- a/scripts/features/mysql8.sh
+++ b/scripts/features/mysql8.sh
@@ -13,10 +13,9 @@ chown -Rf vagrant:vagrant /home/vagrant/.homestead-features
 
 # Disable Apparmor
 ## See https://github.com/laravel/homestead/issues/629#issue-247524528
-
-sudo service apparmor stop
-sudo service apparmor teardown
-sudo update-rc.d -f apparmor remove
+service apparmor stop
+service apparmor teardown
+update-rc.d -f apparmor remove
 
 # Remove MySQL
 

--- a/scripts/features/mysql8.sh
+++ b/scripts/features/mysql8.sh
@@ -51,11 +51,13 @@ EOF
 
 service mysql restart
 
+export MYSQL_PWD=secret
+
 mysql --user="root" -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'secret';"
-mysql --user="root" --password="secret" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -e "CREATE USER 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
-mysql --user="root" --password="secret" -e "CREATE USER 'homestead'@'%' IDENTIFIED BY 'secret';"
-mysql --user="root" --password="secret" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'0.0.0.0' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'%' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -e "FLUSH PRIVILEGES;"
+mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;"
+mysql --user="root" -e "CREATE USER 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
+mysql --user="root" -e "CREATE USER 'homestead'@'%' IDENTIFIED BY 'secret';"
+mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'0.0.0.0' WITH GRANT OPTION;"
+mysql --user="root" -e "GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'%' WITH GRANT OPTION;"
+mysql --user="root" -e "FLUSH PRIVILEGES;"
 service mysql restart


### PR DESCRIPTION
In this PR fixed warnings with password on the command line, such as these:
`homestead: mysql: [Warning] Using a password on the command line interface can be insecure.`
in log you can see on lines [801-807](https://gist.github.com/pOmelchenko/d853d8f5052a68c2354558cd4fcc9b2d#file-mysql8_before-txt-L801-L807)

And added some changes to improve the style ☺️.

- [homestead.yaml](https://gist.github.com/pOmelchenko/d853d8f5052a68c2354558cd4fcc9b2d#file-homestead-yaml)
- log for homestead up – [before](https://gist.github.com/pOmelchenko/d853d8f5052a68c2354558cd4fcc9b2d#file-mysql8_before-txt)
- log for homestead destroy and up – [after](https://gist.github.com/pOmelchenko/d853d8f5052a68c2354558cd4fcc9b2d#file-mysql8_after-txt)