### PR TITLE
Feature - Allow after `vagrant up` scripts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ confDir = $confDir ||= File.expand_path(File.dirname(__FILE__))
 homesteadYamlPath = confDir + "/Homestead.yaml"
 homesteadJsonPath = confDir + "/Homestead.json"
 afterScriptPath = confDir + "/after.sh"
+afterUpScriptPath = confDir + "/after-up.sh"
 customizationScriptPath = confDir + "/user-customizations.sh"
 aliasesPath = confDir + "/aliases"
 
@@ -42,6 +43,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if File.exist? customizationScriptPath then
         config.vm.provision "shell", path: customizationScriptPath, privileged: false, keep_color: true
     end
+
+    if File.exist? afterUpScriptPath then
+        config.trigger.after :up do |trigger|
+            trigger.info = "Running scripts after Vagrant has started"
+            trigger.run_remote = {path: afterUpScriptPath, privileged: false, keep_color: true}
+        end
+    else
 
     if Vagrant.has_plugin?('vagrant-hostsupdater')
         config.hostsupdater.remove_on_suspend = false

--- a/init.bat
+++ b/init.bat
@@ -8,6 +8,7 @@ if ["%~1"]==[""] (
 )
 
 copy /-y resources\after.sh after.sh
+copy /-y resources\after-up.sh after-up.sh
 copy /-y resources\aliases aliases
 
 echo Homestead initialized!

--- a/init.sh
+++ b/init.sh
@@ -7,6 +7,7 @@ else
 fi
 
 cp -i resources/after.sh after.sh
+cp -i resources/after-up.sh after-up.sh
 cp -i resources/aliases aliases
 
 echo "Homestead initialized!"

--- a/resources/after-up.sh
+++ b/resources/after-up.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# If you would like to do some extra work on startup you may
+# add any commands you wish to this file and they will
+# be run after the Vagrant Up command is run.

--- a/src/MakeCommand.php
+++ b/src/MakeCommand.php
@@ -53,6 +53,7 @@ class MakeCommand extends Command
             ->addOption('hostname', null, InputOption::VALUE_OPTIONAL, 'The hostname of the virtual machine.', $this->defaultProjectName)
             ->addOption('ip', null, InputOption::VALUE_OPTIONAL, 'The IP address of the virtual machine.')
             ->addOption('no-after', null, InputOption::VALUE_NONE, 'Determines if the after.sh file is not created.')
+            ->addOption('no-after-up', null, InputOption::VALUE_NONE, 'Determines if the after-up.sh file is not created.')
             ->addOption('no-aliases', null, InputOption::VALUE_NONE, 'Determines if the aliases file is not created.')
             ->addOption('example', null, InputOption::VALUE_NONE, 'Determines if a Homestead example file is created.')
             ->addOption('json', null, InputOption::VALUE_NONE, 'Determines if the Homestead settings file will be in json format.');
@@ -77,6 +78,10 @@ class MakeCommand extends Command
 
         if (! $input->getOption('no-after') && ! $this->afterShellScriptExists()) {
             $this->createAfterShellScript();
+        }
+
+        if (! $input->getOption('no-after-up') && ! $this->afterUpShellScriptExists()) {
+            $this->createAfterUpShellScript();
         }
 
         $format = $input->getOption('json') ? 'json' : 'yaml';
@@ -165,6 +170,16 @@ class MakeCommand extends Command
     }
 
     /**
+     * Determine if the after-up shell script exists.
+     *
+     * @return bool
+     */
+    protected function afterUpShellScriptExists()
+    {
+        return file_exists("{$this->basePath}/after-up.sh");
+    }
+
+    /**
      * Create the after shell script.
      *
      * @return void
@@ -172,6 +187,16 @@ class MakeCommand extends Command
     protected function createAfterShellScript()
     {
         copy(__DIR__.'/../resources/after.sh', "{$this->basePath}/after.sh");
+    }
+
+    /**
+     * Create the after-up shell script.
+     *
+     * @return void
+     */
+    protected function createAfterUpShellScript()
+    {
+        copy(__DIR__.'/../resources/after-up.sh', "{$this->basePath}/after-up.sh");
     }
 
     /**

--- a/tests/InitScriptTest.php
+++ b/tests/InitScriptTest.php
@@ -53,6 +53,14 @@ class InitScriptTest extends TestCase
     }
 
     /** @test */
+    public function it_creates_an_after_up_shell_script()
+    {
+        exec('bash init.sh');
+
+        $this->assertFileExists(self::$testDirectory.'/after-up.sh');
+    }
+
+    /** @test */
     public function it_creates_an_aliases_file()
     {
         exec('bash init.sh');

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -174,6 +174,52 @@ class MakeCommandTest extends TestCase
         $this->assertFileNotExists(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh');
     }
 
+        /** @test */
+    public function an_after_up_shell_script_is_created_by_default()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'after-up.sh');
+
+        $this->assertFileEquals(
+            __DIR__.'/../resources/after-up.sh',
+            self::$testDirectory.DIRECTORY_SEPARATOR.'after-up.sh'
+        );
+    }
+
+    /** @test */
+    public function an_existing_after_up_shell_script_is_not_overwritten()
+    {
+        file_put_contents(
+            self::$testDirectory.DIRECTORY_SEPARATOR.'after-up.sh',
+            'Already existing after-up.sh'
+        );
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([]);
+
+        $this->assertFileExists(self::$testDirectory.DIRECTORY_SEPARATOR.'after-up.sh');
+
+        $this->assertStringEqualsFile(
+            self::$testDirectory.DIRECTORY_SEPARATOR.'after-up.sh',
+            'Already existing after-up.sh'
+        );
+    }
+
+    /** @test */
+    public function an_after_up_file_is_not_created_if_it_is_explicitly_told_to()
+    {
+        $tester = new CommandTester(new MakeCommand());
+
+        $tester->execute([
+            '--no-after-up' => true,
+        ]);
+
+        $this->assertFileNotExists(self::$testDirectory.DIRECTORY_SEPARATOR.'after-up.sh');
+    }
+
     /** @test */
     public function an_example_homestead_yaml_settings_is_created_if_requested()
     {

--- a/tests/MakeCommandTest.php
+++ b/tests/MakeCommandTest.php
@@ -174,7 +174,7 @@ class MakeCommandTest extends TestCase
         $this->assertFileNotExists(self::$testDirectory.DIRECTORY_SEPARATOR.'after.sh');
     }
 
-        /** @test */
+    /** @test */
     public function an_after_up_shell_script_is_created_by_default()
     {
         $tester = new CommandTester(new MakeCommand());


### PR DESCRIPTION
After `vagrant up` is run, trigger the after-up.sh script to execute on the homestead box.

This is related to #1401.

There are times that I have needed to run scripts every time that I start homestead. 
For my exact use case:

- I re-run npm build scripts
- clear out some logs
- start an os level package
- ensure that apache is running (instead of nginx)

By adding this functionality to an `after-up.sh` script and modifying the `Vagrantfile` I was able to accomplish this pretty easily. I thought maybe it would be useful to others.

I can also see it being a niche feature though, so if it was treated like `user-customizations.sh` or closed altogether I would understand.

Thanks for all of your hard work on this project! 