### PR TITLE
Fix Minio Buckets Being Setup Incorrectly

### DIFF
--- a/scripts/create-minio-bucket.sh
+++ b/scripts/create-minio-bucket.sh
@@ -2,3 +2,5 @@
 
 mc mb /usr/local/share/minio/$1
 mc policy set $2 /usr/local/share/minio/$1
+# Minio CLI Makes Buckets Under Root For Some Reason
+sudo chown minio-user:minio-user /usr/local/share/minio/*


### PR DESCRIPTION
Creating new buckets in Minio causes the folders to be created under `root`.
While the fact that the Minio CLI behaves this way is extremely questionable, this is a one-line fix for the permission issue it causes.