### PR TITLE
Update MinIO scripts to use non-deprecated commands and environment values

### DIFF
--- a/scripts/create-minio-bucket.sh
+++ b/scripts/create-minio-bucket.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
+if [[ -d /usr/local/share/minio/$1 ]]; then
+    echo "Bucket already exists, skipping..."
+    exit
+fi
+
 mc mb /usr/local/share/minio/$1
-mc policy set $2 /usr/local/share/minio/$1
+mc anonymous set $2 /usr/local/share/minio/$1
 # Minio CLI Makes Buckets Under Root For Some Reason
 sudo chown minio-user:minio-user /usr/local/share/minio/*

--- a/scripts/features/minio.sh
+++ b/scripts/features/minio.sh
@@ -38,9 +38,10 @@ cat <<EOT >> /etc/default/minio
 # Local export path.
 MINIO_VOLUMES="/usr/local/share/minio/"
 # Use if you want to run Minio on a custom port.
-MINIO_OPTS="--config-dir /etc/minio --address :9600"
-MINIO_ACCESS_KEY=homestead
-MINIO_SECRET_KEY=secretkey
+MINIO_OPTS="--config-dir /etc/minio --address :9600 --console-address :9601"
+MINIO_CONFIG_ENV_FILE=/etc/default/minio
+MINIO_ROOT_USER=homestead
+MINIO_ROOT_PASSWORD=secretkey
 
 EOT
 


### PR DESCRIPTION
The following additional changes were made:

- Add check to see if bucket already exists
- Add `MINIO_CONFIG_ENV_FILE` environment value to /etc/default/minio (as recommended in https://github.com/minio/minio-service/tree/master/linux-systemd)
- Bind the Console Address to port `9601` as before it would start on a random port.

Fixes #1871