### PR TITLE
Ngrok default param for apache share 

### DIFF
--- a/resources/aliases
+++ b/resources/aliases
@@ -227,7 +227,7 @@ function serve-pimcore() {
 function share() {
     if [[ "$1" ]]
     then
-        ngrok http ${@:2} $1:80
+        ngrok http ${@:2} $1:80 --host-header=rewrite
     else
         echo "Error: missing required parameters."
         echo "Usage: "

--- a/resources/aliases
+++ b/resources/aliases
@@ -237,6 +237,19 @@ function share() {
     fi
 }
 
+function sshare() {
+    if [[ "$1" ]]
+    then
+        ngrok http ${@:2} $1:443 --host-header=rewrite
+    else
+        echo "Error: missing required parameters."
+        echo "Usage: "
+        echo "  sshare domain"
+        echo "Invocation with extra params passed directly to ngrok"
+        echo "  sshare domain --subdomain=test1234"
+    fi
+}
+
 function flip() {
     sudo bash /vagrant/scripts/flip-webserver.sh
 }


### PR DESCRIPTION
It looks like trying to share an apache site won't work without adding this param.
```
--host-header=rewrite
```

From what I've tested this has no effect on nginx but will fix it working for apache so defaulting this won't have any negative effects and will work for both.

I've also included an alias for share over port 443 as well `sshare` (secure share) but if you're not happy with this I can remove it.

