### PR TITLE
Feature: Add EventStore script

### DIFF
--- a/scripts/features/eventstore.sh
+++ b/scripts/features/eventstore.sh
@@ -21,13 +21,13 @@ else
 fi
 
 # Install repository
-curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | sudo bash
+curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | bash
 
 # Install EventStore package
-sudo apt-get install -y eventstore-oss"$installVersion"
+apt-get install -y eventstore-oss"$installVersion"
 
 # Update configuration
-sudo sed -i "s/RunProjections: None/RunProjections: ${run_projections:-All}/" /etc/eventstore/eventstore.conf
+sed -i "s/RunProjections: None/RunProjections: ${run_projections:-All}/" /etc/eventstore/eventstore.conf
 
 configuration="
 extIp: ${external_ip:-0.0.0.0}
@@ -35,11 +35,11 @@ extTcpPort: ${external_tcp_port:-2112}
 extHttpPort: ${external_http_port:-2113}
 AdminOnExt: ${admin_on_ext:-true}
 "
-sudo echo "$configuration" >> /etc/eventstore/eventstore.conf
+echo "$configuration" >> /etc/eventstore/eventstore.conf
 
 # Allow the Event Store executable to bind to a port lower than 1024
-sudo setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/eventstored
+setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/eventstored
 
 # Enable and Start EventStore
-sudo systemctl enable eventstore.service
-sudo systemctl start eventstore.service
+systemctl enable eventstore.service
+systemctl start eventstore.service

--- a/scripts/features/eventstore.sh
+++ b/scripts/features/eventstore.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Check if EventStore has been installed
+if [ -f /home/vagrant/.homestead-features/eventstore ]
+then
+    echo "EventStore already installed."
+    exit 0
+fi
+
+touch /home/vagrant/.homestead-features/eventstore
+chown -Rf vagrant:vagrant /home/vagrant/.homestead-features
+
+# Determine wanted version from config
+set -- "$1"
+IFS=".";
+
+if [ -z "${version}" ]; then
+    installVersion="" # by not specifying we'll install latest
+else
+    installVersion="=${version}"
+fi
+
+# Install repository
+curl -s https://packagecloud.io/install/repositories/EventStore/EventStore-OSS/script.deb.sh | sudo bash
+
+# Install EventStore package
+sudo apt-get install -y eventstore-oss"$installVersion"
+
+# Update configuration
+sudo sed -i "s/RunProjections: None/RunProjections: ${run_projections:-All}/" /etc/eventstore/eventstore.conf
+
+configuration="
+extIp: ${external_ip:-0.0.0.0}
+extTcpPort: ${external_tcp_port:-2112}
+extHttpPort: ${external_http_port:-2113}
+AdminOnExt: ${admin_on_ext:-true}
+"
+sudo echo "$configuration" >> /etc/eventstore/eventstore.conf
+
+# Allow the Event Store executable to bind to a port lower than 1024
+sudo setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/eventstored
+
+# Enable and Start EventStore
+sudo systemctl enable eventstore.service
+sudo systemctl start eventstore.service


### PR DESCRIPTION
This script will install and configure EventStore using official documentation https://eventstore.com/docs/getting-started/index.html
There is some options you can add on the Homestead.yaml file

```yaml
#...
features:
    - mariadb: false
    - ohmyzsh: false
    - webdriver: false
    - eventstore:
        version: 5.0.8-1
        run_projections: All
        external_ip: 0.0.0.0
        external_tcp_port: 1113
        external_http_port: 2113
        admin_on_ext: true

ports: # Needed if you want to expose the service on the external IP
     - send: 1113
       to: 1113
     - send: 2113
       to: 2113
#...
```

Then you can access it from http://{VM IP or FQDN}:2113 with the default username and password (`admin` / `changeit`)