### PR TITLE
use `--filter` when calling Dusk

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -36,7 +36,7 @@ function dusk() {
         Xvfb :0 -screen 0 1280x960x24 &
     fi
 
-    php artisan dusk "$@"
+    php artisan dusk --filter "$@"
 }
 
 function php56() {

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -24,7 +24,7 @@ function dusk() {
         Xvfb :0 -screen 0 1280x960x24 &
     fi
 
-    php artisan dusk "$@"
+    php artisan dusk --filter "$@"
 }
 
 function php56() {


### PR DESCRIPTION
with the way it's currently written:

```sh
php artisan dusk "$@"
```

you need to pass the full pass to the test for it to execute correctly.  By using `--filter`, you can simply pass the class name, a specific method name, or any other identifier that PHPUnit `--filter` accepts.