### PR TITLE
drop "mysql8" reference

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -605,7 +605,7 @@ class Homestead
       end
 
       settings['databases'].each do |db|
-        if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mysql8') || (enabled_databases.include? 'mariadb')
+        if (enabled_databases.include? 'mysql') || (enabled_databases.include? 'mariadb')
           config.vm.provision 'shell' do |s|
             s.name = 'Creating MySQL / MariaDB Database: ' + db
             s.path = script_dir + '/create-mysql.sh'


### PR DESCRIPTION
this is a remnant of long ago in our v5 to v8 transition.  we now *only* install MySQL8, so we don't really need this anymore.  if people still have it in their `homestead.yaml` it'll still be fine with my other PR.

this also syncs it up with the duplicated code we have farther down.