### PR TITLE
Fix multiple provisioners with "keys" and "copy" directives

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -154,7 +154,7 @@ class Homestead
       end
       settings['keys'].each do |key|
         if File.exist? File.expand_path(key)
-          config.vm.provision "setting authorize permissions", type: "shell" do |s|
+          config.vm.provision "setting authorize permissions for #{key.split('/').last}", type: "shell" do |s|
             s.privileged = false
             s.inline = "echo \"$1\" > /home/vagrant/.ssh/$2 && chmod 600 /home/vagrant/.ssh/$2"
             s.args = [File.read(File.expand_path(key)), key.split('/').last]
@@ -169,7 +169,7 @@ class Homestead
     # Copy User Files Over to VM
     if settings.include? 'copy'
       settings['copy'].each do |file|
-        config.vm.provision "file", type: "file" do |f|
+        config.vm.provision 'file' do |f|
           f.source = File.expand_path(file['from'])
           f.destination = file['to'].chomp('/') + '/' + file['from'].split('/').last
         end


### PR DESCRIPTION
I tried to add multiple keys and multiple files to copy in the yaml file, but that didn't work.

I noticed that the provisioners get overwritten because they use the same name, as stated in the vagrant documentation: https://www.vagrantup.com/docs/provisioning/basic_usage#overriding-provisioner-settings

The `shell` and `files` provisioner names that also serve as type definition are excluded from that.

So I modified the label for the individual "keys" to include the key file name  
and for copy I merged the "file" label and type definition to just one string, so vagrant handles that correctly and doesn't overwrite it based on the same label.

I couldn't find any other cases like that in the `homestead.rb`, so I think the other provisioners in loops are fine.
