### PR TITLE
Drop MySQL feature example

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -24,9 +24,6 @@
     ],
     "features": [
         {
-            "mysql": true
-        },
-        {
             "mariadb": false
         },
         {

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -21,7 +21,6 @@ databases:
     - homestead
 
 features:
-    - mysql: true
     - mariadb: false
     - postgresql: false
     - ohmyzsh: false


### PR DESCRIPTION
the "mysql" feature no longer exists, so we'll drop it from the example config files.

#1582 dropped the `mysql8.sh` file.

confirmed running with the "mysql" feature produces `homestead: Invalid feature: mysql`