### PR TITLE
Fix Influxdb v2 Provision

### DIFF
--- a/scripts/create-influxdb.sh
+++ b/scripts/create-influxdb.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-influx -execute "create database $1"
+influx bucket create --token="homestead_secret" --name="$1" --org="homestead"

--- a/scripts/features/influxdb.sh
+++ b/scripts/features/influxdb.sh
@@ -27,5 +27,16 @@ echo 'deb [signed-by=/etc/apt/trusted.gpg.d/influxdata-archive_compat.gpg] https
 apt-get update
 apt-get install -y influxdb2
 
+systemctl enable --now influxdb
+
+influx setup \
+    --force \
+    --username "homestead" \
+    --password "secretkey" \
+    --org "homestead" \
+    --bucket "homestead" \
+    --name "homestead" \
+    --token "homestead_secret"
+
 touch /home/$WSL_USER_NAME/.homestead-features/influxdb
 chown -Rf $WSL_USER_NAME:$WSL_USER_GROUP /home/$WSL_USER_NAME/.homestead-features


### PR DESCRIPTION
This is to fix this:
https://github.com/laravel/homestead/issues/1919

This would get the error:
```
==> homestead-testing: Running provisioner: Restart Webserver (shell)...
    homestead-testing: Running: script: Restart Webserver
==> homestead-testing: Running provisioner: Creating InfluxDB Database: example_database (shell)...
    homestead-testing: Running: script: Creating InfluxDB Database: example_database
    homestead-testing: Incorrect Usage. flag provided but not defined: -execute
    homestead-testing:
    homestead-testing: NAME:
    homestead-testing:    influx - Influx Client
    homestead-testing:
    homestead-testing: USAGE:
    homestead-testing:    influx [command]
    homestead-testing:
    homestead-testing: HINT: If you are looking for the InfluxQL shell from 1.x, run "influx v1 shell"
    homestead-testing:
    homestead-testing: COMMANDS:
    homestead-testing:    version              Print the influx CLI version
    homestead-testing:    write                Write points to InfluxDB
    homestead-testing:    bucket               Bucket management commands
    homestead-testing:    completion           Generates completion scripts
    homestead-testing:    query                Execute a Flux query
    homestead-testing:    config               Config management commands
    homestead-testing:    org, organization    Organization management commands
    homestead-testing:    delete               Delete points from InfluxDB
    homestead-testing:    user                 User management commands
    homestead-testing:    task                 Task management commands
    homestead-testing:    telegrafs            List Telegraf configuration(s). Subcommands manage Telegraf configurations.
    homestead-testing:    dashboards           List Dashboard(s).
    homestead-testing:    export               Export existing resources as a template
    homestead-testing:    secret               Secret management commands
    homestead-testing:    v1                   InfluxDB v1 management commands
    homestead-testing:    auth, authorization  Authorization management commands
    homestead-testing:    apply                Apply a template to manage resources
    homestead-testing:    stacks               List stack(s) and associated templates. Subcommands manage stacks.
    homestead-testing:    template             Summarize the provided template
    homestead-testing:    bucket-schema        Bucket schema management commands
    homestead-testing:    scripts              Scripts management commands
    homestead-testing:    ping                 Check the InfluxDB /health endpoint
    homestead-testing:    setup                Setup instance with initial user, org, bucket
    homestead-testing:    backup               Backup database
    homestead-testing:    restore              Restores a backup directory to InfluxDB
    homestead-testing:    remote               Remote connection management commands
    homestead-testing:    replication          Replication stream management commands
    homestead-testing:    server-config        Display server config
    homestead-testing:    help, h              Shows a list of commands or help for one command
    homestead-testing:
    homestead-testing: GLOBAL OPTIONS:
    homestead-testing:    --help, -h  show help
    homestead-testing: Error: flag provided but not defined: -execute
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

Added:
https://docs.influxdata.com/influxdb/v2/reference/cli/influx/setup/

And updated the create db to use this:
https://docs.influxdata.com/influxdb/v2/reference/cli/influx/bucket/create/

It seemed to work now:
```
...
homestead-testing: Created symlink /etc/systemd/system/multi-user.target.wants/influxdb.service → /lib/systemd/system/influxdb.service.
homestead-testing: Setting up influxdb2-cli (2.7.3-1) ...
homestead-testing: User             Organization    Bucket
homestead-testing: homestead        homestead       homestead
...
==> homestead-testing: Running provisioner: Creating InfluxDB Database: example_database (shell)...
homestead-testing: Running: script: Creating InfluxDB Database: example_database
homestead-testing: ID                       Name                    Retention       Shard group duration Organization ID         Schema Type
homestead-testing: 86b6c6a2dc618337 example_database        infinite        168h0m0s            98731afb6626f90b implicit
...
```