### PR TITLE
Reconfigure APT after manual installation of google-chrome-stable

### DIFF
--- a/scripts/features/webdriver.sh
+++ b/scripts/features/webdriver.sh
@@ -24,8 +24,7 @@ ARCH=$(arch)
 # Install The Chrome Web Driver & Dusk Utilities
 if [[ "$ARCH" != "aarch64" ]]; then
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O /tmp/chrome.deb
-    dpkg -i /tmp/chrome.deb
-    apt-get -y --fix-broken install
+    apt-get install -y /tmp/chrome.deb
     rm -f /tmp/chrome.deb
 fi
 

--- a/scripts/features/webdriver.sh
+++ b/scripts/features/webdriver.sh
@@ -25,6 +25,7 @@ ARCH=$(arch)
 if [[ "$ARCH" != "aarch64" ]]; then
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O /tmp/chrome.deb
     dpkg -i /tmp/chrome.deb
+    apt-get -y --fix-broken install
     rm -f /tmp/chrome.deb
 fi
 


### PR DESCRIPTION
After the recent changes in #1932, the Chrome Web Driver installation script fails. This PR fixes this by ensuring that `apt-get` is called with `--fix-broken install` afterwards, to ensure that the dependencies are resolved and google-chrome-stable is actually configured.