### PR TITLE
Fix RVM permissions issue and automatically fetch latest stable Golang version

### DIFF
--- a/scripts/features/golang.sh
+++ b/scripts/features/golang.sh
@@ -22,13 +22,13 @@ chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-feature
 ARCH=$(arch)
 
 # Install Golang
-golangVersion="1.21.4"
 if [[ "$ARCH" == "aarch64" ]]; then
-  wget https://dl.google.com/go/go${golangVersion}.linux-arm64.tar.gz -O golang.tar.gz
+    GOLANG_LATEST_STABLE_VERSION=$(curl https://go.dev/dl/?mode=json | grep -o 'go.*.linux-arm64.tar.gz' | head -n 1 | tr -d '\r\n')
+    wget https://dl.google.com/go/${GOLANG_LATEST_STABLE_VERSION} -O golang.tar.gz
 else
-  wget https://dl.google.com/go/go${golangVersion}.linux-amd64.tar.gz -O golang.tar.gz
+    GOLANG_LATEST_STABLE_VERSION=$(curl https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')
+    wget https://dl.google.com/go/${GOLANG_LATEST_STABLE_VERSION} -O golang.tar.gz
 fi
-
 
 tar -C /usr/local -xzf golang.tar.gz go
 printf "\nPATH=\"/usr/local/go/bin:\$PATH\"\n" | tee -a /home/vagrant/.profile

--- a/scripts/features/rvm.sh
+++ b/scripts/features/rvm.sh
@@ -21,7 +21,7 @@ chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-feature
 
 # Install RVM as vagrant user
 sudo -u $WSL_USER_NAME gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-sudo -u $WSL_USER_NAME curl -LsS https://get.rvm.io | sudo -u $WSL_USER_NAME bash -s stable --ruby --gems=bundler
+sudo -u $WSL_USER_NAME curl -LsS https://get.rvm.io | sudo -u $WSL_USER_NAME bash -s stable --ruby --gems=bundler --auto-dotfiles
 
 # To start using RVM we need to run
 source /home/vagrant/.rvm/scripts/rvm

--- a/scripts/features/rvm.sh
+++ b/scripts/features/rvm.sh
@@ -19,9 +19,9 @@ fi
 touch /home/$WSL_USER_NAME/.homestead-features/rvm
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
 
-# Install RVM
-gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-\curl -sSL https://get.rvm.io | bash -s stable --ruby --gems=bundler
+# Install RVM as vagrant user
+sudo -u $WSL_USER_NAME gpg --keyserver keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+sudo -u $WSL_USER_NAME curl -LsS https://get.rvm.io | sudo -u $WSL_USER_NAME bash -s stable --ruby --gems=bundler
 
 # To start using RVM we need to run
-source /usr/local/rvm/scripts/rvm
+source /home/vagrant/.rvm/scripts/rvm


### PR DESCRIPTION
I was playing around with RVM after I fixed the installed in https://github.com/laravel/homestead/pull/1906 but the more I used it the more I noticed some oddities, mostly around permissions since it is installed as root. e.g `Archives path '/usr/local/rvm/archives' not writable, aborting.`

I needed to use sudo to use some ruby and rvm functions. In this PR I've had this install it as the vagrant user and it seem to result the stuff I was running into.

```
vagrant@homestead-testing:~$ rvm list
t bundler=* ruby-3.0.0 [ x86_64 ]
# => - current
# =* - current && default
#  * - default
vagrant@homestead-testing:~$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux]
vagrant@homestead-testing:~$ gem list bundler
*** LOCAL GEMS ***
bundler (2.4.22, default: 2.2.3)
bundler-unload (1.0.2)
rubygems-bundler (1.4.5)
```

I've also included fetching the latest golang version automatically. https://github.com/golang/go/issues/51135#issuecomment-1036043491
```
vagrant@homestead-testing:~$ go version
go version go1.21.4 linux/amd64
```