### PR TITLE
Add ERB parsing to YAML and JSON settings files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 
 require 'json'
 require 'yaml'
+require 'erb'
 
 VAGRANTFILE_API_VERSION ||= "2"
 confDir = $confDir ||= File.expand_path(File.dirname(__FILE__))
@@ -26,9 +27,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     if File.exist? homesteadYamlPath then
-        settings = YAML::load(File.read(homesteadYamlPath))
+        settings = YAML::load(ERB.new(File.read(homesteadYamlPath)).result)
     elsif File.exist? homesteadJsonPath then
-        settings = JSON::parse(File.read(homesteadJsonPath))
+        settings = JSON::parse(ERB.new(File.read(homesteadJsonPath)).result)
     else
         abort "Homestead settings file not found in #{confDir}"
     end


### PR DESCRIPTION
This PR enables support for ERB template parsing of the `Homestead.yaml` and `Homestead.json` settings files before they are parsed into a hash object in the `Vagrantfile`.

I added ERB parsing because in my case, it enables me to pass through the `COMPOSER_AUTH` environment variable from my host `~/.zshrc` file to my Homestead VM, which I need to install private packages, by loading it in the variables block like this:

```
variables:
  - key: COMPOSER_AUTH
    value: '<%= ENV["COMPOSER_AUTH"] %>'
```

I'm not a Ruby person, so I don't know if this is the "done thing", but I think I've seen this behaviour in Rails. It would allow a bit more flexibility in the configuration files, which would be useful (e.g. scanning a directory for projects to map).

Thanks!