### PR TITLE
Properly apply editorconfig settings to all yaml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,yaml,yaml.example}]
 indent_size = 2

--- a/Homestead.yaml.example
+++ b/Homestead.yaml.example
@@ -7,42 +7,42 @@ provider: virtualbox
 authorize: ~/.ssh/id_rsa.pub
 
 keys:
-    - ~/.ssh/id_rsa
+  - ~/.ssh/id_rsa
 
 folders:
-    - map: ~/code
-      to: /home/vagrant/code
+  - map: ~/code
+    to: /home/vagrant/code
 
 sites:
-    - map: homestead.test
-      to: /home/vagrant/code/public
+  - map: homestead.test
+    to: /home/vagrant/code/public
 
 databases:
-    - homestead
+  - homestead
 
 features:
-    - mariadb: false
-    - postgresql: false
-    - ohmyzsh: false
-    - webdriver: false
-    - influxdb: false
+  - mariadb: false
+  - postgresql: false
+  - ohmyzsh: false
+  - webdriver: false
+  - influxdb: false
 
 services:
-    - enabled:
-          - "mysql"
-#    - disabled:
-#        - "postgresql@11-main"
+  - enabled:
+      - "mysql"
+#   - disabled:
+#       - "postgresql@11-main"
 
-#ports:
-#    - send: 33060 # MySQL/MariaDB
-#      to: 3306
-#    - send: 4040
-#      to: 4040
-#    - send: 54320 # PostgreSQL
-#      to: 5432
-#    - send: 8025 # Mailpit
-#      to: 8025
-#    - send: 9600
-#      to: 9600
-#    - send: 27017
-#      to: 27017
+# ports:
+#   - send: 33060 # MySQL/MariaDB
+#     to: 3306
+#   - send: 4040
+#     to: 4040
+#   - send: 54320 # PostgreSQL
+#     to: 5432
+#   - send: 8025 # Mailpit
+#     to: 8025
+#   - send: 9600
+#     to: 9600
+#   - send: 27017
+#     to: 27017

--- a/resources/Homestead.yaml
+++ b/resources/Homestead.yaml
@@ -7,41 +7,41 @@ provider: virtualbox
 authorize: ~/.ssh/id_rsa.pub
 
 keys:
-    - ~/.ssh/id_rsa
+  - ~/.ssh/id_rsa
 
 folders:
-    - map: ~/code
-      to: /home/vagrant/code
+  - map: ~/code
+    to: /home/vagrant/code
 
 sites:
-    - map: homestead.test
-      to: /home/vagrant/code/public
+  - map: homestead.test
+    to: /home/vagrant/code/public
 
 databases:
-    - homestead
+  - homestead
 
 features:
-    - mariadb: false
-    - postgresql: false
-    - ohmyzsh: false
-    - webdriver: false
+  - mariadb: false
+  - postgresql: false
+  - ohmyzsh: false
+  - webdriver: false
 
 services:
-    - enabled:
-          - "mysql"
-#    - disabled:
-#        - "postgresql@11-main"
+  - enabled:
+      - "mysql"
+#   - disabled:
+#       - "postgresql@11-main"
 
-#ports:
-#    - send: 33060 # MySQL/MariaDB
-#      to: 3306
-#    - send: 4040
-#      to: 4040
-#    - send: 54320 # PostgreSQL
-#      to: 5432
-#    - send: 8025 # Mailpit
-#      to: 8025
-#    - send: 9600
-#      to: 9600
-#    - send: 27017
-#      to: 27017
+# ports:
+#   - send: 33060 # MySQL/MariaDB
+#     to: 3306
+#   - send: 4040
+#     to: 4040
+#   - send: 54320 # PostgreSQL
+#     to: 5432
+#   - send: 8025 # Mailpit
+#     to: 8025
+#   - send: 9600
+#     to: 9600
+#   - send: 27017
+#     to: 27017

--- a/scripts/features/dockstead/mysql-5.7.yaml
+++ b/scripts/features/dockstead/mysql-5.7.yaml
@@ -4,22 +4,22 @@
 #
 version: "3.7"
 services:
-    mysql:
-        image: mysql:5.7
-        volumes:
-            - type: volume
-              source: mysql-data
-              target: /var/lib/mysql
-              volume:
-                  nocopy: true
-        ports:
-            - "3306:3306"
-        healthcheck:
-            test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
-            interval: 3s
-            timeout: 1s
-            retries: 5
-        env_file:
-            - env.docker
+  mysql:
+    image: mysql:5.7
+    volumes:
+      - type: volume
+        source: mysql-data
+        target: /var/lib/mysql
+        volume:
+          nocopy: true
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      interval: 3s
+      timeout: 1s
+      retries: 5
+    env_file:
+      - env.docker
 volumes:
-    mysql-data:
+  mysql-data:


### PR DESCRIPTION
Previously, the editorconfig file contained a section for yaml files, but it only included `*.yml` files, which meant that it wasn't being used outside of the GitHub Actions config. This PR applies the editorconfig to `*.yml, *.yaml, and *.yaml.example`, and applies the correct indentation to those yaml files.