### PR TITLE
[WIP] Add basic libvirt support

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -104,6 +104,18 @@ class Homestead
       v.cpus = settings['cpus'] ||= 1
     end
 
+    # Configure libvirt settings
+    config.vm.provider "libvirt" do |libvirt|
+      libvirt.memory = settings["memory"] ||= "2048"
+      libvirt.cpus = settings["cpus"] ||= "1"
+      libvirt.disk_bus = "virtio"
+      libvirt.disk_driver :cache => "writeback"
+      libvirt.memorybacking :access, :mode => 'shared'
+      libvirt.nic_model_type = "virtio"
+      libvirt.qemu_use_session = false
+      config.vm.synced_folder "./", "/vagrant", type: "virtiofs"
+    end
+  
     # Standardize Ports Naming Schema
     if settings.has_key?('ports')
       settings['ports'].each do |port|
@@ -185,6 +197,10 @@ class Homestead
 
           if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'hyperv'
             folder['type'] = 'smb'
+          end
+
+          if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'libvirt'
+            folder['type'] = 'virtiofs'
           end
 
           if folder['type'] == 'nfs'


### PR DESCRIPTION
For storage I used virtiofs. (NFS didn't work for me, maybe it was because my host os, virtiofs is way faster anyway)

Example config:
https://gist.github.com/csaba215/b96e63377835db50e0cb7cae14047ebf
(Using the box I built for libvirt)
At the moment I get 2 network interfaces, 1 received the ip in the config, the other received ip from the default network.