### PR TITLE
Update golang feature to be aware of CPU arch

### DIFF
--- a/scripts/features/golang.sh
+++ b/scripts/features/golang.sh
@@ -19,9 +19,16 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/golang
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
+ARCH=$(echo uname -a)
+
 # Install Golang
 golangVersion="1.17.2"
-wget https://dl.google.com/go/go${golangVersion}.linux-amd64.tar.gz -O golang.tar.gz
+if $ARCH | grep aarch64; then
+  wget https://dl.google.com/go/go${golangVersion}.darwin-arm64.tar.gz -O golang.tar.gz
+else
+  wget https://dl.google.com/go/go${golangVersion}.linux-amd64.tar.gz -O golang.tar.gz
+fi
+
 tar -C /usr/local -xzf golang.tar.gz go
 printf "\nPATH=\"/usr/local/go/bin:\$PATH\"\n" | tee -a /home/vagrant/.profile
 rm -rf golang.tar.gz


### PR DESCRIPTION
Partially resolves https://github.com/laravel/homestead/issues/1722

Testing on M1:

```
vagrant@homestead:~$ sudo su
root@homestead:/home/vagrant# ARCH=$(echo uname -a)
root@homestead:/home/vagrant#
root@homestead:/home/vagrant# # Install Golang
root@homestead:/home/vagrant# golangVersion="1.17.2"
root@homestead:/home/vagrant# if $ARCH | grep aarch64; then
>   wget https://dl.google.com/go/go${golangVersion}.darwin-arm64.tar.gz -O golang.tar.gz
> else
>   wget https://dl.google.com/go/go${golangVersion}.linux-amd64.tar.gz -O golang.tar.gz
> fi
Linux homestead 5.4.0-89-generic #100-Ubuntu SMP Fri Sep 24 14:29:20 UTC 2021 aarch64 aarch64 aarch64 GNU/Linux
--2021-10-31 00:00:30--  https://dl.google.com/go/go1.17.2.darwin-arm64.tar.gz
```

Testing on Intel MacOS:

```
vagrant@homestead:~$ sudo su
root@homestead:/home/vagrant# ARCH=$(echo uname -a)
root@homestead:/home/vagrant#
root@homestead:/home/vagrant# # Install Golang
root@homestead:/home/vagrant# golangVersion="1.17.2"
root@homestead:/home/vagrant# if $ARCH | grep aarch64; then
>   wget https://dl.google.com/go/go${golangVersion}.darwin-arm64.tar.gz -O golang.tar.gz
> else
>   wget https://dl.google.com/go/go${golangVersion}.linux-amd64.tar.gz -O golang.tar.gz
> fi
--2021-10-31 00:00:50--  https://dl.google.com/go/go1.17.2.linux-amd64.tar.gz
```