### PR TITLE
Libvirt: Use virtiofs for default when no folders are defined.

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -202,8 +202,7 @@ class Homestead
           end
 
           if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'libvirt'
-            folder['type'] = 'virtiofs'
-            config.vm.synced_folder "./", "/vagrant", type: "virtiofs"
+            folder['type'] ||= 'virtiofs'
           end
 
           if folder['type'] == 'nfs'
@@ -232,6 +231,11 @@ class Homestead
           end
         end
       end
+    end
+
+    # use virtiofs for /vagrant mount when using libvirt provider
+    if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'libvirt'
+      config.vm.synced_folder "./", "/vagrant", type: "virtiofs"
     end
 
     # Change PHP CLI version based on configuration


### PR DESCRIPTION
Use virtiofs for default when, no folders are defined.
Also allow changing the type of user mounts. e.g.:
```
folders:
    - map: ~/code
      to: /home/vagrant/code
      type: rsync
    - map: ~/code2
      to: /home/vagrant/code2
```