### PR TITLE
Fix NFS Mount failing on Ubuntu 22.04

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -212,14 +212,20 @@ class Homestead
 
           if folder['type'] == 'nfs'
             mount_opts = folder['mount_options'] ? folder['mount_options'] : ['actimeo=1', 'nolock']
+
+            # Ubuntu 22.04 does not support NFS UDP, so we need to ensure it is disabled
+            nfs_options = {nfs_udp: false}
           elsif folder['type'] == 'smb'
             mount_opts = folder['mount_options'] ? folder['mount_options'] : ['vers=3.02', 'mfsymlinks']
 
             smb_creds = {smb_host: folder['smb_host'], smb_username: folder['smb_username'], smb_password: folder['smb_password']}
           end
-
+          
           # For b/w compatibility keep separate 'mount_opts', but merge with options
-          options = (folder['options'] || {}).merge({ mount_options: mount_opts }).merge(smb_creds || {})
+          options = (folder['options'] || {})
+            .merge({ mount_options: mount_opts })
+            .merge(smb_creds || {})
+            .merge(nfs_options || {})
 
           # Double-splat (**) operator only works with symbol keys, so convert
           options.keys.each{|k| options[k.to_sym] = options.delete(k) }


### PR DESCRIPTION
It appears that NFS over UDP is disabled in Ubuntu 22.04 by default:

 - https://github.com/hashicorp/vagrant/issues/12758
 - https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668#udp-disabled-for-nfs-mounts-7

This causes NFS mounts to fail by default with Homestead without adding the `nfs_udp` option to all existing folder mounts, which if you have a lot of folders mounted like I do, can be a bit tedious.

Since Homestead will be using Ubuntu 22.04 by default going forward, I think disabling `nfs_udp` by default going forward might be a good idea.

This PR will automatically apply the `nfs_udp` option with a value of `false` when a folder is using NFS.
