### PR TITLE
Removed trailing slash from apache config

### DIFF
--- a/scripts/site-types/apache.sh
+++ b/scripts/site-types/apache.sh
@@ -123,7 +123,7 @@ blockssl="<IfModule mod_ssl.c>
         <IfModule !mod_fastcgi.c>
             <IfModule mod_proxy_fcgi.c>
                 <FilesMatch \".+\.ph(ar|p|tml)$\">
-                    SetHandler \"proxy:unix:/var/run/php/php"$5"-fpm.sock|fcgi://localhost/\"
+                    SetHandler \"proxy:unix:/var/run/php/php"$5"-fpm.sock|fcgi://localhost\"
                 </FilesMatch>
             </IfModule>
         </IfModule>


### PR DESCRIPTION
The trailing slash on `fcgi://localhost/` inside apache config file was causing problems while loading some static assets. This PR fixes that problem.