### PR TITLE
Add "mac" networks option

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -33,7 +33,7 @@ class Homestead
     # Configure Additional Networks
     if settings.has_key?('networks')
       settings['networks'].each do |network|
-        config.vm.network network['type'], ip: network['ip'], bridge: network['bridge'] ||= nil, netmask: network['netmask'] ||= '255.255.255.0'
+        config.vm.network network['type'], ip: network['ip'], mac: network['mac'], bridge: network['bridge'] ||= nil, netmask: network['netmask'] ||= '255.255.255.0'
       end
     end
 


### PR DESCRIPTION
Allows setting the MAC Address of an interface (e.g. bridge). This enables setting a fixed MAC. which in turn can be used by a DHCP (in the LAN) to provide an ip. For example:

networks:
    - type: "public_network"
      bridge: "Intel(R) Ethernet Connection (2) I218-V"
      mac: "080027905b10"