### PR TITLE
Add option to force SSL

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -3,6 +3,7 @@ ip: "192.168.10.10"
 memory: 2048
 cpus: 2
 provider: virtualbox
+force_ssl: true
 
 authorize: ~/.ssh/id_rsa.pub
 
@@ -16,6 +17,7 @@ folders:
 sites:
     - map: homestead.test
       to: /home/vagrant/code/public
+#     force_ssl: false
 
 databases:
     - homestead

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -360,6 +360,14 @@ class Homestead
 
           # Convert the site & any options to an array of arguments passed to the
           # specific site type script (defaults to laravel)
+          if site.has_key?('force_ssl')
+            force_ssl = site['force_ssl'] ? 'true' : 'false'
+          elsif settings.has_key?('force_ssl')
+            force_ssl = settings['force_ssl'] ? 'true' : 'false'
+          else
+            force_ssl = 'false';
+          end
+
           s.path = script_dir + "/site-types/#{type}.sh"
           s.args = [
               site['map'],                # $1
@@ -371,7 +379,8 @@ class Homestead
               site['xhgui'] ||= '',       # $7
               site['exec'] ||= 'false',   # $8
               headers ||= '',             # $9
-              rewrites ||= ''             # $10
+              rewrites ||= '',            # $10
+              force_ssl ||= ''            # $11
           ]
 
           # Should we use the wildcard ssl?

--- a/scripts/site-types/laravel.sh
+++ b/scripts/site-types/laravel.sh
@@ -37,9 +37,25 @@ location /xhgui {
 else configureXhgui=""
 fi
 
-block="server {
+if [ "${11}" = "true" ]
+then block="server {
+    listen ${3:-80};
+    server_name .$1;
+
+    # Redirect all HTTP links to the matching HTTPS page
+    return 301 https://\$host\$request_uri;
+}
+
+server {
+    listen ${4:-443} ssl http2;
+";
+else block="server {
     listen ${3:-80};
     listen ${4:-443} ssl http2;
+";
+fi
+
+block+="
     server_name .$1;
     root \"$2\";
 


### PR DESCRIPTION
I added the `force_ssl` option to force SSL for all sites, with the possibility to add overrides per site. The default value is `false` since I'm not sure whether this could break existing installations.

What it does is redirecting all insecure requests to their secure counterparts using NGINX. I considered adding the `Strict-Transport-Security` as well, but in the end I didn't because I'm not sure it has added value for a website on a local development machine.

I only changed the `laravel` site type because it's the only one I'm using and because I'm not sure if you guys want to add this feature. Please let me know what you think.