### PR TITLE
feat: add new site type for fastadmin framework

### DIFF
--- a/scripts/site-types/fastadmin.sh
+++ b/scripts/site-types/fastadmin.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+declare -A params=$6       # Create an associative array
+declare -A headers=${9}    # Create an associative array
+declare -A rewrites=${10}  # Create an associative array
+paramsTXT=""
+if [ -n "$6" ]; then
+   for element in "${!params[@]}"
+   do
+      paramsTXT="${paramsTXT}
+      fastcgi_param ${element} ${params[$element]};"
+   done
+fi
+headersTXT=""
+if [ -n "${9}" ]; then
+   for element in "${!headers[@]}"
+   do
+      headersTXT="${headersTXT}
+      add_header ${element} ${headers[$element]};"
+   done
+fi
+rewritesTXT=""
+if [ -n "${10}" ]; then
+   for element in "${!rewrites[@]}"
+   do
+      rewritesTXT="${rewritesTXT}
+      location ~ ${element} { if (!-f \$request_filename) { return 301 ${rewrites[$element]}; } }"
+   done
+fi
+
+if [ "$7" = "true" ]
+then configureXhgui="
+location /xhgui {
+        try_files \$uri \$uri/ /xhgui/index.php?\$args;
+}
+"
+else configureXhgui=""
+fi
+
+block="server {
+    listen ${3:-80};
+    listen ${4:-443} ssl http2;
+    server_name .$1;
+    root \"$2\";
+
+    index index.html index.htm index.php;
+
+    charset utf-8;
+    client_max_body_size 100M;
+
+    $rewritesTXT
+
+    location / {
+        if (!-e \$request_filename) {
+            rewrite  ^(.*)$  /index.php?s=/\$1  last;
+            break;
+        }
+        $headersTXT
+    }
+
+    $configureXhgui
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log  /var/log/nginx/$1-error.log error;
+
+    sendfile off;
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass unix:/var/run/php/php$5-fpm.sock;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
+        fastcgi_param PATH_INFO  \$fastcgi_path_info;
+        $paramsTXT
+
+        fastcgi_intercept_errors off;
+        fastcgi_buffer_size 16k;
+        fastcgi_buffers 4 16k;
+        fastcgi_connect_timeout 300;
+        fastcgi_send_timeout 300;
+        fastcgi_read_timeout 300;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    ssl_certificate     /etc/ssl/certs/$1.crt;
+    ssl_certificate_key /etc/ssl/certs/$1.key;
+}
+"
+
+echo "$block" > "/etc/nginx/sites-available/$1"
+ln -fs "/etc/nginx/sites-available/$1" "/etc/nginx/sites-enabled/$1"


### PR DESCRIPTION
Example configuration:

sites:
    - map: fastadmin.local
      to: /home/vagrant/fastadmin/public
      type: fastadmin