### PR TITLE
Fix Elasticsearch installation script

### DIFF
--- a/scripts/features/elasticsearch.sh
+++ b/scripts/features/elasticsearch.sh
@@ -36,7 +36,7 @@ echo "deb https://artifacts.elastic.co/packages/$majorVersion.x/apt stable main"
 
 sudo apt-get update
 sudo apt-get -y install openjdk-11-jre
-sudo apt-get -y install elasticsearch"$installVersion"
+sudo apt-get -y install elasticsearch
 
 # Start Elasticsearch on boot
 


### PR DESCRIPTION
The Elasticsearch installation script has been broken for a few months. It seems that Elastic changed how they named their packages, and they no longer have the versions in them.