### PR TITLE
Installed and disable mailhog by default

### DIFF
--- a/bin/wsl-init
+++ b/bin/wsl-init
@@ -507,21 +507,21 @@ service redis-server start
 wget --quiet -O /usr/local/bin/mailhog https://github.com/mailhog/MailHog/releases/download/v0.2.1/MailHog_linux_amd64
 chmod +x /usr/local/bin/mailhog
 
-#sudo tee /etc/systemd/system/mailhog.service <<EOL
-#[Unit]
-#Description=Mailhog
-#After=network.target
-#
-#[Service]
-#User=$WSL_USER_NAME
-#ExecStart=/usr/bin/env /usr/local/bin/mailhog > /dev/null 2>&1 &
-#
-#[Install]
-#WantedBy=multi-user.target
-#EOL
-#
-#systemctl daemon-reload
-#systemctl enable mailhog
+sudo tee /etc/systemd/system/mailhog.service <<EOL
+[Unit]
+Description=Mailhog
+After=network.target
+
+[Service]
+User=$WSL_USER_NAME
+ExecStart=/usr/bin/env /usr/local/bin/mailhog > /dev/null 2>&1 &
+
+[Install]
+WantedBy=multi-user.target
+EOL
+
+systemctl daemon-reload
+systemctl disable mailhog
 
 ## Configure Supervisor
 #systemctl enable supervisor.service


### PR DESCRIPTION
Installed and disable mailhog by default. (we should add `Enable / Disable Services` support to wsl2)