### PR TITLE
Fix RVM installer

### DIFF
--- a/scripts/features/rvm.sh
+++ b/scripts/features/rvm.sh
@@ -20,7 +20,7 @@ touch /home/$WSL_USER_NAME/.homestead-features/rvm
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
 # Install RVM
-gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 \curl -sSL https://get.rvm.io | bash -s stable --ruby --gems=bundler
 
 # To start using RVM we need to run

--- a/scripts/features/rvm.sh
+++ b/scripts/features/rvm.sh
@@ -24,4 +24,4 @@ gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB8
 \curl -sSL https://get.rvm.io | bash -s stable --ruby --gems=bundler
 
 # To start using RVM we need to run
-source /home/vagrant/.rvm/scripts/rvm
+source /usr/local/rvm/scripts/rvm


### PR DESCRIPTION
Looks like the current key server it tries doesn't exist anymore and I've updated it to match https://rvm.io/rvm/install
```
gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
gpg: directory '/home/vagrant/.gnupg' created
gpg: keybox '/home/vagrant/.gnupg/pubring.kbx' created
gpg: keyserver receive failed: No name
```

after that it looks like `source /home/vagrant/.rvm/scripts/rvm` doesn't exist and it wants to use `source /usr/local/rvm/scripts/rvm`

```
    homestead: 1 gem installed
    homestead: 
    homestead:   * To start using RVM you need to run `source /usr/local/rvm/scripts/rvm`
    homestead:     in all your open shell windows, in rare cases you need to reopen all shell windows.
    homestead: /tmp/vagrant-shell: line 27: /home/vagrant/.rvm/scripts/rvm: No such file or directory
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```