### PR TITLE
Update mongo-php-driver from 1.5.2 to 1.6.1 on mongodb.sh

### DIFF
--- a/scripts/features/mongodb.sh
+++ b/scripts/features/mongodb.sh
@@ -25,7 +25,7 @@ sudo systemctl enable mongod
 sudo systemctl start mongod
 
 sudo rm -rf /tmp/mongo-php-driver /usr/src/mongo-php-driver
-git clone -c advice.detachedHead=false -q -b '1.5.2' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
+git clone -c advice.detachedHead=false -q -b '1.6.1' --single-branch https://github.com/mongodb/mongo-php-driver.git /tmp/mongo-php-driver
 sudo mv /tmp/mongo-php-driver /usr/src/mongo-php-driver
 cd /usr/src/mongo-php-driver
 git submodule -q update --init


### PR DESCRIPTION
[1.6.1 was released on Dec 5, 2019](https://github.com/mongodb/mongo-php-driver/releases/tag/1.6.1)

1.5.2 was released on Aug 1, 2018