### PR TITLE
Libvirt: fix vm naming

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -106,6 +106,7 @@ class Homestead
     
     # Configure libvirt settings
     config.vm.provider "libvirt" do |libvirt|
+      libvirt.default_prefix = ''
       libvirt.memory = settings["memory"] ||= "2048"
       libvirt.cpu_model = settings["cpus"] ||= "1"
       libvirt.nested = "true"


### PR DESCRIPTION
Currently the vm name is based on the current directory and name parameter.(e.g. homestead_homestead when directory is homestead and vm name is homestead) It should be based on the name parameter only.