### PR TITLE
FIx deprecation warning from MariaDB 11

### DIFF
--- a/scripts/create-mysql.sh
+++ b/scripts/create-mysql.sh
@@ -16,24 +16,16 @@ EOF
 
 chown vagrant /home/vagrant/.my.cnf
 
+DB=$1
 
-DB=$1;
-
-mysql=$(ps ax | grep mysql | wc -l)
 mariadb=$(ps ax | grep mariadb | wc -l)
+mysql=$(ps ax | grep mysql | wc -l)
 
-if [ "$mysql" -gt 1 ]
-then
-    mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
+if [ "$mariadb" -gt 1 ]; then
+    mariadb -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci"
+elif [ "$mysql" -gt 1 ]; then
+    mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci"
 else
-    # Skip Creating MySQL database
-    echo "We didn't find MySQL (\$mysql), skipping \$DB creation"
-fi
-
-if [ "$mariadb" -gt 1 ]
-then
-    mysql -e "CREATE DATABASE IF NOT EXISTS \`$DB\` DEFAULT CHARACTER SET utf8mb4 DEFAULT COLLATE utf8mb4_unicode_ci";
-else
-    # Skip Creating MariaDB database
-    echo "We didn't find MariaDB (\$mariadb), skipping \$DB creation"
+    # Skip Creating database
+    echo "We didn't find MariaDB (\$mariadb) or MySQL (\$mysql), skipping \`$DB\` creation"
 fi

--- a/scripts/features/mariadb.sh
+++ b/scripts/features/mariadb.sh
@@ -10,8 +10,7 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-if [ -f /home/$WSL_USER_NAME/.homestead-features/mariadb ]
-then
+if [ -f /home/$WSL_USER_NAME/.homestead-features/mariadb ]; then
     echo "MariaDB already installed."
     exit 0
 fi
@@ -34,13 +33,12 @@ rm -rf /var/log/mysql
 rm -rf /etc/mysql
 
 # Determine version from config
-
 set -- "$1"
-IFS=".";
+IFS="."
 
 # Add Maria PPA
 if [ -z "${version}" ]; then
-    curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash  
+    curl -LsS https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
 else
     curl -LsS -O https://downloads.mariadb.com/MariaDB/mariadb_repo_setup | sudo bash
     sudo bash mariadb_repo_setup --mariadb-server-version="$version"
@@ -50,7 +48,7 @@ fi
 debconf-set-selections <<< "mariadb-server mysql-server/data-dir select ''"
 debconf-set-selections <<< "mariadb-server mysql-server/root_password password secret"
 debconf-set-selections <<< "mariadb-server mysql-server/root_password_again password secret"
-mkdir  /etc/mysql
+mkdir /etc/mysql
 touch /etc/mysql/debian.cnf
 
 # Install MariaDB
@@ -68,17 +66,17 @@ EOF
 
 export MYSQL_PWD=secret
 
-mysql --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO root@'localhost' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
-service mysql restart
+mariadb --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO root@'localhost' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+mariadb --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO root@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+service mariadb restart
 
-mysql --user="root" --password="secret" -h localhost -e "CREATE USER IF NOT EXISTS 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
-mysql --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
-mysql --user="root" --password="secret" -h localhost -e "FLUSH PRIVILEGES;"
-service mysql restart
+mariadb --user="root" --password="secret" -h localhost -e "CREATE USER IF NOT EXISTS 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret';"
+mariadb --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO 'homestead'@'0.0.0.0' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+mariadb --user="root" --password="secret" -h localhost -e "GRANT ALL ON *.* TO 'homestead'@'%' IDENTIFIED BY 'secret' WITH GRANT OPTION;"
+mariadb --user="root" --password="secret" -h localhost -e "FLUSH PRIVILEGES;"
+service mariadb restart
 
-mysql_upgrade --user="root" --verbose --force
-service mysql restart
+mariadb_upgrade --user="root" --verbose --force
+service mariadb restart
 
 unset MYSQL_PWD


### PR DESCRIPTION
With MariaDB 11 it'll complain with deprecated program name. this updates it to use mariadb instead of mysql to fix it :)

Before:
```
    homestead-testing: Configuration file '/etc/mysql/debian-start'
    homestead-testing:  ==> Deleted (by you or by a script) since installation.
    homestead-testing:  ==> Package distributor has shipped an updated version.
    homestead-testing:  ==> Using new file as you requested.
    homestead-testing: Installing new version of config file /etc/mysql/debian-start ...
    homestead-testing: renamed '/etc/logrotate.d/mysql-server' -> '/etc/logrotate.d/mysql-server.dpkg-bak'
    homestead-testing: Created symlink /etc/systemd/system/multi-user.target.wants/mariadb.service → /lib/systemd/system/mariadb.service.
    homestead-testing: mariadb-extra.socket is a disabled or a static unit, not starting it.
    homestead-testing: mariadb-extra.socket is a disabled or a static unit, not starting it.
    homestead-testing: Setting up libcgi-fast-perl (1:2.15-1) ...
    homestead-testing: Setting up mariadb-server-compat (1:11.1.2+maria~ubu2004) ...
    homestead-testing: Processing triggers for systemd (245.4-4ubuntu3.19) ...
    homestead-testing: Processing triggers for man-db (2.9.1-1) ...
    homestead-testing: Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead

...

==> homestead-testing: Running provisioner: Creating MySQL / MariaDB Database: homestead (shell)...
    homestead-testing: Running: script: Creating MySQL / MariaDB Database: homestead
    homestead-testing: We didn't find MySQL ($mysql), skipping $DB creation
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
==> homestead-testing: Running provisioner: Creating MySQL / MariaDB Database: totally_real_db (shell)...
    homestead-testing: Running: script: Creating MySQL / MariaDB Database: totally_real_db
    homestead-testing: We didn't find MySQL ($mysql), skipping $DB creation
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
==> homestead-testing: Running provisioner: Creating MySQL / MariaDB Database: totally_real_db_two (shell)...
    homestead-testing: Running: script: Creating MySQL / MariaDB Database: totally_real_db_two
    homestead-testing: We didn't find MySQL ($mysql), skipping $DB creation
    homestead-testing: mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
==> homestead-testing: Running provisioner: Update Composer (shell)...
```