### PR TITLE
add Laravel Pint alias

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -7,6 +7,7 @@ alias art=artisan
 
 alias codecept='vendor/bin/codecept'
 alias phpspec='vendor/bin/phpspec'
+alias pint='vendor/bin/pint'
 alias serve=serve-laravel
 
 alias xoff='sudo phpdismod -s cli xdebug'


### PR DESCRIPTION
Pint now comes pre-installed with every new Laravel installation. Adding an alias so we can reference it more easily.