### PR TITLE
Fix MariaDB set-up script - issue #1816 - vagrant up crashes on create database…

### DIFF
--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -57,6 +57,7 @@ EOF
 
 export MYSQL_PWD=secret
 
+mysql --user="root" -e "GRANT ALL ON *.* TO root@'localhost' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 mysql --user="root" -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
 service mysql restart
 


### PR DESCRIPTION
After installation set-up in create-mysql.sh script is failing on MariaDB , because the root@localhost doesn't have the password. This fixes it and the databases specified in the Homestead.yaml are then properly created