### PR TITLE
Add Elasticsearch repositories only once to sources.list

### DIFF
--- a/scripts/features/elasticsearch.sh
+++ b/scripts/features/elasticsearch.sh
@@ -32,7 +32,10 @@ echo "Elasticsearch majorVersion: $majorVersion"
 # Install Java & Elasticsearch
 
 wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-echo "deb https://artifacts.elastic.co/packages/$majorVersion.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-$majorVersion.x.list
+
+if [ ! -f /etc/apt/sources.list.d/elastic-$majorVersion.x.list ]; then
+    echo "deb https://artifacts.elastic.co/packages/$majorVersion.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-$majorVersion.x.list
+fi
 
 sudo apt-get update
 sudo apt-get -y install openjdk-11-jre


### PR DESCRIPTION
Make sure repositories are only added once to the `sources.list`, e.g. when re-provisioning your virtual machine. Otherwise, you get a bunch of warnings like this during provisioning:
```
homestead: W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/elastic-5.x.list:1 and /etc/apt/sources.list.d/elastic-5.x.list:2
```