### PR TITLE
Added function to extend scripts and site types

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         abort "Homestead settings file not found in #{confDir}"
     end
 
-    Homestead.configure(config, settings)
+    Homestead.configure(config, settings, "")
 
     if File.exist? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true

--- a/resources/localized/Vagrantfile
+++ b/resources/localized/Vagrantfile
@@ -12,6 +12,7 @@ homesteadJsonPath = File.expand_path("Homestead.json", File.dirname(__FILE__))
 afterScriptPath = "after.sh"
 customizationScriptPath = "user-customizations.sh"
 aliasesPath = "aliases"
+userScriptPath = File.dirname(__FILE__) + "/homestead/scripts"
 
 require File.expand_path(confDir + '/scripts/homestead.rb')
 
@@ -33,7 +34,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         abort "Homestead settings file not found in " + File.dirname(__FILE__)
     end
 
-    Homestead.configure(config, settings)
+    Homestead.configure(config, settings, userScriptPath)
 
     if File.exist? afterScriptPath then
         config.vm.provision "shell", path: afterScriptPath, privileged: false, keep_color: true


### PR DESCRIPTION
I added the option to overwrite scripts (and especially add site types) when using Homestead on a per project basis.

Because I want to use Homestead on a ProcessWire project and I would like to use it with composer not globally but only on this project I searched for a way to include a new site type "ProcessWire" but couldn't find any other than forking the git and add it then. But I also don't want to maintaine a full fork and keep it up to date I had the idea to enable a user script dir.

The directory will be in a folder called "homestead" which lies beneath the homestead.yaml. So for example to add a new site type you just create a file "homestead/scripts/site-types/processwire.sh"

You could also use this feature to overwrite some settings by other scripts/site-types