### PR TITLE
Ubuntu 22.04 Updates - v14.x (Next Major Version)

### DIFF
--- a/scripts/features/couchdb.sh
+++ b/scripts/features/couchdb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Unsupported on arm64
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"
@@ -19,11 +20,12 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/couchdb
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-echo "deb https://apache.bintray.com/couchdb-deb focal main" \
-    | sudo tee -a /etc/apt/sources.list.d/couchdb.list
+sudo apt update && sudo apt install -y curl apt-transport-https gnupg
+curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
+source /etc/os-release
+echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
+    | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
-  8756C4F765C9AC3CB6B85D62379CE192D401AB61
 sudo apt-get update
 echo "couchdb couchdb/mode select standalone
 couchdb couchdb/mode seen true

--- a/scripts/features/crystal.sh
+++ b/scripts/features/crystal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Unsupported on arm64
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"

--- a/scripts/features/elasticsearch.sh
+++ b/scripts/features/elasticsearch.sh
@@ -19,39 +19,17 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/elasticsearch
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-# Determine version from config
-
-set -- "$1"
-IFS=".";
-
-if [ -z "${version}" ]; then
-    installVersion="" # by not specifying we'll install latest
-    majorVersion="7" # default to version 7
-else
-    installVersion="=$version"
-    majorVersion="$(echo $version | head -c 1)"
-fi
-
-
-echo "Elasticsearch installVersion: $installVersion"
-echo "Elasticsearch majorVersion: $majorVersion"
-
-
 # Install Java & Elasticsearch
 
-wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-
-if [ ! -f /etc/apt/sources.list.d/elastic-$majorVersion.x.list ]; then
-    echo "deb https://artifacts.elastic.co/packages/$majorVersion.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-$majorVersion.x.list
-fi
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list
 
 sudo apt-get update
-sudo apt-get -y install openjdk-11-jre
-sudo apt-get -y install elasticsearch"$installVersion"
+sudo apt-get -y install openjdk-11-jre elasticsearch
 
 # Start Elasticsearch on boot
 
-sudo update-rc.d elasticsearch defaults 95 10
+sudo systemctl enable elasticsearch
 
 # Update configuration to use 'homestead' as the cluster
 

--- a/scripts/features/meilisearch.sh
+++ b/scripts/features/meilisearch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Unsupported on 22.04?
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"

--- a/scripts/features/mongodb.sh
+++ b/scripts/features/mongodb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Unsupported on 22.04
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"

--- a/scripts/features/timescaledb.sh
+++ b/scripts/features/timescaledb.sh
@@ -23,10 +23,10 @@ sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb
 wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
 sudo apt-get update
 
-sudo apt-get -y install timescaledb-2-postgresql-13
+sudo apt-get -y install timescaledb-2-postgresql-14
 
 sudo timescaledb-tune --quiet --yes
-printf "\ntimescaledb.telemetry_level=off\n" | sudo tee -a /etc/postgresql/13/main/postgresql.conf
+printf "\ntimescaledb.telemetry_level=off\n" | sudo tee -a /etc/postgresql/14/main/postgresql.conf
 
 sudo service postgresql restart
 


### PR DESCRIPTION
* Remove support for specified elasticsearch version
* Set TimescaleDB to use PostgreSQL 14
* Testing Jammy CouchDB
* CouchDB doesn't support arm64
* Marking feature compatibility


## Rework `Homestead.yaml` services configuration to match features.

Old `services`
```
services:
    - enabled:
        - "postgresql"
    - disabled:
        - "mysql"
```

New `services`

```
services:
    - postgresql: true
    - mysql: false
```