### PR TITLE
Prevent duplicate features on provision 

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -274,6 +274,9 @@ class Homestead
           end
         end
       end
+        
+      # Remove duplicate features to prevent trying to install it multiple times
+      settings['features'] = settings['features'].uniq{ |e| e.keys[0] }
 
       settings['features'].each do |feature|
         feature_name = feature.keys[0]


### PR DESCRIPTION
We have multiple sites in the homestead yaml that use the same PHP version and during the provision it will try and install the same PHP version over and over again.

This should only get the unique features and install them.