### PR TITLE
11.x/10.x base box Composer Hotfix

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -591,7 +591,7 @@ class Homestead
     # Update Composer On Every Provision
     config.vm.provision 'shell' do |s|
       s.name = 'Update Composer'
-      s.inline = 'sudo chown -R vagrant:vagrant /usr/local/bin && sudo -u vagrant /usr/local/bin/composer self-update --no-progress && sudo chown -R vagrant:vagrant /home/vagrant/.config/'
+      s.inline = 'sudo chown -R vagrant:vagrant /usr/local/bin && sudo -u vagrant /usr/local/bin/composer self-update --no-progress'
       s.privileged = false
     end
 


### PR DESCRIPTION
Removed chown of composer dir that causes boxes to not build correctly.

Issue Reference: https://github.com/laravel/homestead/issues/1593