### PR TITLE
Fix Apache Proxy Websockets

### DIFF
--- a/scripts/features/php8.3.sh
+++ b/scripts/features/php8.3.sh
@@ -12,7 +12,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 if [ -f /home/$WSL_USER_NAME/.homestead-features/php83 ]
 then
-    echo "PHP 8.2 already installed."
+    echo "PHP 8.3 already installed."
     exit 0
 fi
 
@@ -25,8 +25,7 @@ php8.3 php8.3-bcmath php8.3-bz2 php8.3-cgi php8.3-cli php8.3-common php8.3-curl 
 php8.3-enchant php8.3-fpm php8.3-gd php8.3-gmp php8.3-imap php8.3-interbase php8.3-intl php8.3-ldap \
 php8.3-mbstring php8.3-mysql php8.3-odbc php8.3-opcache php8.3-pgsql php8.3-phpdbg php8.3-pspell php8.3-readline \
 php8.3-snmp php8.3-soap php8.3-sqlite3 php8.3-sybase php8.3-tidy php8.3-xml php8.3-xsl \
-php8.3-zip
-# php8.3-imagick php8.3-memcached php8.3-redis php8.3-xmlrpc php8.3-xdebug
+php8.3-zip php8.3-imagick php8.3-memcached php8.3-redis php8.3-xmlrpc php8.3-xdebug
 
 # Configure php.ini for CLI
 sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/8.3/cli/php.ini
@@ -35,11 +34,11 @@ sed -i "s/memory_limit = .*/memory_limit = 512M/" /etc/php/8.3/cli/php.ini
 sed -i "s/;date.timezone.*/date.timezone = UTC/" /etc/php/8.3/cli/php.ini
 
 # Configure Xdebug
-#  echo "xdebug.mode = debug" >> /etc/php/8.3/mods-available/xdebug.ini
-#  echo "xdebug.discover_client_host = true" >> /etc/php/8.3/mods-available/xdebug.ini
-#  echo "xdebug.client_port = 9003" >> /etc/php/8.3/mods-available/xdebug.ini
-#  echo "xdebug.max_nesting_level = 512" >> /etc/php/8.3/mods-available/xdebug.ini
-#  echo "opcache.revalidate_freq = 0" >> /etc/php/8.3/mods-available/opcache.ini
+echo "xdebug.mode = debug" >> /etc/php/8.3/mods-available/xdebug.ini
+echo "xdebug.discover_client_host = true" >> /etc/php/8.3/mods-available/xdebug.ini
+echo "xdebug.client_port = 9003" >> /etc/php/8.3/mods-available/xdebug.ini
+echo "xdebug.max_nesting_level = 512" >> /etc/php/8.3/mods-available/xdebug.ini
+echo "opcache.revalidate_freq = 0" >> /etc/php/8.3/mods-available/opcache.ini
 
 # Configure php.ini for FPM
 sed -i "s/error_reporting = .*/error_reporting = E_ALL/" /etc/php/8.3/fpm/php.ini

--- a/scripts/site-types/apache-proxy.sh
+++ b/scripts/site-types/apache-proxy.sh
@@ -25,7 +25,7 @@ then
     then
         if ! [[ "$2" =~ ^https: ]]
         then
-            socket=$(echo "$2" | sed -E "s/^http(s?):\/\//wss:\/\//g")
+            socket=$(echo "$2" | sed -E "s/^http(s?):\/\//ws:\/\//g")
         else
             socket=$(echo "$2" | sed -E "s/^http(s?):\/\//wss:\/\//g")
         fi

--- a/scripts/site-types/apache-proxy.sh
+++ b/scripts/site-types/apache-proxy.sh
@@ -23,16 +23,35 @@ if [ -n "$2" ]
 then
     if ! [[ "$2" =~ ^[0-9]+$ ]]
     then
+        if ! [[ "$2" =~ ^https: ]]
+        then
+            socket=$(echo "$2" | sed -E "s/^http(s?):\/\//wss:\/\//g")
+        else
+            socket=$(echo "$2" | sed -E "s/^http(s?):\/\//wss:\/\//g")
+        fi
+
         proxyPass="
+        RewriteEngine On
+        RewriteCond %{HTTP:Upgrade} =websocket [NC]
+        RewriteRule /(.*) $socket/ [P,L]
+
         ProxyPass / ${2}/
         ProxyPassReverse / ${2}/
         "
     else proxyPass="
+        RewriteEngine On
+        RewriteCond %{HTTP:Upgrade} =websocket [NC]
+        RewriteRule /(.*) ws://127.0.0.1:$2/ [P,L]
+
         ProxyPass / http://127.0.0.1:$2/
         ProxyPassReverse / http://127.0.0.1:$2/
         "
     fi
 else proxyPass="
+RewriteEngine On
+RewriteCond %{HTTP:Upgrade} =websocket [NC]
+RewriteRule /(.*) ws://127.0.0.1/ [P,L]
+
 ProxyPass / http://127.0.0.1/
 ProxyPassReverse / http://127.0.0.1/
 "


### PR DESCRIPTION
This adds support for web sockets in the Apache proxy.

It defaults to `ws://127.0.0.1` and if you only included a port it will be `ws://127.0.0.1:$2` otherwise, it check `$2` has HTTPS and adds the correct web socket protocol