### PR TITLE
13.0.0 - PHP 8.1 Default Requires Base Box  >= 12.0.0, < 13.0.0

### DIFF
--- a/bin/homestead
+++ b/bin/homestead
@@ -8,7 +8,7 @@ if(is_file( __DIR__.'/../vendor/autoload.php')) {
     require __DIR__.'/../../../autoload.php';
 }
 
-$app = new Symfony\Component\Console\Application('Laravel Homestead', '12.8.0');
+$app = new Symfony\Component\Console\Application('Laravel Homestead', '13.0.0');
 
 $app->add(new Laravel\Homestead\MakeCommand);
 $app->add(new Laravel\Homestead\WslApplyFeatures);

--- a/resources/aliases
+++ b/resources/aliases
@@ -7,7 +7,6 @@ alias art=artisan
 
 alias codecept='vendor/bin/codecept'
 alias phpspec='vendor/bin/phpspec'
-alias phpunit='vendor/bin/phpunit'
 alias serve=serve-laravel
 
 alias xoff='sudo phpdismod -s cli xdebug'
@@ -43,6 +42,22 @@ function dusk() {
         php artisan dusk --filter "$@"
     fi
 }
+
+function p() {
+    if [ -f vendor/bin/pest ]; then
+       vendor/bin/pest "$@"
+    else
+       vendor/bin/phpunit "$@"
+    fi
+ }
+ 
+ function pf() {
+    if [ -f vendor/bin/pest ]; then
+       vendor/bin/pest --filter "$@"
+    else
+       vendor/bin/phpunit --filter "$@"
+    fi
+ }
 
 function php56() {
     sudo update-alternatives --set php /usr/bin/php5.6

--- a/resources/aliases
+++ b/resources/aliases
@@ -97,7 +97,7 @@ function serve-apache() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/apache.sh
-        sudo bash /vagrant/scripts/site-types/apache.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/apache.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -110,7 +110,7 @@ function serve-laravel() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/laravel.sh
-        sudo bash /vagrant/scripts/site-types/laravel.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/laravel.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -122,7 +122,7 @@ function serve-proxy() {
     if [[ "$1" && "$2" ]]
     then
         sudo dos2unix /vagrant/scripts/site-types/proxy.sh
-        sudo bash /vagrant/scripts/site-types/proxy.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/proxy.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -135,7 +135,7 @@ function serve-silverstripe() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/silverstripe.sh
-        sudo bash /vagrant/scripts/site-types/silverstripe.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/silverstripe.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -148,7 +148,7 @@ function serve-spa() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/spa.sh
-        sudo bash /vagrant/scripts/site-types/spa.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/spa.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -161,7 +161,7 @@ function serve-statamic() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/statamic.sh
-        sudo bash /vagrant/scripts/site-types/statamic.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/statamic.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -174,7 +174,7 @@ function serve-symfony2() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/symfony2.sh
-        sudo bash /vagrant/scripts/site-types/symfony2.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/symfony2.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -187,7 +187,7 @@ function serve-symfony4() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/symfony4.sh
-        sudo bash /vagrant/scripts/site-types/symfony4.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/symfony4.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -200,7 +200,7 @@ function serve-pimcore() {
     then
         sudo bash /vagrant/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/scripts/site-types/pimcore.sh
-        sudo bash /vagrant/scripts/site-types/pimcore.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/scripts/site-types/pimcore.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -80,7 +80,7 @@ function serve-apache() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/apache.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/apache.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/apache.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -93,7 +93,7 @@ function serve-laravel() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/laravel.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/laravel.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/laravel.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -105,7 +105,7 @@ function serve-proxy() {
     if [[ "$1" && "$2" ]]
     then
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/proxy.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/proxy.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/proxy.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -118,7 +118,7 @@ function serve-silverstripe() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/silverstripe.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/silverstripe.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/silverstripe.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -131,7 +131,7 @@ function serve-spa() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/spa.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/spa.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/spa.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -144,7 +144,7 @@ function serve-statamic() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/statamic.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/statamic.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/statamic.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -157,7 +157,7 @@ function serve-symfony2() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/symfony2.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/symfony2.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/symfony2.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -170,7 +170,7 @@ function serve-symfony4() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/symfony4.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/symfony4.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/symfony4.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "
@@ -183,7 +183,7 @@ function serve-pimcore() {
     then
         sudo bash /vagrant/vendor/laravel/homestead/scripts/create-certificate.sh "$1"
         sudo dos2unix /vagrant/vendor/laravel/homestead/scripts/site-types/pimcore.sh
-        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/pimcore.sh "$1" "$2" 80 443 "${3:-7.4}"
+        sudo bash /vagrant/vendor/laravel/homestead/scripts/site-types/pimcore.sh "$1" "$2" 80 443 "${3:-8.1}"
     else
         echo "Error: missing required parameters."
         echo "Usage: "

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -7,7 +7,6 @@ alias art=artisan
 
 alias codecept='vendor/bin/codecept'
 alias phpspec='vendor/bin/phpspec'
-alias phpunit='vendor/bin/phpunit'
 alias serve=serve-laravel
 
 alias xoff='sudo phpdismod -s cli xdebug'
@@ -24,8 +23,29 @@ function dusk() {
         Xvfb :0 -screen 0 1280x960x24 &
     fi
 
-    php artisan dusk --filter "$@"
+    if [[ $? -eq 0 ]]
+    then
+        php artisan dusk
+    else
+        php artisan dusk --filter "$@"
+    fi
 }
+
+function p() {
+    if [ -f vendor/bin/pest ]; then
+       vendor/bin/pest "$@"
+    else
+       vendor/bin/phpunit "$@"
+    fi
+ }
+ 
+ function pf() {
+    if [ -f vendor/bin/pest ]; then
+       vendor/bin/pest --filter "$@"
+    else
+       vendor/bin/phpunit --filter "$@"
+    fi
+ }
 
 function php56() {
     sudo update-alternatives --set php /usr/bin/php5.6

--- a/scripts/features/minio.sh
+++ b/scripts/features/minio.sh
@@ -16,7 +16,7 @@ then
     exit 0
 fi
 
-ARCH=$(echo uname -a)
+ARCH=$(arch)
 
 
 touch /home/$WSL_USER_NAME/.homestead-features/minio

--- a/scripts/features/minio.sh
+++ b/scripts/features/minio.sh
@@ -22,7 +22,7 @@ ARCH=$(echo uname -a)
 touch /home/$WSL_USER_NAME/.homestead-features/minio
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-if $ARCH | grep aarch64; then
+if [[ "$ARCH" == "aarch64" ]]; then
   curl -sO https://dl.minio.io/server/minio/release/linux-arm64/minio
 else
   curl -sO https://dl.minio.io/server/minio/release/linux-amd64/minio
@@ -56,7 +56,7 @@ sudo systemctl start minio
 sudo ufw allow 9600
 
 # Installing Minio Client
-if $ARCH | grep aarch64; then
+if [[ "$ARCH" == "aarch64" ]]; then
   curl -sO https://dl.minio.io/client/mc/release/linux-arm64/mc
 else
   curl -sO https://dl.minio.io/client/mc/release/linux-amd64/mc

--- a/scripts/features/minio.sh
+++ b/scripts/features/minio.sh
@@ -16,10 +16,17 @@ then
     exit 0
 fi
 
+ARCH=$(echo uname -a)
+
+
 touch /home/$WSL_USER_NAME/.homestead-features/minio
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-wget https://dl.minio.io/server/minio/release/linux-amd64/minio
+if $ARCH | grep aarch64; then
+  curl -sO https://dl.minio.io/server/minio/release/linux-arm64/minio
+else
+  curl -sO https://dl.minio.io/server/minio/release/linux-amd64/minio
+fi
 
 sudo chmod +x minio
 sudo mv minio /usr/local/bin
@@ -49,7 +56,12 @@ sudo systemctl start minio
 sudo ufw allow 9600
 
 # Installing Minio Client
-curl -sO https://dl.minio.io/client/mc/release/linux-amd64/mc
+if $ARCH | grep aarch64; then
+  curl -sO https://dl.minio.io/client/mc/release/linux-arm64/mc
+else
+  curl -sO https://dl.minio.io/client/mc/release/linux-amd64/mc
+fi
+
 chmod +x mc
 sudo mv mc /usr/local/bin
 mc config host add homestead http://127.0.1.1:9600 homestead secretkey

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -378,7 +378,7 @@ class Homestead
               site['to'],                 # $2
               site['port'] ||= http_port, # $3
               site['ssl'] ||= https_port, # $4
-              site['php'] ||= '8.0',      # $5
+              site['php'] ||= '8.1',      # $5
               params ||= '',              # $6
               site['xhgui'] ||= '',       # $7
               site['exec'] ||= 'false',   # $8
@@ -518,13 +518,18 @@ class Homestead
         end
 
         config.vm.provision 'shell' do |s|
+          s.inline = "echo \"\nenv[$1] = '$2'\" >> /etc/php/8.1/fpm/pool.d/www.conf"
+          s.args = [var['key'], var['value']]
+        end
+
+        config.vm.provision 'shell' do |s|
           s.inline = "echo \"\n# Set Homestead Environment Variable\nexport $1=$2\" >> /home/vagrant/.profile"
           s.args = [var['key'], var['value']]
         end
       end
 
       config.vm.provision 'shell' do |s|
-        s.inline = 'service php5.6-fpm restart;service php7.0-fpm restart;service  php7.1-fpm restart; service php7.2-fpm restart; service php7.3-fpm restart; service php7.4-fpm restart; service php8.0-fpm restart;'
+        s.inline = 'service php5.6-fpm restart;service php7.0-fpm restart;service  php7.1-fpm restart; service php7.2-fpm restart; service php7.3-fpm restart; service php7.4-fpm restart; service php8.0-fpm restart; service php8.1-fpm restart;'
       end
     end
 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -19,7 +19,7 @@ class Homestead
     config.vm.define settings['name'] ||= 'homestead'
     config.vm.box = settings['box'] ||= 'laravel/homestead'
     unless settings.has_key?('SpeakFriendAndEnter')
-      config.vm.box_version = settings['version'] ||= '>= 11.0.0, < 12.0.0'
+      config.vm.box_version = settings['version'] ||= '>= 12.0.0, < 13.0.0'
     end
     config.vm.hostname = settings['hostname'] ||= 'homestead'
 

--- a/scripts/in-flight-service.sh
+++ b/scripts/in-flight-service.sh
@@ -4,5 +4,5 @@
 # Without having to ship an entirely new base box.
 
 # Fix expired certs: https://github.com/laravel/homestead/issues/1707
-sudo rm -rf /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
-sudo update-ca-certificates
+# sudo rm -rf /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
+# sudo update-ca-certificates


### PR DESCRIPTION
* PHP 8.1 is now default
* Base box version support `'>= 12.0.0, < 13.0.0`
*  Update minio feature to be aware of CPU arch (#1734) @a-yasui
* Add test aliases for both Pest and PHPunit dynamically (#1738)  @lloricode
*  `php-swoole` package removed from base box. (Many 8.1 deprecation warnings when running `composer`)