### PR TITLE
Enforce `fastcgi.conf`

### DIFF
--- a/scripts/site-types/cakephp3.sh
+++ b/scripts/site-types/cakephp3.sh
@@ -76,12 +76,13 @@ server {
 
     location ~ \.php$ {
         try_files \$uri =404;
-        include fastcgi_params;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        fastcgi_intercept_errors on;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
+
+        fastcgi_intercept_errors on;
     }
 
     location ~ /\.ht {

--- a/scripts/site-types/elgg.sh
+++ b/scripts/site-types/elgg.sh
@@ -91,19 +91,18 @@ block="server {
     # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
     location ~ \.php$ {
         try_files \$uri @elgg;
-        fastcgi_index index.php;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
-        include /etc/nginx/fastcgi_params;
+        fastcgi_index index.php;
+        include fastcgi.conf;
     }
 
     location @elgg {
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
 
-        include /etc/nginx/fastcgi_params;
+        include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME \$document_root/index.php;
-        fastcgi_param SCRIPT_NAME     /index.php;
-        fastcgi_param QUERY_STRING    __elgg_uri=\$uri&\$args;
+        fastcgi_param SCRIPT_NAME /index.php;
+        fastcgi_param QUERY_STRING __elgg_uri=\$uri&\$args;
     }
 
     ssl_certificate     /etc/ssl/certs/$1.crt;

--- a/scripts/site-types/frontcontroller.sh
+++ b/scripts/site-types/frontcontroller.sh
@@ -67,8 +67,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/laravel.sh
+++ b/scripts/site-types/laravel.sh
@@ -68,8 +68,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/magento.sh
+++ b/scripts/site-types/magento.sh
@@ -29,17 +29,16 @@ block="server {
     location ~* ^/setup($|/) {
         root \$MAGE_ROOT;
         location ~ ^/setup/index.php {
-            fastcgi_pass   unix:/var/run/php/php$5-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+            fastcgi_index index.php;
 
-            fastcgi_param  PHP_FLAG  \"session.auto_start=off \n suhosin.session.cryptua=off\";
-            fastcgi_param  PHP_VALUE \"memory_limit=756M \n max_execution_time=600\";
+            include fastcgi.conf;
+            fastcgi_param PHP_FLAG  \"session.auto_start=off \n suhosin.session.cryptua=off\";
+            fastcgi_param PHP_VALUE \"memory_limit=756M \n max_execution_time=600\";
+            $paramsTXT
+
             fastcgi_read_timeout 600s;
             fastcgi_connect_timeout 600s;
-
-            fastcgi_index  index.php;
-            fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
-            $paramsTXT
-            include        fastcgi_params;
         }
 
         location ~ ^/setup/(?!pub/). {
@@ -57,12 +56,12 @@ block="server {
 
         location ~ ^/update/index.php {
             fastcgi_split_path_info ^(/update/index.php)(/.+)$;
-            fastcgi_pass   unix:/var/run/php/php$5-fpm.sock;
-            fastcgi_index  index.php;
-            fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
-            fastcgi_param  PATH_INFO        \$fastcgi_path_info;
+            fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+            fastcgi_index index.php;
+
+            include fastcgi.conf;
+            fastcgi_param PATH_INFO \$fastcgi_path_info;
             $paramsTXT
-            include        fastcgi_params;
         }
 
         # Deny everything but index.php
@@ -157,19 +156,18 @@ block="server {
     # PHP entry point for main application
     location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
         try_files \$uri =404;
-        fastcgi_pass   unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_index index.php;
+
+        include fastcgi.conf;
+        fastcgi_param PHP_FLAG \"session.auto_start=off \n suhosin.session.cryptua=off\";
+        fastcgi_param PHP_VALUE \"memory_limit=756M \n max_execution_time=18000\";
+        $paramsTXT
+
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
-
-        fastcgi_param  PHP_FLAG  \"session.auto_start=off \n suhosin.session.cryptua=off\";
-        fastcgi_param  PHP_VALUE \"memory_limit=756M \n max_execution_time=18000\";
         fastcgi_read_timeout 600s;
         fastcgi_connect_timeout 600s;
-
-        fastcgi_index  index.php;
-        fastcgi_param  SCRIPT_FILENAME  \$document_root\$fastcgi_script_name;
-        $paramsTXT
-        include        fastcgi_params;
     }
 
     gzip on;

--- a/scripts/site-types/modx.sh
+++ b/scripts/site-types/modx.sh
@@ -60,8 +60,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/phalcon.sh
+++ b/scripts/site-types/phalcon.sh
@@ -78,8 +78,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/silverstripe.sh
+++ b/scripts/site-types/silverstripe.sh
@@ -76,8 +76,8 @@ block="server {
         fastcgi_keep_conn on;
         fastcgi_pass   unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index  index.php;
-        fastcgi_param  SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
-        include        fastcgi_params;
+
+        include fastcgi.conf;
         $paramsTXT
     }
 
@@ -120,15 +120,16 @@ block="server {
     }
 
     location ~ \.php$ {
-        fastcgi_keep_conn on;
-        fastcgi_pass   unix:/var/run/php/php$5-fpm.sock;
-        fastcgi_index  index.php;
-        fastcgi_param  SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
-        include        fastcgi_params;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_index index.php;
+
+        include fastcgi.conf;
+        $paramsTXT
+
         fastcgi_buffer_size 32k;
         fastcgi_busy_buffers_size 64k;
+        fastcgi_keep_conn on;
         fastcgi_buffers 4 32k;
-        $paramsTXT
     }
 
     $configureXhgui

--- a/scripts/site-types/statamic.sh
+++ b/scripts/site-types/statamic.sh
@@ -68,8 +68,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/symfony2.sh
+++ b/scripts/site-types/symfony2.sh
@@ -67,8 +67,8 @@ block="server {
     location ~ ^/(app_dev|app_test|config)\.php(/|\$) {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;
@@ -83,8 +83,8 @@ block="server {
     location ~ ^/app\.php(/|$) {
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/symfony4.sh
+++ b/scripts/site-types/symfony4.sh
@@ -67,8 +67,8 @@ block="server {
     location ~ \.php(/|\$) {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/thinkphp.sh
+++ b/scripts/site-types/thinkphp.sh
@@ -72,8 +72,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/umi.sh
+++ b/scripts/site-types/umi.sh
@@ -125,9 +125,8 @@ block="server {
         fastcgi_split_path_info ^(.+\.php)(/.+)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
 
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;

--- a/scripts/site-types/wordpress.sh
+++ b/scripts/site-types/wordpress.sh
@@ -71,10 +71,11 @@ block="server {
 
     location ~ \.php$ {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        include fastcgi_params;
-        fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_index index.php;
+
+        include fastcgi.conf;
+
         fastcgi_intercept_errors on;
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;

--- a/scripts/site-types/yii.sh
+++ b/scripts/site-types/yii.sh
@@ -77,12 +77,13 @@ block="server {
 
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        try_files \$uri =404;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
         fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
-        try_files \$uri =404;
+
         fastcgi_intercept_errors off;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;

--- a/scripts/site-types/zf.sh
+++ b/scripts/site-types/zf.sh
@@ -79,8 +79,8 @@ block="server {
     location ~ \.php$ {
         fastcgi_split_path_info ^(.+\.php)(/.*)\$;
         fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME \$document_root/\$fastcgi_script_name;
+
+        include fastcgi.conf;
         $paramsTXT
 
         fastcgi_intercept_errors off;


### PR DESCRIPTION
Enforce `fastcgi.conf`.

> In 0.8.30 (released: 15th of December 2009) Igor then included
> `fastcgi.conf` which was the same as `fastcgi_params` except
> including the improved SCRIPT_FILENAME `fastcgi_param`. This meant
> that the community could now start recommending people include
> `fastcgi.conf` instead of recommending moving `SCRIPT_FILENAME` into
> `fastcgi_params`.

https://blog.martinfjordvald.com/nginx-config-history-fastcgi_params-versus-fastcgi-conf/