### PR TITLE
Use mDNS to resolve all host names

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -261,11 +261,11 @@ class Homestead
       # socket = { 'map' => 'socket-wrench.test', 'to' => '/var/www/socket-wrench/public' }
       # settings['sites'].unshift(socket)
 
-      aliases = []
+      domains = []
 
       settings['sites'].each do |site|
 
-        aliases.push(site['map'])
+        domains.push(site['map'])
 
         # Create SSL certificate
         config.vm.provision 'shell' do |s|
@@ -383,7 +383,7 @@ class Homestead
         end
       end
 
-      config.vm.provision "shell", args: aliases.join(","), inline: <<-SHELL
+      config.vm.provision "shell", args: domains.join(","), inline: <<-SHELL
         sed -i "s/#browse-domains=.*/browse-domains=$1/" /etc/avahi/avahi-daemon.conf
         sed -i "s/browse-domains=.*/browse-domains=$1/" /etc/avahi/avahi-daemon.conf
         service avahi-daemon restart

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -261,7 +261,11 @@ class Homestead
       # socket = { 'map' => 'socket-wrench.test', 'to' => '/var/www/socket-wrench/public' }
       # settings['sites'].unshift(socket)
 
+      aliases = []
+
       settings['sites'].each do |site|
+
+        aliases.push(site['map'])
 
         # Create SSL certificate
         config.vm.provision 'shell' do |s|
@@ -378,6 +382,12 @@ class Homestead
           end
         end
       end
+
+      config.vm.provision "shell", args: aliases.join(","), inline: <<-SHELL
+        sed -i "s/#browse-domains=.*/browse-domains=$1/" /etc/avahi/avahi-daemon.conf
+        sed -i "s/browse-domains=.*/browse-domains=$1/" /etc/avahi/avahi-daemon.conf
+        service avahi-daemon restart
+      SHELL
     end
 
     # Configure All Of The Server Environment Variables


### PR DESCRIPTION
This PR uses the `browse-domains` feature to advertise _all_ domains defined in the Homestead.yaml `sites` block for resolution. Eliminates the need to manage hosts files.