### PR TITLE
Add more permissive fastcgi_x_timeout options for Symfony 2 DEV

### DIFF
--- a/scripts/site-types/symfony2.sh
+++ b/scripts/site-types/symfony2.sh
@@ -73,6 +73,9 @@ block="server {
         fastcgi_intercept_errors off;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;        
     }
 
     # PROD


### PR DESCRIPTION
Add more permissive fastcgi_x_timeout options for DEV environment  "time to establish connection to upstream", "time after FPM replies accepted until the whole response is transmitted"