### PR TITLE
Add MySQL as a default feature

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -24,11 +24,14 @@
     ],
     "features": [
         {
+            "mysql": true
+        },
+        {
             "mariadb": false
-        }, 
+        },
         {
             "ohmyzsh": false
-        }, 
+        },
         {
             "webdriver": false
         }

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -21,6 +21,7 @@ databases:
     - homestead
 
 features:
+    - mysql: false
     - mariadb: false
     - ohmyzsh: false
     - webdriver: false


### PR DESCRIPTION
Since commit 7ef844020750deb012d3596b9b0a9aa97b896977 the MySQL databases are no longer being created by default. This is an undocumented change, and can be quite confusing, considering MySQL has always been enabled by default in Laravel Homestead.

I have enabled the MySQL feature by default in the Homestead.yaml/json configuration files. This still allows for MySQL to be disabled if desired, without being confusing and forgoing sensible defaults.