### PR TITLE
Updated wslapplyfeatures to use feature variables.

### DIFF
--- a/src/WslApplyFeatures.php
+++ b/src/WslApplyFeatures.php
@@ -80,7 +80,7 @@ class WslApplyFeatures extends Command
 
             if ($feature_variables !== false) {
                 $feature_path = "{$this->featuresPath}/{$feature_name}.sh > ~/.homestead-features/{$feature_name}.log";
-                # Prepare the feature variables if provided.
+                // Prepare the feature variables if provided.
                 if (is_array($feature_variables)) {
                     $variables = join(' ', $feature_variables);
                     $feature_cmd = "sudo -E bash {$feature_path} {$variables}";

--- a/src/WslApplyFeatures.php
+++ b/src/WslApplyFeatures.php
@@ -80,7 +80,13 @@ class WslApplyFeatures extends Command
 
             if ($feature_variables !== false) {
                 $feature_path = "{$this->featuresPath}/{$feature_name}.sh > ~/.homestead-features/{$feature_name}.log";
-                $feature_cmd = "sudo -E bash {$feature_path}";
+                # Prepare the feature variables if provided.
+                if (is_array($feature_variables)) {
+                    $variables = join(' ', $feature_variables);
+                    $feature_cmd = "sudo -E bash {$feature_path} {$variables}";
+                } else {
+                    $feature_cmd = "sudo -E bash {$feature_path}";
+                }
                 shell_exec($feature_cmd);
                 $output->writeln("Command output can be found via: sudo cat ~/.homestead-features/{$feature_name}.log");
             }


### PR DESCRIPTION
example: (this will pass the server_id as variables/args)
features:
    - blackfire:
        server_id: "server_id"
        server_token: "server_value"
        client_id: "client_id"
        client_token: "client_value"
    - cassandra: true