### PR TITLE
Fix APT repository label change issues

### DIFF
--- a/scripts/allow-apt-repository-changes.sh
+++ b/scripts/allow-apt-repository-changes.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+if [ ! -f "/etc/apt/apt.conf.d/99allow-repository-change" ]; then
+    echo "Configuring APT to allow repository label and other metadata changes..."
+    
+    cat << EOF | sudo tee /etc/apt/apt.conf.d/99allow-repository-change
+Acquire::AllowReleaseInfoChange::Label "true";
+Acquire::AllowReleaseInfoChange::Suite "true";
+Acquire::AllowReleaseInfoChange::Version "true";
+Acquire::AllowReleaseInfoChange::Codename "true";
+EOF
+
+    echo "APT configuration for repository changes completed."
+else
+    echo "APT already configured to handle repository changes."
+fi 

--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -270,6 +270,8 @@ class Homestead
         end
       end
 
+      config.vm.provision "allow_apt_changes", type: "shell", path: script_dir + "/allow-apt-repository-changes.sh"
+
       config.vm.provision "apt_update", type: "shell", inline: "apt-get update"
 
       # Ensure we have PHP versions used in sites in our features


### PR DESCRIPTION
This PR adds a new script and configuration to handle APT repository metadata changes gracefully.

The PHP PPA from ondrej/php has changed its label from '* The main PPA for supported PHP versions with many PECL extensions ' to 'PPA for PHP', causing Vagrant provisioning to fail with an exit status error.

This change adds apt configuration that allows repository metadata changes (label, suite, version, codename) to prevent these issues from breaking the apt-get update process.