### PR TITLE
Feature oh my zsh : set theme and plugins from config

### DIFF
--- a/scripts/features/ohmyzsh.sh
+++ b/scripts/features/ohmyzsh.sh
@@ -22,6 +22,15 @@ chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-feature
 # Install oh-my-zsh
 git clone https://github.com/ohmyzsh/ohmyzsh.git /home/vagrant/.oh-my-zsh
 cp /home/vagrant/.oh-my-zsh/templates/zshrc.zsh-template /home/vagrant/.zshrc
+
+# Set theme and plugins according to config
+if [ -n "${theme}" ]; then
+    sed -i "s/^ZSH_THEME=.*/ZSH_THEME=\"${theme}\"/" /home/vagrant/.zshrc
+fi
+if [ -n "${plugins}" ]; then
+    sed -i "s/^plugins=.*/plugins=(${plugins})/" /home/vagrant/.zshrc
+fi
+
 printf "\nemulate sh -c 'source ~/.bash_aliases'\n" | tee -a /home/vagrant/.zprofile
 printf "\nemulate sh -c 'source ~/.profile'\n" | tee -a /home/vagrant/.zprofile
 chown -R vagrant:vagrant /home/vagrant/.oh-my-zsh


### PR DESCRIPTION
With this we can set (and keep after a `vagrant destroy` command) at least the theme and plugins for our oh my zsh config. If any of `theme` or `plugins` is not set, we keep the default config.