### PR TITLE
Add feature for installing Mailpit and disabling Mailhog

### DIFF
--- a/scripts/features/mailpit.sh
+++ b/scripts/features/mailpit.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+if [ -f ~/.homestead-features/wsl_user_name ]; then
+    WSL_USER_NAME="$(cat ~/.homestead-features/wsl_user_name)"
+    WSL_USER_GROUP="$(cat ~/.homestead-features/wsl_user_group)"
+else
+    WSL_USER_NAME=vagrant
+    WSL_USER_GROUP=vagrant
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -f /home/$WSL_USER_NAME/.homestead-features/mailpit ]
+then
+    echo "mailpit already installed."
+    exit 0
+fi
+
+touch /home/$WSL_USER_NAME/.homestead-features/mailpit
+chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
+
+sudo bash < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh)
+
+chown -f $WSL_USER_NAME:$WSL_USER_GROUP /usr/local/bin/mailpit
+
+cat > /etc/systemd/system/mailpit.service << EOF
+[Unit]
+Description=Mailpit
+After=network.target
+
+[Service]
+User=vagrant
+ExecStart=/usr/bin/env /usr/local/bin/mailpit
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl disable --now mailhog
+
+systemctl enable --now mailpit

--- a/scripts/features/mailpit.sh
+++ b/scripts/features/mailpit.sh
@@ -19,7 +19,7 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/mailpit
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-sudo bash < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh)
+curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh | sh
 
 chown -f $WSL_USER_NAME:$WSL_USER_GROUP /usr/local/bin/mailpit
 


### PR DESCRIPTION
Resolves https://github.com/laravel/homestead/issues/1860

This just uses the install script provided on mailpit's repository which will download the correct binary based on the OS and Architecture you're running, it supports arm64 so should work fine on Apple Silicon devices.

It will also disable mailhog's systemd service, however the mailhog binary will remain installed on the system if the user wishes to switch back.