### PR TITLE
Don't remove hosts on halt for vagrant-hostsupdater

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if Vagrant.has_plugin?('vagrant-hostsupdater')
+        config.hostsupdater.remove_on_suspend = false
         config.hostsupdater.aliases = settings['sites'].map { |site| site['map'] }
     elsif Vagrant.has_plugin?('vagrant-hostmanager')
         config.hostmanager.enabled = true


### PR DESCRIPTION
**Vagrant-Hostmanager**

Will add/remove hosts with vagrant up and vagrant destroy (https://github.com/devopsgroup-io/vagrant-hostmanager#usage)

**Vagrant-Hostsupdater**

Will add/remove hosts with vagrant up and vagrant halt (https://github.com/cogitatio/vagrant-hostsupdater#keeping-host-entries-after-suspendhalt)

`config.hostsupdater.remove_on_suspend = false`
This disables vagrant-hostsupdater from running on suspend and halt.

I don't want to enable passwordless access to /etc/hosts so this flag is handy for my setup. Usually a password is only required if a site is added or removed. 

Thanks for your work. Homestead is awesome :+1: 

