### PR TITLE
Feature: swoole support (PHP 7.1+)

### DIFF
--- a/scripts/features/swoole.sh
+++ b/scripts/features/swoole.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -f /home/vagrant/.homestead-features/swoole ]
+then
+    echo "Swoole already installed."
+    exit 0
+fi
+
+touch /home/vagrant/.homestead-features/swoole
+chown -Rf vagrant:vagrant /home/vagrant/.homestead-features
+
+sudo rm -rf /tmp/swoole-php-driver /usr/src/swoole-php-driver
+git clone -c advice.detachedHead=false -q -b 'v4.4.5' --single-branch https://github.com/swoole/swoole-src.git /tmp/swoole-php-driver
+sudo mv /tmp/swoole-php-driver /usr/src/swoole-php-driver
+cd /usr/src/swoole-php-driver
+git submodule -q update --init
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php7.1-dev
+phpize7.1
+./configure --enable-sockets --with-php-config=/usr/bin/php-config7.1 > /dev/null
+make clean > /dev/null
+make >/dev/null 2>&1
+sudo make install
+sudo bash -c "echo 'extension=swoole.so' > /etc/php/7.1/mods-available/swoole.ini"
+sudo ln -s /etc/php/7.1/mods-available/swoole.ini /etc/php/7.1/cli/conf.d/20-swoole.ini
+sudo ln -s /etc/php/7.1/mods-available/swoole.ini /etc/php/7.1/fpm/conf.d/20-swoole.ini
+sudo service php7.1-fpm restart
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php7.2-dev
+phpize7.2
+./configure --enable-sockets --with-php-config=/usr/bin/php-config7.2 > /dev/null
+make clean > /dev/null
+make >/dev/null 2>&1
+sudo make install
+sudo bash -c "echo 'extension=swoole.so' > /etc/php/7.2/mods-available/swoole.ini"
+sudo ln -s /etc/php/7.2/mods-available/swoole.ini /etc/php/7.2/cli/conf.d/20-swoole.ini
+sudo ln -s /etc/php/7.2/mods-available/swoole.ini /etc/php/7.2/fpm/conf.d/20-swoole.ini
+sudo service php7.2-fpm restart
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y install php7.3-dev
+phpize7.3
+./configure --enable-sockets --with-php-config=/usr/bin/php-config7.3 > /dev/null
+make clean > /dev/null
+make >/dev/null 2>&1
+sudo make install
+sudo bash -c "echo 'extension=swoole.so' > /etc/php/7.3/mods-available/swoole.ini"
+sudo ln -s /etc/php/7.3/mods-available/swoole.ini /etc/php/7.3/cli/conf.d/20-swoole.ini
+sudo ln -s /etc/php/7.3/mods-available/swoole.ini /etc/php/7.3/fpm/conf.d/20-swoole.ini
+sudo service php7.3-fpm restart


### PR DESCRIPTION
As we have support for Zend Expressive website type here would be nice to add also swoole module to PHP. It can be used with: https://github.com/zendframework/zend-expressive-swoole

[Since v4.4.0](https://github.com/swoole/swoole-src/tree/v4.4.0) it supports only PHP 7.1.
Not sure if there is a point to install previous version to support older PHP versions?

Also would be nice to add [inotify](https://pecl.php.net/package/inotify) support but I don't know how to do it for different PHP versions. It is also used with swoole.

I do have also another problem: SOCK_DGRAM and SOCK_STREAM connections are not working. When I am using that socket type and trying to start server I am getting: `Error: Operation not permitted`. I've tried `sudo`, different ports, params... The thing is that on xenial it works without issues, and on bionic I can't get it working for some reason. Maybe someone here will know why and how to fix it?

Thanks!