### PR TITLE
[Meilisearch] Add executable path and default homestead IP on ExecStart

### DIFF
--- a/scripts/features/meilisearch.sh
+++ b/scripts/features/meilisearch.sh
@@ -33,7 +33,7 @@ After=systemd-user-sessions.service
 
 [Service]
 Type=simple
-ExecStart=meilisearch
+ExecStart=/usr/bin/meilisearch --http-addr '192.168.10.10:7700'
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Update Meilisearch `ExecStart` adding the executable path and the default homestead IP.