### PR TITLE
Faster first startup of feature mariadb and fixing upgrading packages

### DIFF
--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -25,7 +25,7 @@ service apparmor stop
 update-rc.d -f apparmor remove
 
 # Remove MySQL
-apt-get -o Dpkg::Options::="--force-confnew" remove -y --purge mysql-server mysql-client mysql-common
+apt-get -o Dpkg::Options::="--force-confnew" remove -y --purge mysql-server mysql-client
 apt-get autoremove -y
 apt-get autoclean
 
@@ -43,7 +43,7 @@ mkdir  /etc/mysql
 touch /etc/mysql/debian.cnf
 
 # Install MariaDB
-apt-get install -y mariadb-server mariadb-client
+apt-get -o Dpkg::Options::="--force-confnew" install -y mariadb-server mariadb-client mysql-common
 
 # Configure Maria Remote Access and ignore db dirs
 sed -i "s/bind-address            = 127.0.0.1/bind-address            = 0.0.0.0/" /etc/mysql/mariadb.conf.d/50-server.cnf


### PR DESCRIPTION
Removing mysql-common upgrades many other packages due to package dependencies. This costs a lot of time and leads to unintentional changes in other packets. Removing the mysql-common package is not required for installing mariadb-server and mariadb-client, the package just needs to be updated from the mariadb repository.

Current first Startup (vagrant up) takes 29:05 minuntes. [Logfile](https://gist.github.com/marcheffels/af410d8aefb3996d60e65d079ce68bc9)
With this PR first Startup (vagrant up) takes 06:05 minuntes. [Logfile](https://gist.github.com/marcheffels/6985931935fba7585f4a82d49a6394bf)

to reproduce you only need this change in your Homestead.yaml
`features:`
`    - mysql: false`
`    - mariadb: true`
