### PR TITLE
Updating magento template to support params

### DIFF
--- a/scripts/site-types/magento.sh
+++ b/scripts/site-types/magento.sh
@@ -1,3 +1,14 @@
+declare -A params=$6       # Create an associative array
+
+paramsTXT=""
+if [ -n "$6" ]; then
+   for element in "${!params[@]}"
+   do
+      paramsTXT="${paramsTXT}
+      fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
@@ -26,6 +37,7 @@ block="server {
 
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
+            $paramsTXT
             include        fastcgi_params;
         }
 
@@ -48,6 +60,7 @@ block="server {
             fastcgi_index  index.php;
             fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
             fastcgi_param  PATH_INFO        \$fastcgi_path_info;
+            $paramsTXT
             include        fastcgi_params;
         }
 
@@ -154,6 +167,7 @@ block="server {
 
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
+        $paramsTXT
         include        fastcgi_params;
     }
 


### PR DESCRIPTION
MAGE_RUN_CODE and MAGE_RUN_TYPE fastcgi params are required for multi domain magento installations. This adds support for them