### PR TITLE
pimcore: escape backticks in string

### DIFF
--- a/scripts/site-types/pimcore.sh
+++ b/scripts/site-types/pimcore.sh
@@ -75,7 +75,7 @@ server {
         return 404;
     }
     # b) Prevent clients from accessing hidden files (starting with a dot)
-    # Access to `/.well-known/` is allowed.
+    # Access to \`/.well-known/\` is allowed.
     # https://www.mnot.net/blog/2010/04/07/well-known
     # https://tools.ietf.org/html/rfc5785
     location ~* /\.(?!well-known/) {


### PR DESCRIPTION
fixes the following issue that occurs when running `serve-pimcore`:

```sh
serve-pimcore pimcore-demo.test /home/vagrant/projects/misc/pimcore-demo/web
/vagrant/scripts/site-types/pimcore.sh: line 187: /.well-known/: No such file or directory
```
---

**edit**
Apologies, I just noticed that this is a partial duplicate of #1449. I am leaving this PR open since this change keeps the backticks as in the [Pimcore Nginx config file](https://pimcore.com/docs/6.x/Development_Documentation/Installation_and_Upgrade/System_Setup_and_Hosting/Nginx_Configuration.html) instead of removing them, but feel free to close this if you go with #1449.