### PR TITLE
Fix reload provision when using php 5.6

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -673,7 +673,7 @@ class Homestead
     # Update Composer On Every Provision
     config.vm.provision 'shell' do |s|
       s.name = 'Update Composer'
-      s.inline = 'sudo chown -R vagrant:vagrant /usr/local/bin && sudo -u vagrant /usr/local/bin/composer self-update --no-progress && sudo chown -R vagrant:vagrant /home/vagrant/.config/'
+      s.inline = 'sudo chown -R vagrant:vagrant /usr/local/bin && sudo -u vagrant /usr/bin/php8.3 /usr/local/bin/composer self-update --no-progress && sudo chown -R vagrant:vagrant /home/vagrant/.config/'
       s.privileged = false
     end
 


### PR DESCRIPTION
it throws an error when using php 5.6

sample

```yaml
    - map: local.test
      to: /home/vagrant/code/local
      php: "5.6"
```

```
    homestead: Composer 2.3.0 dropped support for PHP <7.2.5 and you are running 5.6.40-68+ubuntu22.04.1+deb.sury.org+1, please upgrade PHP or use Composer 2.2 LTS via "composer self-update --2.2". Aborting.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```