### PR TITLE
Fix Ngrok config

### DIFF
--- a/scripts/create-ngrok.sh
+++ b/scripts/create-ngrok.sh
@@ -4,7 +4,10 @@ PATH_NGROK="/home/vagrant/.config/ngrok"
 PATH_CONFIG="${PATH_NGROK}/ngrok.yml"
 
 # Only create a ngrok config file if there isn't one already there.
-if [ ! -f $PATH_CONFIG ]
-then
-mkdir -p $PATH_NGROK && echo "web_addr: $1:4040" > $PATH_CONFIG
+if [ ! -f $PATH_CONFIG ]; then
+    mkdir -p "$PATH_NGROK"
+    cat > "$PATH_CONFIG" << EOF
+version: 2
+web_addr: $1:4040
+EOF
 fi


### PR DESCRIPTION
Ngrok updated to a newer version since they deprecated v1 which we did in here
https://github.com/laravel/settler/pull/251

but it looks like we missed updating the config.

Trying to use the share aliases without the version will result in
```
ERROR:  Error reading configuration file '/home/vagrant/.config/ngrok/ngrok.yml': `version` property is required.
ERROR:
ERROR:  If you're upgrading from an older version of ngrok, you can run:
ERROR:
ERROR:      ngrok config upgrade
ERROR:
ERROR:  to upgrade to the new format and add the version number.
```

Adding `version: 2` seems to resolve the issue and it will work like before.