### PR TITLE
Bugfix: Database backups assumes existing `databases` setting.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -550,7 +550,7 @@ class Homestead
       s.inline = 'sudo service motd-news restart'
     end
 
-    if settings.has_key?('backup') && settings['backup'] && (Vagrant::VERSION >= '2.1.0' || Vagrant.has_plugin?('vagrant-triggers'))
+    if settings.has_key?('databases') && settings.has_key?('backup') && settings['backup'] && (Vagrant::VERSION >= '2.1.0' || Vagrant.has_plugin?('vagrant-triggers'))
       dir_prefix = '/vagrant/'
       settings['databases'].each do |database|
         Homestead.backup_mysql(database, "#{dir_prefix}/mysql_backup", config)


### PR DESCRIPTION
Database backups assumes `settings['databases']` to be non empty.

An error is triggered when `settings['databases']` is empty and `backup`
setting is enabled.