### PR TITLE
Don't request specific IP for VMware Fusion on Mac OS BigSur and greater

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -24,10 +24,16 @@ class Homestead
     config.vm.hostname = settings['hostname'] ||= 'homestead'
 
     # Configure A Private Network IP
-    if settings['ip'] != 'autonetwork'
-      config.vm.network :private_network, ip: settings['ip'] ||= '192.168.56.56'
+    if ['vmware_desktop', 'vmware_fusion'].include? ENV['VAGRANT_DEFAULT_PROVIDER']
+      if RUBY_PLATFORM.match(/darwin/)
+        config.vm.network :private_network
+      end
     else
-      config.vm.network :private_network, ip: '0.0.0.0', auto_network: true
+      if settings['ip'] != 'autonetwork'
+        config.vm.network :private_network, ip: settings['ip'] ||= '192.168.56.56'
+      else
+        config.vm.network :private_network, ip: '0.0.0.0', auto_network: true
+      end
     end
 
     # Configure Additional Networks

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -25,7 +25,7 @@ class Homestead
 
     # Configure A Private Network IP
     if ['vmware_desktop', 'vmware_fusion'].include? ENV['VAGRANT_DEFAULT_PROVIDER']
-      if RUBY_PLATFORM.match(/darwin/)
+      if RUBY_PLATFORM.match(/darwin2/)
         config.vm.network :private_network
       end
     else


### PR DESCRIPTION
Per https://developer.hashicorp.com/vagrant/docs/providers/vmware/known-issues#big-sur-related-issues homestead can't request a specific address for fusion on OSs greater than BigSur. This change sets the recommended value for BigSur and greater Mac OS versions.