### PR TITLE
Update to separate the MariaDB / MySQL provisioning scripts

### DIFF
--- a/scripts/create-mariadb.sh
+++ b/scripts/create-mariadb.sh
@@ -11,12 +11,12 @@ cp /root/.my.cnf /home/vagrant/.my.cnf
 
 DB=$1;
 
-mysql=$(pidof mysqld)
+mariadb=$(pidof mariadbd)
 
-if [ -z "$mysql" ]
+if [ -z "$mariadb" ]
 then
-    # Skip Creating MySQL database
-    echo "We didn't find a PID for mysqld, skipping $DB creation"
+    # Skip Creating MariaDB database
+    echo "We didn't find a PID for mariadbd, skipping $DB creation"
 else
     mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
 fi

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -545,9 +545,17 @@ class Homestead
       end
 
       settings['databases'].each do |db|
-        if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mysql8') || (enabled_databases.include? 'mariadb')
+        if enabled_databases.include? 'mariadb'
           config.vm.provision 'shell' do |s|
-            s.name = 'Creating MySQL / MariaDB Database: ' + db
+            s.name = 'Creating MariaDB Database: ' + db
+            s.path = script_dir + '/create-mariadb.sh'
+            s.args = [db]
+          end
+        end
+
+        if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mysql8')
+          config.vm.provision 'shell' do |s|
+            s.name = 'Creating MySQL Database: ' + db
             s.path = script_dir + '/create-mysql.sh'
             s.args = [db]
           end


### PR DESCRIPTION
This pull request is related to issue #1614

This update separates the MariaDB / MySQL provisioning scripts to prevent the display of a failure message that is accurate but misleading / confusing. Assuming that only one of MariaDB or MySQL is enabled the following message currently will always be displayed because the other process will not exist:
```
homestead: We didn't find a PID for [mariadb | mysqld], skipping $DB creation
```

Updates include:
* separate the `create-mysql.sh` script into `create-mariadb.sh` for MariaDB and `create-mysql.sh` for MySQL
* update the `homestead.rb` script to execute the appropriate script
* update the skip messages to not escape the database name so that the database name is displayed instead of `skipping $DB creation`

For example, when enabling MariaDB with the following `Homestead.yaml` configuration:
```
databases:
    - homestead

features:
    - mysql: false
    - mariadb: true
```

the current output is:
```
==> homestead: Running provisioner: Creating MySQL / MariaDB Database: homestead (shell)...
    homestead: Running: script: Creating MySQL / MariaDB Database: homestead
    homestead: We didn't find a PID for mysqld, skipping $DB creation
```

With the proposed update the output is:
```
==> homestead: Running provisioner: Creating MariaDB Database: homestead (shell)...
    homestead: Running: script: Creating MariaDB Database: homestead
```

Similarly when enabling MySQL with the following `Homestead.yaml` configuration:
```
databases:
    - homestead

features:
    - mysql: true
    - mariadb: false
```

the current output is:
```
==> homestead: Running provisioner: Creating MySQL / MariaDB Database: homestead (shell)...
    homestead: Running: script: Creating MySQL / MariaDB Database: homestead
    homestead: We didn't find a PID for mariadb, skipping $DB creation
```

With the proposed update the output is:
```
==> homestead: Running provisioner: Creating MySQL Database: homestead (shell)...
    homestead: Running: script: Creating MySQL Database: homestead
```
