### PR TITLE
Ensure php8.2-fpm service is properly enabled and restarted

### DIFF
--- a/scripts/features/php8.2.sh
+++ b/scripts/features/php8.2.sh
@@ -10,6 +10,14 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
+SERVICE_STATUS=$(systemctl is-enabled php8.2-fpm.service)
+
+if [ "$SERVICE_STATUS" == "disabled" ];
+then
+  systemctl enable php8.2-fpm
+  service php8.2-fpm restart
+fi
+
 if [ -f /home/$WSL_USER_NAME/.homestead-features/php82 ]
 then
     echo "PHP 8.2 already installed."
@@ -60,3 +68,6 @@ sed -i "s/group = www-data/group = vagrant/" /etc/php/8.2/fpm/pool.d/www.conf
 sed -i "s/listen\.owner.*/listen.owner = vagrant/" /etc/php/8.2/fpm/pool.d/www.conf
 sed -i "s/listen\.group.*/listen.group = vagrant/" /etc/php/8.2/fpm/pool.d/www.conf
 sed -i "s/;listen\.mode.*/listen.mode = 0666/" /etc/php/8.2/fpm/pool.d/www.conf
+
+systemctl enable php8.2-fpm
+service php8.2-fpm restart


### PR DESCRIPTION
It looks like these lines didn't get copied over from the previous PHP scripts when 8.3 was added; this should ensure that when PHP 8.2 is used, the correct php-fpm service gets enabled and restarted.

Edit: I didn't actually notice that an issue had been made until after I'd made this PR, as I ran into it on my own, but this should fix #1950.