### PR TITLE
Permits SSH logging with login and password

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         abort "Homestead settings file not found in #{confDir}"
     end
 
+    sshUsername = settings['ssh_username']
+    sshPassword = settings['ssh_password']
+    if !sshUsername.empty?
+        config.ssh.username = sshUsername
+        puts "Configure SSH username #{sshUsername}"
+    end
+    if !sshPassword.empty?
+        config.ssh.password = sshPassword
+        puts "Configure SSH password #{sshPassword}"
+    end
+
     Homestead.configure(config, settings)
 
     if File.exist? afterScriptPath then


### PR DESCRIPTION
By adding the following keys in `homestead.yaml` file, it would permit to log into the box using login and password method.

```
ssh_username: vagrant
ssh_password: vagrant
```

![image](https://github.com/laravel/homestead/assets/646632/78e37734-60de-473b-9d81-5f582eb893c2)
