### PR TITLE
feat(php) enable php-fpm on box startup

### DIFF
--- a/scripts/features/php5.6.sh
+++ b/scripts/features/php5.6.sh
@@ -62,5 +62,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/5.6/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/5.6/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/5.6/fpm/pool.d/www.conf
 
-systemctl disable php5.6-fpm
+systemctl enable php5.6-fpm
 service php5.6-fpm restart

--- a/scripts/features/php7.0.sh
+++ b/scripts/features/php7.0.sh
@@ -61,5 +61,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/7.0/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/7.0/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/7.0/fpm/pool.d/www.conf
 
-systemctl disable php7.0-fpm
+systemctl enable php7.0-fpm
 service php7.0-fpm restart

--- a/scripts/features/php7.1.sh
+++ b/scripts/features/php7.1.sh
@@ -61,5 +61,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/7.1/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/7.1/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/7.1/fpm/pool.d/www.conf
 
-systemctl disable php7.1-fpm
+systemctl enable php7.1-fpm
 service php7.1-fpm restart

--- a/scripts/features/php7.2.sh
+++ b/scripts/features/php7.2.sh
@@ -62,5 +62,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/7.2/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/7.2/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/7.2/fpm/pool.d/www.conf
 
-systemctl disable php7.2-fpm
+systemctl enable php7.2-fpm
 service php7.2-fpm restart

--- a/scripts/features/php7.3.sh
+++ b/scripts/features/php7.3.sh
@@ -61,5 +61,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/7.3/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/7.3/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/7.3/fpm/pool.d/www.conf
 
-systemctl disable php7.3-fpm
+systemctl enable php7.3-fpm
 service php7.3-fpm restart

--- a/scripts/features/php7.4.sh
+++ b/scripts/features/php7.4.sh
@@ -61,5 +61,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/7.4/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/7.4/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/7.4/fpm/pool.d/www.conf
 
-systemctl disable php7.4-fpm
+systemctl enable php7.4-fpm
 service php7.4-fpm restart

--- a/scripts/features/php8.0.sh
+++ b/scripts/features/php8.0.sh
@@ -61,5 +61,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/8.0/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/8.0/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/8.0/fpm/pool.d/www.conf
 
-systemctl disable php8.0-fpm
+systemctl enable php8.0-fpm
 service php8.0-fpm restart

--- a/scripts/features/php8.1.sh
+++ b/scripts/features/php8.1.sh
@@ -63,5 +63,5 @@ sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/8.1/fpm/pool.d/www.c
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/8.1/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/8.1/fpm/pool.d/www.conf
 
-systemctl disable php8.1-fpm
+systemctl enable php8.1-fpm
 service php8.1-fpm restart


### PR DESCRIPTION
After the box restart, the php version do not start automatically.
This pull request revert this.

Thanks