### PR TITLE
Add Dev Support to Network settings

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -33,7 +33,7 @@ class Homestead
     # Configure Additional Networks
     if settings.has_key?('networks')
       settings['networks'].each do |network|
-        config.vm.network network['type'], ip: network['ip'], mac: network['mac'], bridge: network['bridge'] ||= nil, netmask: network['netmask'] ||= '255.255.255.0'
+        config.vm.network network['type'], ip: network['ip'], mac: network['mac'], bridge: network['bridge'] ||= nil, dev: network['dev'] ||= nil, netmask: network['netmask'] ||= '255.255.255.0'
       end
     end
 


### PR DESCRIPTION
Currently trying to set a network interface when you don't have an eth0 will cause it to fail.

```
[root@homestead testing-homestead]# vagrant up
Bringing machine 'testing-homestead' up with 'libvirt' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

Libvirt Provider:
* network configuration 2 for machine testing-homestead is a public_network referencing host device 'eth0' which does not exist, consider adding ':dev => ....' referencing one of enp2s0
```

This allow passing a dev e.g:
```
networks:
    - type: "public_network"
      ip: "192.168.1.72"
      bridge: "enp2s0"
      dev: "enp2s0"
```