### PR TITLE
Dynamically set ngrok webUI IP (fixes share with HyperV)

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -192,7 +192,7 @@ function share() {
         PATH_NGROK="/home/vagrant/.ngrok2"
         PATH_CONFIG="${PATH_NGROK}/ngrok.yml"
 
-        sed -i "/web_addr:/c\web_addr: ${LOCAL_IP}:4040" ${PATH_CONFIG}
+        sed -i "/^web_addr:/c\web_addr: ${LOCAL_IP}:4040" ${PATH_CONFIG}
 
         ngrok http ${@:2} -host-header="$1" 80
     else

--- a/resources/aliases
+++ b/resources/aliases
@@ -188,6 +188,12 @@ function serve-pimcore() {
 function share() {
     if [[ "$1" ]]
     then
+        LOCAL_IP=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
+        PATH_NGROK="/home/vagrant/.ngrok2"
+        PATH_CONFIG="${PATH_NGROK}/ngrok.yml"
+
+        sed -i "/web_addr:/c\web_addr: ${LOCAL_IP}:4040" ${PATH_CONFIG}
+
         ngrok http ${@:2} -host-header="$1" 80
     else
         echo "Error: missing required parameters."


### PR DESCRIPTION
This proposal fixes https://github.com/laravel/homestead/issues/1278

I'm not entirely sure this should be merged as it adds a pretty obscure regex and rewrites a config file on the fly just to fix a limitation of Vagrant with HyperV.

Maybe mentioning the issue in the docs and proposing a fix (manually editing the file to replace the IP or set `web_addr` to false to disable the WebUI altogether) would be enough ?