### PR TITLE
Always allow symlink creation in shared folders when using VirtualBox provider on a Windows host OS

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -55,6 +55,10 @@ class Homestead
       if settings.has_key?('paravirtprovider') && settings['paravirtprovider']
         vb.customize ['modifyvm', :id, '--paravirtprovider', settings['paravirtprovider'] ||= 'kvm']
       end
+      
+      if Vagrant::Util::Platform.windows?
+        vb.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+      end
     end
 
     # Override Default SSH port on the host


### PR DESCRIPTION
This saves people from having to edit their own Vagrantfile when on Windows and need to use symlinks.

My main reason for proposing this is for people who are using Homestead directly from the repository, as the main Vagrantfile is tracked in git, which can make upgrading Homestead versions, or setting up a new installation, more annoying.

As far as I'm aware there is no detriment to having this enabled always when using Windows.

According to the [VirtualBox documentation](https://www.virtualbox.org/manual/ch04.html#sharedfolders), this option is actually required on all host operating systems if you wish to create symbolic links inside of a shared folder, but it is noted in the [Homestead documentation](https://laravel.com/docs/9.x/homestead#symbolic-links-on-windows) this is only needed for Windows, thus why I've gated this to solely windows.