### PR TITLE
Create Mysql8 Databases if Mysql8 feature enabled

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -534,7 +534,7 @@ class Homestead
       end
 
       settings['databases'].each do |db|
-        if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mariadb')
+        if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mysql8') || (enabled_databases.include? 'mariadb')
           config.vm.provision 'shell' do |s|
             s.name = 'Creating MySQL / MariaDB Database: ' + db
             s.path = script_dir + '/create-mysql.sh'


### PR DESCRIPTION
Generating databases on up/provision when using mysql 8 is broken. This fixes that :)