### PR TITLE
Clear PHP 8.1 and PHP 8.2 variables

### DIFF
--- a/scripts/clear-variables.sh
+++ b/scripts/clear-variables.sh
@@ -31,3 +31,11 @@ fi
 if [ -f /etc/php/8.0/fpm/pool.d/www.conf ]; then
     sed -i '/env\[.*/,+1d' /etc/php/8.0/fpm/pool.d/www.conf
 fi
+
+if [ -f /etc/php/8.1/fpm/pool.d/www.conf ]; then
+    sed -i '/env\[.*/,+1d' /etc/php/8.1/fpm/pool.d/www.conf
+fi
+
+if [ -f /etc/php/8.2/fpm/pool.d/www.conf ]; then
+    sed -i '/env\[.*/,+1d' /etc/php/8.2/fpm/pool.d/www.conf
+fi


### PR DESCRIPTION
Honestly, not sure if this is needed, I'm just following the fact that we are doing it for previous versions. I thought someone may have forgotten to do it.