### PR TITLE
Install rabbitmqadmin CLI tool when enabling rabbitmq feature

### DIFF
--- a/scripts/features/rabbitmq.sh
+++ b/scripts/features/rabbitmq.sh
@@ -64,6 +64,7 @@ sudo rabbitmq-plugins enable rabbitmq_management
 sudo rabbitmqctl add_user homestead secret
 sudo rabbitmqctl set_user_tags homestead administrator
 sudo rabbitmqctl set_permissions -p / homestead ".*" ".*" ".*"
+sudo rabbitmqctl set_topic_permissions -p / homestead ".*" ".*" ".*"
 
 # Install rabbitmqadmin CLI tool - https://www.rabbitmq.com/management-cli.html
 sudo wget http://localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin

--- a/scripts/features/rabbitmq.sh
+++ b/scripts/features/rabbitmq.sh
@@ -64,3 +64,7 @@ sudo rabbitmq-plugins enable rabbitmq_management
 sudo rabbitmqctl add_user homestead secret
 sudo rabbitmqctl set_user_tags homestead administrator
 sudo rabbitmqctl set_permissions -p / homestead ".*" ".*" ".*"
+
+# Install rabbitmqadmin CLI tool - https://www.rabbitmq.com/management-cli.html
+sudo wget http://localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
+sudo chmod +x /usr/local/bin/rabbitmqadmin

--- a/scripts/features/rabbitmq.sh
+++ b/scripts/features/rabbitmq.sh
@@ -67,5 +67,5 @@ sudo rabbitmqctl set_permissions -p / homestead ".*" ".*" ".*"
 sudo rabbitmqctl set_topic_permissions -p / homestead ".*" ".*" ".*"
 
 # Install rabbitmqadmin CLI tool - https://www.rabbitmq.com/management-cli.html
-sudo wget http://localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
+sudo wget -q http://localhost:15672/cli/rabbitmqadmin -O /usr/local/bin/rabbitmqadmin
 sudo chmod +x /usr/local/bin/rabbitmqadmin


### PR DESCRIPTION
This tool is useful for administering rabbitmq locally, allowing you to create exchanges, queues and bindings on the CLI.

I've also adding in topic permissions for the default homestead user to ensure they have access to all topics on all exchanges.