### PR TITLE
Wrong cpus key for libvirt

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -112,7 +112,7 @@ class Homestead
     config.vm.provider "libvirt" do |libvirt|
       libvirt.default_prefix = ''
       libvirt.memory = settings["memory"] ||= "2048"
-      libvirt.cpu_model = settings["cpus"] ||= "1"
+      libvirt.cpus = settings["cpus"] ||= "1"
       libvirt.nested = "true"
       libvirt.disk_bus = "virtio"
       libvirt.machine_type = "q35"


### PR DESCRIPTION
Looks like we're trying to set the key cpu_model instead of cpus

https://wiki.openstack.org/wiki/LibvirtXMLCPUModel

In my homestead yaml I have 
```
memory: 2048
cpus: 4
```

but noticed it wasn't setting the cpus
```
[root@homestead testing-homestead]# vagrant up
Bringing machine 'testing-homestead' up with 'libvirt' provider...
==> testing-homestead: Checking if box 'laravel/homestead' version '13.0.0' is up to date...
==> testing-homestead: Creating image (snapshot of base box volume).
==> testing-homestead: Creating domain with the following settings...
==> testing-homestead:  -- Name:              testing-homestead
==> testing-homestead:  -- Description:       Source: /home/testing-homestead/Vagrantfile
==> testing-homestead:  -- Domain type:       kvm
==> testing-homestead:  -- Cpus:              1
==> testing-homestead:  -- Feature:           acpi
==> testing-homestead:  -- Feature:           apic
==> testing-homestead:  -- Feature:           pae
==> testing-homestead:  -- Clock offset:      utc
==> testing-homestead:  -- Memory:            2048M
```

after my change
```
[root@homestead testing-homestead]# vagrant up
Bringing machine 'testing-homestead' up with 'libvirt' provider...
==> testing-homestead: Checking if box 'laravel/homestead' version '13.0.0' is up to date...
==> testing-homestead: Creating image (snapshot of base box volume).
==> testing-homestead: Creating domain with the following settings...
==> testing-homestead:  -- Name:              testing-homestead
==> testing-homestead:  -- Description:       Source: /home/testing-homestead/Vagrantfile
==> testing-homestead:  -- Domain type:       kvm
==> testing-homestead:  -- Cpus:              4
==> testing-homestead:  -- Feature:           acpi
==> testing-homestead:  -- Feature:           apic
==> testing-homestead:  -- Feature:           pae
==> testing-homestead:  -- Clock offset:      utc
==> testing-homestead:  -- Memory:            2048M
```