### PR TITLE
Databases erase prevention setting

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -20,6 +20,8 @@ sites:
 databases:
     - homestead
 
+backup: true
+
 features:
     - mariadb: false
     - ohmyzsh: false


### PR DESCRIPTION
Updates Homestead.yaml.example to include as a default setting the "backup: true". This will prevent databases from being deleted on "vagrant destroy", especially for users that are not familiar with the destroy process and its consequences.
Homestead updates require the "vagrant destroy" to update the machine and many users aren't aware that they will end up losing the databases. For experienced users, it's just a matter of configuring the Homestead.yaml file and set it to false or remove the entry.