### PR TITLE
Add new site type for webman framework

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -374,16 +374,17 @@ class Homestead
           # specific site type script (defaults to laravel)
           s.path = script_dir + "/site-types/#{type}.sh"
           s.args = [
-              site['map'],                # $1
-              site['to'],                 # $2
-              site['port'] ||= http_port, # $3
-              site['ssl'] ||= https_port, # $4
-              site['php'] ||= '8.1',      # $5
-              params ||= '',              # $6
-              site['xhgui'] ||= '',       # $7
-              site['exec'] ||= 'false',   # $8
-              headers ||= '',             # $9
-              rewrites ||= ''             # $10
+              site['map'],                   # $1
+              site['to'],                    # $2
+              site['port'] ||= http_port,    # $3
+              site['ssl'] ||= https_port,    # $4
+              site['php'] ||= '8.1',         # $5
+              params ||= '',                 # $6
+              site['xhgui'] ||= '',          # $7
+              site['exec'] ||= 'false',      # $8
+              headers ||= '',                # $9
+              rewrites ||= '',               # $10
+              site['webman_port'] ||= '8787' # $11
           ]
 
           # Should we use the wildcard ssl?

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -384,7 +384,7 @@ class Homestead
               site['exec'] ||= 'false',      # $8
               headers ||= '',                # $9
               rewrites ||= '',               # $10
-              site['webman_port'] ||= '8787' # $11
+              site['upstream'] ||= '8787'    # $11
           ]
 
           # Should we use the wildcard ssl?

--- a/scripts/site-types/upstream.sh
+++ b/scripts/site-types/upstream.sh
@@ -37,7 +37,7 @@ location /xhgui {
 else configureXhgui=""
 fi
 
-block="upstream webman {
+block="upstream upstream {
     server 127.0.0.1:${11};
 }
 
@@ -59,7 +59,7 @@ server {
         $headersTXT
 
         if (!-f \$request_filename){
-          proxy_pass http://webman;
+          proxy_pass http://upstream;
         }
     }
 

--- a/scripts/site-types/webman.sh
+++ b/scripts/site-types/webman.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+declare -A params=$6       # Create an associative array
+declare -A headers=${9}    # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
+paramsTXT=""
+if [ -n "$6" ]; then
+   for element in "${!params[@]}"
+   do
+      paramsTXT="${paramsTXT}
+      fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "${9}" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
+fi
+
+if [ "$7" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
+block="upstream webman {
+    server 127.0.0.1:${11};
+}
+
+server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name .$1;
+    root \"$2\";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+
+    $rewritesTXT
+
+    location / {
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header Host \$host;
+        $headersTXT
+
+        if (!-f \$request_filename){
+          proxy_pass http://webman;
+        }
+    }
+
+    $configureXhgui
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/$1-error.log error;
+
+    sendfile off;
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    ssl_certificate     /etc/ssl/certs/$1.crt;
+    ssl_certificate_key /etc/ssl/certs/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"


### PR DESCRIPTION
/cc @mouyong

Resolves https://github.com/laravel/homestead/issues/1764

Example configuration:

```
sites:
    - map: vcdt.test
      to: /home/vagrant/vcdt/public
      type: webman
      webman_port: 9393
```

Results in the following virutalhost:

```
upstream webman {
    server 127.0.0.1:9393;
}

server {
    listen 80;
    listen 443 ssl http2;
    server_name .vcdt.test;
    root "/home/vagrant/vcdt/public";

    index index.html index.htm index.php;

    charset utf-8;



    location / {
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header Host $host;


        if (!-f $request_filename){
          proxy_pass http://webman;
        }
    }



    location = /favicon.ico { access_log off; log_not_found off; }
    location = /robots.txt  { access_log off; log_not_found off; }

    access_log off;
    error_log  /var/log/nginx/vcdt.test-error.log error;

    sendfile off;

    location ~ /\.ht {
        deny all;
    }

    ssl_certificate     /etc/ssl/certs/vcdt.test.crt;
    ssl_certificate_key /etc/ssl/certs/vcdt.test.key;
}
```