### PR TITLE
Update wordpress.sh

### DIFF
--- a/scripts/site-types/wordpress.sh
+++ b/scripts/site-types/wordpress.sh
@@ -59,7 +59,7 @@ block="server {
     }
 
     location @prod_site {
-        rewrite ^/(.*)$ https://${11}/$1 redirect;
+        rewrite ^/(.*)$ https://\${11}/\$1 redirect;
     }
 
     location ~ /.*\.(jpg|jpeg|png|js|css)$ {


### PR DESCRIPTION
escape $ in location redirect.
I found that the $1 was in the nginx config on vagrant machine. (arm64/parallels)
I escaped the $1 to fix. I also removed the https:// before ${11} (but not in this pr) as i prefer to specify the scheme in the yaml