### PR TITLE
Apache corrupts files on mounted folder

### DIFF
--- a/scripts/site-types/apache.sh
+++ b/scripts/site-types/apache.sh
@@ -36,6 +36,7 @@ block="<VirtualHost *:$3>
     <Directory "$2">
         AllowOverride All
         Require all granted
+        EnableMMAP Off
     </Directory>
     <IfModule mod_fastcgi.c>
         AddHandler php"$5"-fcgi .php


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=900821

I encountered this issue under hyper-v. The proposed fix disables mmap, which seems to be broken on cifs.