### PR TITLE
Added query logging for MariaDB

### DIFF
--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -51,8 +51,8 @@ cat > /etc/mysql/mariadb.conf.d/50-server.cnf << EOF
 [mysqld]
 bind-address = 0.0.0.0
 ignore-db-dir = lost+found
-general_log
-general_log_file=/var/log/mysql/mariadb.log
+#general_log
+#general_log_file=/var/log/mysql/mariadb.log
 EOF
 
 export MYSQL_PWD=secret

--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -51,6 +51,8 @@ cat > /etc/mysql/mariadb.conf.d/50-server.cnf << EOF
 [mysqld]
 bind-address = 0.0.0.0
 ignore-db-dir = lost+found
+general_log
+general_log_file=/var/log/mysql/mariadb.log
 EOF
 
 export MYSQL_PWD=secret


### PR DESCRIPTION
Since Homestead is aimed for development, query logging can be of great help when trying to debug queries, especially complex queries made through ORM. The proposed changes will enable query logging on MariaDB by default

[https://mariadb.com/kb/en/general-query-log/](https://mariadb.com/kb/en/general-query-log/)