### PR TITLE
FIX: features' versions are not properly parsed to bash scripts

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -243,7 +243,7 @@ class Homestead
         config.vm.provision "shell" do |s|
           s.name = "Installing " + feature_name
           s.path = feature_path
-          s.env = feature_variables
+          s.env = feature
         end
       end
     end


### PR DESCRIPTION
Hello

I've noticed this bug today. Here's the fix. The example below now work as intended :
```yml
features:
  - elasticsearch: true
    version: 7
  - gearman: true
```
