### PR TITLE
Minio conditional statement and bucket location change

### DIFF
--- a/scripts/create-minio-bucket.sh
+++ b/scripts/create-minio-bucket.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-mc mb homestead/$1
-mc policy set $2 homestead/$1
+mc mb /usr/local/share/minio/$1
+mc policy set $2 /usr/local/share/minio/$1

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -518,7 +518,7 @@ class Homestead
     end
 
     # Create Minio Buckets
-    if settings.has_key?('buckets') && settings['minio']
+    if settings.has_key?('buckets') && settings['features'].any? { |feature| feature.include?('minio') }
       settings['buckets'].each do |bucket|
         config.vm.provision 'shell' do |s|
           s.name = 'Creating Minio Bucket: ' + bucket['name']


### PR DESCRIPTION
Buckets created in the folder "homestead" no longer seem to appear within the Minio GUI, instead changed to create the buckets where directly referenced.

Also changed the conditional statement within the initial script to reflect the recent structure changes to "features" array within .yaml. 