### PR TITLE
Remove site-specific client_max_body_size

### DIFF
--- a/scripts/site-types/cakephp3.sh
+++ b/scripts/site-types/cakephp3.sh
@@ -74,8 +74,6 @@ server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         try_files \$uri =404;
         include fastcgi_params;

--- a/scripts/site-types/elgg.sh
+++ b/scripts/site-types/elgg.sh
@@ -66,9 +66,6 @@ block="server {
         application/vnd.ms-fontobject
         image/svg+xml;
 
-    # Max post size
-    client_max_body_size 8M;
-
     $rewritesTXT
 
     location ~ /.well-known {

--- a/scripts/site-types/laravel.sh
+++ b/scripts/site-types/laravel.sh
@@ -64,8 +64,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;

--- a/scripts/site-types/modx.sh
+++ b/scripts/site-types/modx.sh
@@ -55,8 +55,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;

--- a/scripts/site-types/spa.sh
+++ b/scripts/site-types/spa.sh
@@ -54,8 +54,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ /\.ht {
         deny all;
     }

--- a/scripts/site-types/statamic.sh
+++ b/scripts/site-types/statamic.sh
@@ -63,8 +63,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;

--- a/scripts/site-types/symfony2.sh
+++ b/scripts/site-types/symfony2.sh
@@ -62,8 +62,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     # DEV
     location ~ ^/(app_dev|app_test|config)\.php(/|\$) {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;

--- a/scripts/site-types/symfony4.sh
+++ b/scripts/site-types/symfony4.sh
@@ -62,8 +62,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     # DEV
     location ~ ^/index\.php(/|\$) {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;

--- a/scripts/site-types/thinkphp.sh
+++ b/scripts/site-types/thinkphp.sh
@@ -67,8 +67,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;

--- a/scripts/site-types/umi.sh
+++ b/scripts/site-types/umi.sh
@@ -120,8 +120,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;

--- a/scripts/site-types/wordpress.sh
+++ b/scripts/site-types/wordpress.sh
@@ -86,8 +86,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ /\.ht {
         deny all;
     }

--- a/scripts/site-types/yii.sh
+++ b/scripts/site-types/yii.sh
@@ -68,8 +68,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;

--- a/scripts/site-types/zf.sh
+++ b/scripts/site-types/zf.sh
@@ -75,8 +75,6 @@ block="server {
 
     sendfile off;
 
-    client_max_body_size 100m;
-
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;


### PR DESCRIPTION
Homestead would provide greater flexibility if this value were simply removed.

Currently, there is no straightforward means by which to override this hard-coded, site-specific value, which causes large file uploads to fail with HTTP status code 413 in NGINX.

If this directive is simply removed, the end-user is able to add a preferred value to e.g. `/home/vagrant/.config/nginx/nginx.conf`, drop an override file in `/etc/nginx/conf.d`, etc.

There seems to be no obvious downside to removing this value.