### PR TITLE
Bugfix: Unable to locate package python-django.

### DIFF
--- a/scripts/features/python.sh
+++ b/scripts/features/python.sh
@@ -13,7 +13,7 @@ chown -Rf vagrant:vagrant /home/vagrant/.homestead-features
 
 # Install Python
 apt-get update
-apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python3-venv python-django
+apt-get install -y python3-pip build-essential libssl-dev libffi-dev python3-dev python3-venv python3-django
 sudo -H -u vagrant bash -c 'pip3 install django'
 sudo -H -u vagrant bash -c 'pip3 install numpy'
 sudo -H -u vagrant bash -c 'pip3 install masonite'


### PR DESCRIPTION
Correct bug that prevents installing python feature dependencies due to
`python-django` package being renamed to `python3-django`.

```
homestead: E: Unable to locate package python-django
```