### PR TITLE
Fix Magento site type "upstream sent too big header while reading res…

### DIFF
--- a/scripts/site-types/magento.sh
+++ b/scripts/site-types/magento.sh
@@ -144,7 +144,8 @@ block="server {
     location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
         try_files \$uri =404;
         fastcgi_pass   unix:/var/run/php/php$5-fpm.sock;
-        fastcgi_buffers 1024 4k;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
 
         fastcgi_param  PHP_FLAG  \"session.auto_start=off \n suhosin.session.cryptua=off\";
         fastcgi_param  PHP_VALUE \"memory_limit=756M \n max_execution_time=18000\";


### PR DESCRIPTION
…ponse header from upstream" error

Raise `fastcgi_buffer_size` as official Magento Nginx sample recent change (https://github.com/magento/magento2/blame/2.4-develop/nginx.conf.sample#L185) to allow PHP process larger request.