### PR TITLE
Homestead 14.x Updates

### DIFF
--- a/resources/Homestead.json
+++ b/resources/Homestead.json
@@ -24,9 +24,6 @@
     ],
     "features": [
         {
-            "mysql": true
-        },
-        {
             "mariadb": false
         },
         {

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -21,7 +21,6 @@ databases:
     - homestead
 
 features:
-    - mysql: true
     - mariadb: false
     - postgresql: false
     - ohmyzsh: false

--- a/resources/aliases
+++ b/resources/aliases
@@ -50,7 +50,7 @@ function p() {
        vendor/bin/phpunit "$@"
     fi
  }
- 
+
  function pf() {
     if [ -f vendor/bin/pest ]; then
        vendor/bin/pest --filter "$@"
@@ -105,6 +105,12 @@ function php81() {
     sudo update-alternatives --set php /usr/bin/php8.1
     sudo update-alternatives --set php-config /usr/bin/php-config8.1
     sudo update-alternatives --set phpize /usr/bin/phpize8.1
+}
+
+function php82() {
+    sudo update-alternatives --set php /usr/bin/php8.2
+    sudo update-alternatives --set php-config /usr/bin/php-config8.2
+    sudo update-alternatives --set phpize /usr/bin/phpize8.2
 }
 
 function serve-apache() {

--- a/resources/localized/aliases
+++ b/resources/localized/aliases
@@ -38,7 +38,7 @@ function p() {
        vendor/bin/phpunit "$@"
     fi
  }
- 
+
  function pf() {
     if [ -f vendor/bin/pest ]; then
        vendor/bin/pest --filter "$@"
@@ -93,6 +93,12 @@ function php81() {
     sudo update-alternatives --set php /usr/bin/php8.1
     sudo update-alternatives --set php-config /usr/bin/php-config8.1
     sudo update-alternatives --set phpize /usr/bin/phpize8.1
+}
+
+function php82() {
+    sudo update-alternatives --set php /usr/bin/php8.2
+    sudo update-alternatives --set php-config /usr/bin/php-config8.2
+    sudo update-alternatives --set phpize /usr/bin/phpize8.2
 }
 
 function serve-apache() {

--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -2,30 +2,30 @@
 
 cat > /root/.my.cnf << EOF
 [client]
-user = homestead
+user = root
 password = secret
-host = localhost
+host = 127.0.0.1
 EOF
 
 cp /root/.my.cnf /home/vagrant/.my.cnf
 
 DB=$1;
 
-mysql=$(pidof mysqld)
-mariadb=$(pidof mariadbd)
+mysql=$(ps ax | grep mysql | wc -l)
+mariadb=$(ps ax | grep mariadb | wc -l)
 
-if [ -z "$mysql" ]
+if [ "$mysql" -gt 1 ]
 then
-      # Skip Creating MySQL database
-      echo "We didn't find a PID for mysqld, skipping \$DB creation"
+    mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
 else
-      mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
+    # Skip Creating MySQL database
+    echo "We didn't find MySQL (\$mysql), skipping \$DB creation"
 fi
 
-if [ -z "$mariadb" ]
+if [ "$mariadb" -gt 1 ]
 then
-      # Skip Creating MariaDB database
-      echo "We didn't find a PID for mariadb, skipping \$DB creation"
+    mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
 else
-      mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
+    # Skip Creating MariaDB database
+    echo "We didn't find MariaDB (\$mariadb), skipping \$DB creation"
 fi

--- a/scripts/features/couchdb.sh
+++ b/scripts/features/couchdb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Unsupported on arm64
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"
@@ -19,11 +20,12 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/couchdb
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-echo "deb https://apache.bintray.com/couchdb-deb focal main" \
-    | sudo tee -a /etc/apt/sources.list.d/couchdb.list
+sudo apt update && sudo apt install -y curl apt-transport-https gnupg
+curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
+source /etc/os-release
+echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ ${VERSION_CODENAME} main" \
+    | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
-  8756C4F765C9AC3CB6B85D62379CE192D401AB61
 sudo apt-get update
 echo "couchdb couchdb/mode select standalone
 couchdb couchdb/mode seen true

--- a/scripts/features/crystal.sh
+++ b/scripts/features/crystal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Unsupported on arm64
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"

--- a/scripts/features/dockstead.sh
+++ b/scripts/features/dockstead.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+if [ -f ~/.homestead-features/wsl_user_name ]; then
+    WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"
+    WSL_USER_GROUP="$(cat ~/.homestead-features/wsl_user_group)"
+else
+    WSL_USER_NAME=vagrant
+    WSL_USER_GROUP=vagrant
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -f /home/$WSL_USER_NAME/.homestead-features/dockstead ]
+then
+    echo "dockstead already installed."
+    exit 0
+fi
+
+touch /home/$WSL_USER_NAME/.homestead-features/dockstead
+chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
+
+# Ensure we're in swarm mode
+docker swarm init --advertise-addr 192.168.56.56

--- a/scripts/features/dockstead/env.docker
+++ b/scripts/features/dockstead/env.docker
@@ -1,0 +1,5 @@
+# Mysql Parameters
+MYSQL_ROOT_PASSWORD=secret
+MYSQL_DATABASE=homestead
+MYSQL_USER=homestead
+MYSQL_PASSWORD=secret

--- a/scripts/features/dockstead/mysql-5.7.yaml
+++ b/scripts/features/dockstead/mysql-5.7.yaml
@@ -1,0 +1,25 @@
+---
+#
+# docker stack deploy -c /vagrant/scripts/features/dockstead/mysql-5.7.yaml mysql-56
+#
+version: "3.7"
+services:
+    mysql:
+        image: mysql:5.7
+        volumes:
+            - type: volume
+              source: mysql-data
+              target: /var/lib/mysql
+              volume:
+                  nocopy: true
+        ports:
+            - "3306:3306"
+        healthcheck:
+            test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+            interval: 3s
+            timeout: 1s
+            retries: 5
+        env_file:
+            - env.docker
+volumes:
+    mysql-data:

--- a/scripts/features/dockstead/mysql-57.sh
+++ b/scripts/features/dockstead/mysql-57.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Stop the default MySQL Service
+sudo service mysql stop
+
+# Update /home/vagrant/.my.cnf
+sed -i "s/localhost/127.0.0.1/" /home/vagrant/.my.cnf
+
+# Start the MySQL 5.7 stack
+docker stack deploy -c /vagrant/scripts/features/dockstead/mysql-5.7.yaml mysql-57
+echo "Sleeping for 30 seconds while we wait for MySQL service to come up"
+sleep 30

--- a/scripts/features/elasticsearch.sh
+++ b/scripts/features/elasticsearch.sh
@@ -19,39 +19,17 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/elasticsearch
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-# Determine version from config
-
-set -- "$1"
-IFS=".";
-
-if [ -z "${version}" ]; then
-    installVersion="" # by not specifying we'll install latest
-    majorVersion="7" # default to version 7
-else
-    installVersion="=$version"
-    majorVersion="$(echo $version | head -c 1)"
-fi
-
-
-echo "Elasticsearch installVersion: $installVersion"
-echo "Elasticsearch majorVersion: $majorVersion"
-
-
 # Install Java & Elasticsearch
 
-wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-
-if [ ! -f /etc/apt/sources.list.d/elastic-$majorVersion.x.list ]; then
-    echo "deb https://artifacts.elastic.co/packages/$majorVersion.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-$majorVersion.x.list
-fi
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list
 
 sudo apt-get update
-sudo apt-get -y install openjdk-11-jre
-sudo apt-get -y install elasticsearch"$installVersion"
+sudo apt-get -y install openjdk-11-jre elasticsearch
 
 # Start Elasticsearch on boot
 
-sudo update-rc.d elasticsearch defaults 95 10
+sudo systemctl enable elasticsearch
 
 # Update configuration to use 'homestead' as the cluster
 

--- a/scripts/features/meilisearch.sh
+++ b/scripts/features/meilisearch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Unsupported on 22.04?
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"

--- a/scripts/features/mongodb.sh
+++ b/scripts/features/mongodb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Unsupported on 22.04
 
 if [ -f ~/.homestead-features/wsl_user_name ]; then
     WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"

--- a/scripts/features/timescaledb.sh
+++ b/scripts/features/timescaledb.sh
@@ -23,10 +23,10 @@ sudo sh -c "echo 'deb https://packagecloud.io/timescale/timescaledb/ubuntu/ `lsb
 wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | sudo apt-key add -
 sudo apt-get update
 
-sudo apt-get -y install timescaledb-2-postgresql-13
+sudo apt-get -y install timescaledb-2-postgresql-14
 
 sudo timescaledb-tune --quiet --yes
-printf "\ntimescaledb.telemetry_level=off\n" | sudo tee -a /etc/postgresql/13/main/postgresql.conf
+printf "\ntimescaledb.telemetry_level=off\n" | sudo tee -a /etc/postgresql/14/main/postgresql.conf
 
 sudo service postgresql restart
 


### PR DESCRIPTION
* Remove support for specified elasticsearch version
* Set TimescaleDB to use PostgreSQL 14
* Testing Jammy CouchDB
* CouchDB doesn't support arm64
* Marking feature compatibility


## Rework `Homestead.yaml` services configuration to match features.

Old `services`
```
services:
    - enabled:
        - "postgresql"
    - disabled:
        - "mysql"
```

New `services`

```
services:
    - postgresql: true
    - mysql: false
```