### PR TITLE
Upgrade TimescaleDB to 2.0 for Postgres 11 and 12

### DIFF
--- a/scripts/features/mongodb.sh
+++ b/scripts/features/mongodb.sh
@@ -19,7 +19,7 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/mongodb
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu/dists/$(lsb_release -cs)/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
 
 curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
 

--- a/scripts/features/mongodb.sh
+++ b/scripts/features/mongodb.sh
@@ -19,7 +19,7 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/mongodb
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu/dists/$(lsb_release -cs)/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu $(lsb_release -cs)/mongodb-org/4.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
 
 curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | sudo apt-key add -
 

--- a/scripts/features/timescaledb.sh
+++ b/scripts/features/timescaledb.sh
@@ -24,12 +24,12 @@ sudo apt-get update
 
 # Now install appropriate package for PG version
 if [ -f ~/.homestead-features/wsl_user_name ]; then
-    sudo apt-get -y install timescaledb-postgresql-12
+    sudo apt-get -y install timescaledb-2-postgresql-12
 else
     sudo apt-get -y install timescaledb-postgresql-9.6
     sudo apt-get -y install timescaledb-postgresql-10
-    sudo apt-get -y install timescaledb-postgresql-11
-    sudo apt-get -y install timescaledb-postgresql-12
+    sudo apt-get -y install timescaledb-2-postgresql-11
+    sudo apt-get -y install timescaledb-2-postgresql-12
 fi
 
 sudo timescaledb-tune --quiet --yes


### PR DESCRIPTION
Hello,

This PR is a follow-up on my previous post #1590, and sets TimescaleDB 2.0 as a default for both Postgres 11 and 12, which it [fully supports](https://docs.timescale.com/latest/getting-started/installation/ubuntu/installation-apt-ubuntu).

Will be revisiting this again soon to maybe make TS2 default for Postgres 13 as well in the near future, as they've announced full support will be ready in [February 2021](https://github.com/timescale/timescaledb/issues/2779#issuecomment-769783709).

-- Yazeed
