### PR TITLE
Update meilisearch for aarch64 support

### DIFF
--- a/scripts/features/meilisearch.sh
+++ b/scripts/features/meilisearch.sh
@@ -20,15 +20,8 @@ touch /home/$WSL_USER_NAME/.homestead-features/meilisearch
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
 # add the sources for meilisearch
-if [[ "$ARCH" == "aarch64" ]]; then
-    curl -L https://install.meilisearch.com | sh
-    mv ./meilisearch /usr/bin/
-else
-    echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
-
-    # update apt and install meilisearch
-    apt-get update && apt-get install meilisearch-http
-fi
+curl -L https://install.meilisearch.com | sh
+mv ./meilisearch /usr/bin/
 
 # Create a service file
 cat > /etc/systemd/system/meilisearch.service << EOF

--- a/scripts/features/meilisearch.sh
+++ b/scripts/features/meilisearch.sh
@@ -20,10 +20,15 @@ touch /home/$WSL_USER_NAME/.homestead-features/meilisearch
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
 # add the sources for meilisearch
-echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
+if [[ "$ARCH" == "aarch64" ]]; then
+    curl -L https://install.meilisearch.com | sh
+    mv ./meilisearch /usr/bin/
+else
+    echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 
-# update apt and install meilisearch
-apt-get update && apt-get install meilisearch-http
+    # update apt and install meilisearch
+    apt-get update && apt-get install meilisearch-http
+fi
 
 # Create a service file
 cat > /etc/systemd/system/meilisearch.service << EOF


### PR DESCRIPTION
This updates meilisearch to work with aarch64, related to this thread: https://github.com/meilisearch/meilisearch/discussions/2048, the if statement may not be needed as the sh command would do the check and install, however I left it in as I can only test it using the arm aarch64 variation.