### PR TITLE
Add function to switch to PHP 8.0

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -80,6 +80,12 @@ function php74() {
     sudo update-alternatives --set phpize /usr/bin/phpize7.4
 }
 
+function php80() {
+    sudo update-alternatives --set php /usr/bin/php8.0
+    sudo update-alternatives --set php-config /usr/bin/php-config8.0
+    sudo update-alternatives --set phpize /usr/bin/phpize8.0
+}
+
 function serve-apache() {
     if [[ "$1" && "$2" ]]
     then

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -63,6 +63,12 @@ function php74() {
     sudo update-alternatives --set phpize /usr/bin/phpize7.4
 }
 
+function php80() {
+    sudo update-alternatives --set php /usr/bin/php8.0
+    sudo update-alternatives --set php-config /usr/bin/php-config8.0
+    sudo update-alternatives --set phpize /usr/bin/phpize8.0
+}
+
 function serve-apache() {
     if [[ "$1" && "$2" ]]
     then


### PR DESCRIPTION
I added the function to switch to PHP 8.0, just like there are the functions for PHP 7.x.

One thing I noticed: the `/usr/bin/phpize` and `/usr/bin/php-config` version-specific binaries don't seem to be installed anymore. Is this normal? If so, we should probably update the aliases.