### PR TITLE
force all non file matches through the Front Controller

### DIFF
--- a/scripts/site-types/laravel.sh
+++ b/scripts/site-types/laravel.sh
@@ -43,14 +43,12 @@ block="server {
     server_name .$1;
     root \"$2\";
 
-    index index.html index.htm index.php;
-
     charset utf-8;
 
     $rewritesTXT
 
     location / {
-        try_files \$uri \$uri/ /index.php?\$query_string;
+        try_files \$uri /index.php?\$query_string;
         $headersTXT
     }
 
@@ -64,7 +62,7 @@ block="server {
 
     sendfile off;
 
-    location ~ \.php$ {
+    location = /index.php {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;


### PR DESCRIPTION
ok, bear with me on this one...

### Problems

##### Problem 1

Some legacy systems used routes that ended in `.php`. In a standard Laravel app and Nginx setup, routes that end in `.php` **do not work**.

```php
Route::get('contact.php', 'ContactController@create');
```

If you try to access www.example.com/contact.php, you will get back a "No input file specified." message.

##### Problem 2

If you visit a URL that matches a directory in the public directory, you will get back a "403 Forbidden" error.

### Desired Behavior

Ideally, all URLs that are not direct file matches (images, JS, css, etc...) will be passed to the front controller (`/index.php`) for handling by the framework.

### Solution

So let's talk about the changes in this PR in steps, starting actually from the bottom.  We will assume we are trying to match the URL https://www.example.com/test.php

---

Nginx's handling of which location block to serve is actually a little confusing, so if you're looking for a great explanation, check out [this article on Digital Ocean](https://www.digitalocean.com/community/tutorials/understanding-nginx-server-and-location-block-selection-algorithms). The thing that concerns us right now is, even though `/test.php` matches the first prefix location block, it *also* matches the regex location block, and Nginx givess authority to that regex block and executes there. If the `test.php` file actually exists on the server it will be run through the PHP interpreter, but if it doesn't, we'll get our "No input file specified." message.

Switching to an **exact match** location block of

```
location = /index.php {
```

means the PHP interpreter will **only** run on that 1 specific file.

Now when we visit www.example.com/test.php, it will actually serve through our Front Controller! 😄 

And added benefit, Nginx exact matches are faster than regex matches (still looking for data to back this up, other than it just being stated in the docs).

---

Next, let's say we have a folder in our public directory called `/images`.  Currently if I try to access it I get a 403 error. 

By removing the `$uri/` in the `try_files` directive, we will no longer match that directory, and it will be allowed to fall through to the front controller.

Now that we no longer care about directories, we no longer need to set default index files for them to look up.

### Potential Issues

The one thing we **lose** with this PR is the ability to execute PHP files in the public directory directly.  I would argue that's a good thing, since everything should go through the framework.

However, if someone makes a file at `public/test.php` and we try to access it at www.example.com/test.php, now since we are not running it through the PHP interpreter, it will be downloaded as a generic file, thus exposing the source code of that file.  Not great, but I would say the ***only*** PHP file in your public directory should be `index.php`.

This *could* be negated by adding a regex location block **after** our exact match to catch any `.php` files that actually exist.