### PR TITLE
set "mysql" as an enabled database

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -604,6 +604,11 @@ class Homestead
         end
       end
 
+      # Enable MySQL if MariaDB is not enabled
+      if (!enabled_databases.include? 'mysql') && (!enabled_databases.include? 'mariadb')
+        enabled_databases.push 'mysql'
+      end
+
       settings['databases'].each do |db|
         if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mysql8') || (enabled_databases.include? 'mariadb')
           config.vm.provision 'shell' do |s|
@@ -696,6 +701,11 @@ class Homestead
 
           enabled_databases.push feature_name
         end
+      end
+
+      # Enable MySQL if MariaDB is not enabled
+      if (!enabled_databases.include? 'mysql') && (!enabled_databases.include? 'mariadb')
+        enabled_databases.push 'mysql'
       end
 
       # Loop over each DB


### PR DESCRIPTION
MySQL is kind of a weird case, because it's our default database, and it cannot (shouldn't?) run side by side with MariaDB.

We kind of cheated this previously by having "mysql" as a key in the "features" configuration, but it's technically not a "feature" as it doesn't have a file in `/scripts/features/`.  this resulted in an "Invalid feature: mysql" warning in the provision script.

This change will allow us to remove `mysql: true` from our docs and example files, while still having MySQL work correctly.