### PR TITLE
Allow specifying a full proxy_pass value if needed for the Proxy site type

### DIFF
--- a/scripts/site-types/proxy.sh
+++ b/scripts/site-types/proxy.sh
@@ -19,6 +19,22 @@ if [ -n "$9" ]; then
    done
 fi
 
+if [ -n "$2" ]
+then
+    if ! [[ "$2" =~ ^[0-9]+$ ]]
+    then
+        proxyPass="
+        proxy_pass ${2};
+        "
+    else proxyPass="
+        proxy_pass http://127.0.0.1:$2;
+        "
+    fi
+else proxyPass="
+proxy_pass http://127.0.0.1;
+"
+fi
+
 block="server {
     listen ${3:-80};
     listen ${4:-443} ssl;
@@ -31,7 +47,7 @@ block="server {
         proxy_set_header Connection "upgrade";
         proxy_set_header Host \$host;
         proxy_http_version 1.1;
-        proxy_pass http://127.0.0.1:${2};
+        $proxyPass
         $headersTXT
         $paramsTXT
     }


### PR DESCRIPTION
This PR adds the possibility to specify a full proxy_pass value (E.g: http://192.168.1.2:3000) when using the `proxy` site type with the familiar `to:` key in your homestead.yml file.

This PR should **not** be a breaking change as it now detects if the value passed to the `to:` key is an integer.
If the value is an integer (most likely a port, example `to: 5000`) the proxy pass will result in: 
`proxy_pass http://127.0.0.1:5000;` which is the current behavior.

If the value is **not** an integer (Example: `to: http://192.168.1.2:3000`) it will result in: `proxy_pass http://192.168.1.2:3000;`

It's useful for a dev to specify the full value for `proxy` site types if for example, a front-end dev server running on the host machine (not inside the Homestead VM) needs to be proxied from the nice domain/webserver facilities of Homestead to the front-end dev server.
Of course, there might be a plethora of other reasons why passing a full proxy_pass value is beneficial.

### Examples:
homestead.yml
```yml
sites:
    - map: front.domain.test # Create proxy for frontend dev server
      to: "http://192.168.1.2:3000"
      type: proxy
```
Results in:
```nginx
proxy_pass http://192.168.1.2:3000;
```
___
homestead.yml
```yml
sites:
    - map: front2.domain.test # Create proxy for frontend dev server
      to: http://192.168.1.2:3000
      type: proxy
```
Results in:
```nginx
proxy_pass http://192.168.1.2:3000;
```
___
homestead.yml
```yml
sites:
    - map: front3.domain.test # Create proxy for frontend dev server
      to: 3000
      type: proxy
```
Results in:
```nginx
proxy_pass http://127.0.0.1:3000;
```
___
homestead.yml
```yml
sites:
    - map: front4.domain.test # Create proxy for frontend dev server
      type: proxy
```
Results in:
```nginx
proxy_pass http://127.0.0.1;
```

