### PR TITLE
drop "mysql" feature

### DIFF
--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -21,7 +21,6 @@ databases:
     - homestead
 
 features:
-    - mysql: true
     - mariadb: false
     - postgresql: false
     - ohmyzsh: false

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -21,7 +21,6 @@ databases:
     - homestead
 
 features:
-    - mysql: true
     - mariadb: false
     - postgresql: false
     - ohmyzsh: false


### PR DESCRIPTION
"mysql" is not a valid feature, as it is our default database, and does not get installed with a `/scripts/feature/` file.

if this gets merged, the docs will be updated as well.