### PR TITLE
add PostgreSQL as a default feature

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -30,6 +30,9 @@
             "mariadb": false
         },
         {
+            "postgresql": false
+        },
+        {
             "ohmyzsh": false
         },
         {

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -23,6 +23,7 @@ databases:
 features:
     - mysql: false
     - mariadb: false
+    - postgresql: false
     - ohmyzsh: false
     - webdriver: false
 


### PR DESCRIPTION
Similar to the PR for MySQL here: https://github.com/laravel/homestead/pull/1527 , this change adds the option to enable PostgreSQL in the features array in the Homestead.yaml file.