### PR TITLE
Add php version to cron schedule

### DIFF
--- a/scripts/cron-schedule.sh
+++ b/scripts/cron-schedule.sh
@@ -6,7 +6,8 @@ fi
 
 SITE_DOMAIN=$1
 SITE_PUBLIC_DIRECTORY=$2
+SITE_PHP_VERSION=$3
 
-cron="* * * * * vagrant  . /home/vagrant/.profile; /usr/bin/php $SITE_PUBLIC_DIRECTORY/../artisan schedule:run >> /dev/null 2>&1"
+cron="* * * * * vagrant  . /home/vagrant/.profile; /usr/bin/php$SITE_PHP_VERSION $SITE_PUBLIC_DIRECTORY/../artisan schedule:run >> /dev/null 2>&1"
 
 echo "$cron" > "/etc/cron.d/$SITE_DOMAIN"

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -440,7 +440,7 @@ class Homestead
 
             if site['schedule']
               s.path = script_dir + '/cron-schedule.sh'
-              s.args = [site['map'].tr('^A-Za-z0-9', ''), site['to']]
+              s.args = [site['map'].tr('^A-Za-z0-9', ''), site['to'], site['php'] ||= '']
             else
               s.inline = "rm -f /etc/cron.d/$1"
               s.args = [site['map'].tr('^A-Za-z0-9', '')]


### PR DESCRIPTION
Hello Joe!

I came across an issue where I have multiple sites running on the same box with different php versions. The cron schedule was always using the current php version of the CLI, which causes issues when a site has a different version configured.

This update appends the php version to the cron command if it is set.