### PR TITLE
Added "https" type to force https when needed

### DIFF
--- a/scripts/site-types/https.sh
+++ b/scripts/site-types/https.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+declare -A params=$6       # Create an associative array
+declare -A headers=${9}    # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
+paramsTXT=""
+if [ -n "$6" ]; then
+   for element in "${!params[@]}"
+   do
+      paramsTXT="${paramsTXT}
+      fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "${9}" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
+fi
+
+if [ "$7" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
+block="server {
+    listen 80;
+    listen [::]:80;
+
+    server_name .$1;
+
+    return 301 https://$1$request_uri;
+}
+server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name .$1;
+    root \"$2\";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    $rewritesTXT
+
+    location / {
+        try_files \$uri \$uri/ /index.php?\$query_string;
+        $headersTXT
+    }
+
+    $configureXhgui
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/$1-error.log error;
+
+    sendfile off;
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        $paramsTXT
+
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    ssl_certificate     /etc/nginx/ssl/$1.crt;
+    ssl_certificate_key /etc/nginx/ssl/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"


### PR DESCRIPTION
In some usecases it is necessary to force a project to open in **https** rather than **http**. (like **phpMyAdmin**).   

So with this type we can force a site to redirect to https (port 443) mode when opened with http (port 80).

![Annotation 2020-08-03 173402](https://user-images.githubusercontent.com/30769988/89185614-c3408500-d5af-11ea-89fc-9ab9021d0794.png)

Example:

```yaml
sites:
    - map: homestead.test
      to: /home/vagrant/homestead/public
      type: "https"
```