### PR TITLE
Wordpress - Enable debug mode automatically

### DIFF
--- a/scripts/site-types/wordpress.sh
+++ b/scripts/site-types/wordpress.sh
@@ -118,6 +118,8 @@ if ( ! defined( 'WP_CONTENT_DIR' ) ) {\\n\
 if ( ! defined( 'WP_CONTENT_URL' ) ) {\\n\
 	define( 'WP_CONTENT_URL', WP_HOME . '/wp-content' );\\n\
 }\\n\
+\\n\
+define( 'WP_DEBUG', true ); \\n\
 "
 
 


### PR DESCRIPTION
Due to homestead being a development platform, enabling WP_DEBUG automatically makes sense.

