### PR TITLE
fixing pimcore

### DIFF
--- a/scripts/site-types/pimcore.sh
+++ b/scripts/site-types/pimcore.sh
@@ -46,10 +46,6 @@ block="# mime types are covered in nginx.conf by:
 #   include       mime.types;
 # }
 
-upstream php-pimcore5-$1 {
-    server unix:/var/run/php/php$5-fpm.sock;
-}
-
 server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -75,7 +71,7 @@ server {
         return 404;
     }
     # b) Prevent clients from accessing hidden files (starting with a dot)
-    # Access to `/.well-known/` is allowed.
+    # Access to /.well-known/ is allowed.
     # https://www.mnot.net/blog/2010/04/07/well-known
     # https://tools.ietf.org/html/rfc5785
     location ~* /\.(?!well-known/) {
@@ -151,7 +147,7 @@ server {
         # fastcgi_param SCRIPT_FILENAME \$realpath_root\$fastcgi_script_name;
         # fastcgi_param DOCUMENT_ROOT \$realpath_root;
 
-        fastcgi_pass php-pimcore5-$1;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         # Prevents URIs that include the front controller. This will 404:
         # http://domain.tld/app.php/some-path
         # Remove the internal directive to allow URIs like this
@@ -166,10 +162,10 @@ server {
             allow 127.0.0.1;
             # add additional IP's or Ranges
             deny all;
-            fastcgi_pass php-pimcore5-$1;
+            fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         }
         location /fpm-ping {
-            fastcgi_pass php-pimcore5-$1;
+            fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         }
     }
     # nginx Status


### PR DESCRIPTION
Remove backticks - On "vagrant provision" the backticks will be interpreted
Remove upstream - To allow multiple pimcore sites