### PR TITLE
Configure the software source and the default site for multiple sites

### DIFF
--- a/scripts/change-sources.sh
+++ b/scripts/change-sources.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+new_sources="$1"
+old_sources="http://archive.ubuntu.com"
+if [[ -f /home/vagrant/.homestead-features/sources ]]; then
+    old_sources=$(cat /home/vagrant/.homestead-features/sources)
+fi
+
+if [[ "$old_sources" != "$new_sources" ]]; then
+    touch /home/vagrant/.homestead-features/sources
+    echo "$new_sources" > /home/vagrant/.homestead-features/sources
+    chown -Rf vagrant:vagrant /home/vagrant/.homestead-features
+
+    sudo find /etc/apt -name 'sources.list' | xargs perl -pi -e "s|$old_sources|$new_sources|g"
+
+    sudo apt-get update
+fi

--- a/scripts/clear-apache.sh
+++ b/scripts/clear-apache.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Clear The Old Apache Sites
+
+rm -f /etc/apache2/sites-enabled/*
+rm -f /etc/apache2/sites-available/*

--- a/scripts/site-types/apache.sh
+++ b/scripts/site-types/apache.sh
@@ -62,8 +62,14 @@ block="<VirtualHost *:$3>
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet
 "
 
-echo "$block" > "/etc/apache2/sites-available/$1.conf"
-ln -fs "/etc/apache2/sites-available/$1.conf" "/etc/apache2/sites-enabled/$1.conf"
+if [[ "${11}" == "false" ]]; then
+  echo "$block" > "/etc/apache2/sites-available/$1.conf"
+  ln -fs "/etc/apache2/sites-available/$1.conf" "/etc/apache2/sites-enabled/$1.conf"
+else
+  echo "$block" >"/etc/apache2/sites-available/000-default.conf"
+  ln -fs "/etc/apache2/sites-available/000-default.conf" "/etc/apache2/sites-enabled/000-default.conf"
+fi
+
 
 blockssl="<IfModule mod_ssl.c>
     <VirtualHost *:$4>
@@ -140,8 +146,13 @@ blockssl="<IfModule mod_ssl.c>
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet
 "
 
-echo "$blockssl" > "/etc/apache2/sites-available/$1-ssl.conf"
-ln -fs "/etc/apache2/sites-available/$1-ssl.conf" "/etc/apache2/sites-enabled/$1-ssl.conf"
+if [[ "${11}" == "false" ]]; then
+  echo "$blockssl" > "/etc/apache2/sites-available/$1-ssl.conf"
+  ln -fs "/etc/apache2/sites-available/$1-ssl.conf" "/etc/apache2/sites-enabled/$1-ssl.conf"
+else
+  echo "$blockssl" >"/etc/apache2/sites-available/default-ssl.conf"
+  ln -fs "/etc/apache2/sites-available/000-default-ssl.conf" "/etc/apache2/sites-enabled/default-ssl.conf"
+fi
 
 ps auxw | grep apache2 | grep -v grep > /dev/null
 

--- a/scripts/site-types/laravel.sh
+++ b/scripts/site-types/laravel.sh
@@ -37,10 +37,23 @@ location /xhgui {
 else configureXhgui=""
 fi
 
+listen_80="${3:-80}"
+listen_443="${4:-443} ssl http2"
+server_name=".$1"
+if [[ "${11}" != "false" ]]; then
+    listen_80="80 default_server"
+    listen_443="[::]:80 default_server"
+    server_name="_"
+fi
+
+sudo service apache2 stop
+sudo systemctl disable apache2
+sudo systemctl enable nginx
+
 block="server {
-    listen ${3:-80};
-    listen ${4:-443} ssl http2;
-    server_name .$1;
+    listen $listen_80;
+    listen $listen_443;
+    server_name $server_name;
     root \"$2\";
 
     index index.html index.htm index.php;


### PR DESCRIPTION
- Networks vary in different regions. Changing software sources helps prevent network crashes

Configure the software source

Homestead.yaml
```yaml
sources: "http://archive.ubuntu.com"
ip: "192.168.10.10"
memory: 2048
cpus: 2
```

- When configuring multiple sites, team development members must be happy to configure one site that can be accessed using IP

Configure the default site in Nginx and Apache

Homestead.yaml
```yaml
# in Nginx
sites:
    - map: laravel.test
      to: /home/vagrant/code/laravel/public
      default: true
    - map: blog.test
      to: /home/vagrant/code/blog/public
    - map: explore.test
      to: /home/vagrant/code/explore/public

# in Apache
sites:
    - map: laravel.test
      to: /home/vagrant/code/laravel/public
      type: "apache"
      default: true
    - map: blog.test
      to: /home/vagrant/code/blog/public
      type: "apache"
    - map: explore.test
      to: /home/vagrant/code/explore/public
      type: "apache"
```

I submitted it for the first time, but I don't understand your merger rules. Please forgive me if there is anything unreasonable，thanks