### PR TITLE
Upgrade InfluxDB feature to v2 (v2.7.4)

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -26,6 +26,7 @@ features:
     - postgresql: false
     - ohmyzsh: false
     - webdriver: false
+    - influxdb: false
 
 services:
     - enabled:

--- a/scripts/features/influxdb.sh
+++ b/scripts/features/influxdb.sh
@@ -16,9 +16,16 @@ then
     exit 0
 fi
 
+
+# InfluxDB v2.7.4 - from https://www.influxdata.com/downloads/
+
+# influxdata-archive_compat.key GPG fingerprint:
+#     9D53 9D90 D332 8DC7 D6C8 D3B9 D8FF 8E1F 7DF8 B07E
+wget -q https://repos.influxdata.com/influxdata-archive_compat.key
+echo '393e8779c89ac8d958f81f942f9ad7fb82a25e133faddaf92e15b16e6ac9ce4c influxdata-archive_compat.key' | sha256sum -c && cat influxdata-archive_compat.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg > /dev/null
+echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https://repos.influxdata.com/debian stable main' | sudo tee /etc/apt/sources.list.d/influxdata.list
+apt-get update
+apt-get install -y influxdb2
+
 touch /home/$WSL_USER_NAME/.homestead-features/influxdb
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features
-
-apt-get update
-apt-get install -y influxdb
-apt-get install -y influxdb-client


### PR DESCRIPTION
Upgrade InfluxDB feature script to install InfluxDB v2.x (v2.7.4) instead of v1.x

Source issue: #1912 