### PR TITLE
Drop Yarn

### DIFF
--- a/bin/wsl-init
+++ b/bin/wsl-init
@@ -186,7 +186,6 @@ apt-get install -y nodejs
 /usr/bin/npm install -g npm
 #/usr/bin/npm install -g gulp-cli
 #/usr/bin/npm install -g bower
-/usr/bin/npm install -g yarn
 #/usr/bin/npm install -g grunt-cli
 
 ## Install rabbitmq-server and its dependencies
@@ -429,4 +428,3 @@ sysctl fs.protected_regular=0
 # Setup Homestead repo
 su $WSL_USER_NAME -c 'composer install'
 su $WSL_USER_NAME -c 'bash init.sh'
-

--- a/resources/aliases
+++ b/resources/aliases
@@ -19,12 +19,6 @@ alias nrwp="npm run watch-poll"
 alias nrh="npm run hot"
 alias nrp="npm run production"
 
-alias yrd="yarn run dev"
-alias yrw="yarn run watch"
-alias yrwp="yarn run watch-poll"
-alias yrh="yarn run hot"
-alias yrp="yarn run production"
-
 function artisan() {
     php artisan "$@"
 }


### PR DESCRIPTION
I know Yarn was a good stop-gap years ago for when there were serious shortcomings with NPM, but now that NPM has gotten its act together, I think we can drop Yarn support.

Yarn users are welcome to add this into their own custom aliases, but I think we're covering the 99% use case here.