### PR TITLE
Add generated ca to local cert storage

### DIFF
--- a/scripts/create-certificate.sh
+++ b/scripts/create-certificate.sh
@@ -87,6 +87,10 @@ then
         -key "$PATH_ROOT_KEY" \
         -x509 -new -extensions v3_ca -days 3650 -sha256 \
         -out "$PATH_ROOT_CRT" 2>/dev/null
+        
+        # Symlink ca to local certificate storage and run update command
+        ln --force --symbolic $PATH_ROOT_CRT /usr/local/share/ca-certificates/
+        update-ca-certificates
 fi
 
 # Only generate a certificate if there isn't one already there.


### PR DESCRIPTION
Tried to connect from service a to service b on the same homestead box but the connection was refused due a self signed certificate. 

This patch will symlink the new ca to local certificate storage and execute the update script. Full disclosure: Tested it once :see_no_evil: 